### PR TITLE
Reset ENABLE_ALL_PACKAGES on Configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,12 @@ foreach(source ${fletch_external_sources})
 
 endforeach()
 
+#+
+# A common use case is to turn on everything and then turn a few things off in ccmake or
+# cmake-gui.  Unless we reset ENABLE_ALL, it'll just "fix" things again
+#-
+set(fletch_ENABLE_ALL_PACKAGES FALSE CACHE BOOL "" FORCE)
+
 if (NOT "#@${fletch_requires_make}" STREQUAL "#@")                                                                                                                                                                  
     if (NOT MAKE_EXECUTABLE)                                                                                                                                                                                              
         message(FATAL_ERROR "Could not find 'make', required to build ${fletch_requires_make}.")                                                                                                                       


### PR DESCRIPTION
This allows the user to turn everything on and the (now that ALL is
reset) turn off 1 or 2 packages -- a reasonble use case