### PR TITLE
Patch eigen ninja fortran fix

### DIFF
--- a/CMake/External_Eigen.cmake
+++ b/CMake/External_Eigen.cmake
@@ -7,7 +7,10 @@ ExternalProject_Add(Eigen
   DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
   INSTALL_DIR  ${fletch_BUILD_INSTALL_PREFIX}
   BUILD_IN_SOURCE 0
-
+  PATCH_COMMAND ${CMAKE_COMMAND}
+    -DEigen_patch:PATH=${vision-tpl_SOURCE_DIR}/Patches/Eigen
+    -DEigen_source:PATH=${vision-tpl_BUILD_PREFIX}/src/Eigen
+    -P ${vision-tpl_SOURCE_DIR}/Patches/Eigen/Patch.cmake
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/CMake/External_Eigen.cmake
+++ b/CMake/External_Eigen.cmake
@@ -8,9 +8,9 @@ ExternalProject_Add(Eigen
   INSTALL_DIR  ${fletch_BUILD_INSTALL_PREFIX}
   BUILD_IN_SOURCE 0
   PATCH_COMMAND ${CMAKE_COMMAND}
-    -DEigen_patch:PATH=${vision-tpl_SOURCE_DIR}/Patches/Eigen
-    -DEigen_source:PATH=${vision-tpl_BUILD_PREFIX}/src/Eigen
-    -P ${vision-tpl_SOURCE_DIR}/Patches/Eigen/Patch.cmake
+    -DEigen_patch:PATH=${fletch_SOURCE_DIR}/Patches/Eigen
+    -DEigen_source:PATH=${fletch_BUILD_PREFIX}/src/Eigen
+    -P ${fletch_SOURCE_DIR}/Patches/Eigen/Patch.cmake
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Patches/Eigen/Patch.cmake
+++ b/Patches/Eigen/Patch.cmake
@@ -1,0 +1,12 @@
+#+
+# This file is called as CMake -P script for the patch step of
+# External_Eigen.cmake Eigen_patch and Eigen_source are defined on the command
+# line along with the call.
+#-
+
+message("Patching Eigen ${Eigen_patch} AND ${Eigen_source}")
+configure_file(
+  ${Eigen_patch}/language_support.cmake
+  ${Eigen_source}/cmake/
+  COPYONLY
+)

--- a/Patches/Eigen/language_support.cmake
+++ b/Patches/Eigen/language_support.cmake
@@ -1,0 +1,66 @@
+# cmake/modules/language_support.cmake
+#
+# Temporary additional general language support is contained within this
+# file.
+
+# This additional function definition is needed to provide a workaround for
+# CMake bug 9220.
+
+# On debian testing (cmake 2.6.2), I get return code zero when calling
+# cmake the first time, but cmake crashes when running a second time
+# as follows:
+#
+#  -- The Fortran compiler identification is unknown
+#  CMake Error at /usr/share/cmake-2.6/Modules/CMakeFortranInformation.cmake:7 (GET_FILENAME_COMPONENT):
+#    get_filename_component called with incorrect number of arguments
+#  Call Stack (most recent call first):
+#    CMakeLists.txt:3 (enable_language)
+#
+# My workaround is to invoke cmake twice.  If both return codes are zero,
+# it is safe to invoke ENABLE_LANGUAGE(Fortran OPTIONAL)
+
+function(workaround_9220 language language_works)
+  #message("DEBUG: language = ${language}")
+  set(text
+    "project(test NONE)
+    cmake_minimum_required(VERSION 2.8.0)
+    set (CMAKE_Fortran_FLAGS \"${CMAKE_Fortran_FLAGS}\")
+    set (CMAKE_EXE_LINKER_FLAGS \"${CMAKE_EXE_LINKER_FLAGS}\")
+    enable_language(${language} OPTIONAL)
+  ")
+  file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/language_tests/${language})
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/language_tests/${language})
+  file(WRITE ${CMAKE_BINARY_DIR}/language_tests/${language}/CMakeLists.txt
+    ${text})
+  execute_process(
+    COMMAND ${CMAKE_COMMAND}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/language_tests/${language}
+    RESULT_VARIABLE return_code
+    OUTPUT_QUIET
+    ERROR_QUIET
+    )
+
+  if(return_code EQUAL 0)
+    # Second run
+    execute_process (
+      COMMAND ${CMAKE_COMMAND}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/language_tests/${language}
+      RESULT_VARIABLE return_code
+      OUTPUT_QUIET
+      ERROR_QUIET
+      )
+    if(return_code EQUAL 0)
+      set(${language_works} ON PARENT_SCOPE)
+    else(return_code EQUAL 0)
+      set(${language_works} OFF PARENT_SCOPE)
+    endif(return_code EQUAL 0)
+  else(return_code EQUAL 0)
+    set(${language_works} OFF PARENT_SCOPE)
+  endif(return_code EQUAL 0)
+endfunction(workaround_9220)
+
+# Temporary tests of the above function.
+#workaround_9220(CXX CXX_language_works)
+#message("CXX_language_works = ${CXX_language_works}")
+#workaround_9220(CXXp CXXp_language_works)
+#message("CXXp_language_works = ${CXXp_language_works}")

--- a/Patches/Eigen/language_support.cmake
+++ b/Patches/Eigen/language_support.cmake
@@ -33,7 +33,7 @@ function(workaround_9220 language language_works)
   file(WRITE ${CMAKE_BINARY_DIR}/language_tests/${language}/CMakeLists.txt
     ${text})
   execute_process(
-    COMMAND ${CMAKE_COMMAND}
+    COMMAND ${CMAKE_COMMAND} . -G ${CMAKE_GENERATOR}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/language_tests/${language}
     RESULT_VARIABLE return_code
     OUTPUT_QUIET
@@ -43,7 +43,7 @@ function(workaround_9220 language language_works)
   if(return_code EQUAL 0)
     # Second run
     execute_process (
-      COMMAND ${CMAKE_COMMAND}
+      COMMAND ${CMAKE_COMMAND} . -G ${CMAKE_GENERATOR}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/language_tests/${language}
       RESULT_VARIABLE return_code
       OUTPUT_QUIET


### PR DESCRIPTION
Patch Eigen to fix issues when using the ninja generator.
The current release fails when searching for a Fortran compiler when using ninja.

The patch was to add -G ${CMAKE_GENERATOR} to the COMMAND in execute_process. We would fail on ninja without it, since it would not consider the actual generator used.

