### PR TITLE
Work around QTBUG-28132 Race Condition

### DIFF
--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -82,7 +82,13 @@ if(WIN32)
     ${Qt_build}
     )
 
-  set(Qt_install_cmd ${JOM_EXE} install)
+  # Qt has a race condition (https://bugreports.qt.io/browse/QTBUG-28132) where
+  # multi-thread builds can intermittantly fail.  Essentially during the install
+  # step different targets will check if a directory exists and call MD when it doesn't.
+  # On windows if the race is a tie and two threads see that the directory doesn't exist,
+  # the second thread will error out because MD fails if the directory exists.  A 
+  # Work around is to turn off multi threaded builds for install:
+  set(Qt_install_cmd ${JOM_EXE} -j1 install)
   set(Qt_configure configure.exe)
   if(MSVC12)
     #We have some trouble determining the correct platform for VS2013


### PR DESCRIPTION
Works around QTBUG-28132 where multiple threads during install can see that a directory doesn't exist and try to make it which fails on windows.