### PR TITLE
Fix shapelib

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -110,9 +110,9 @@ set(libjson_md5 "82f3fcbf9f8cf3c4e25e1bdd77d65164")
 list(APPEND fletch_external_sources libjson)
 
 # shapelib
-set(shapelib_version 1.3.0b2)
-set(shapelib_url "http://download2.osgeo.org/shapelib/shapelib-${shapelib_version}.tar.gz")
-set(shapelib_md5 "708ea578bc299dcd9f723569d12bee8d")
+set(shapelib_version 1.3.0)
+set(shapelib_url "http://download.osgeo.org/shapelib/shapelib-${shapelib_version}.tar.gz")
+set(shapelib_md5 "2ff7d0b21d4b7506b452524492795f77")
 list(APPEND fletch_external_sources shapelib)
 
 # TinyXML

--- a/Patches/shapelib/Patch.cmake
+++ b/Patches/shapelib/Patch.cmake
@@ -8,4 +8,4 @@
 message("Patching shapelib")
 file(COPY ${shapelib_patch}/CMakeLists.txt DESTINATION ${shapelib_source})
 #file(COPY ${shapelib_patch}/SHAPELIBConfig.cmake.in DESTINATION ${shapelib_source})
-file(COPY ${shapelib_patch}/shapefil.h DESTINATION ${shapelib_source})
+#file(COPY ${shapelib_patch}/shapefil.h DESTINATION ${shapelib_source})


### PR DESCRIPTION
The download location has moved.  Beta is no longer available.  The updated version does not seem to need the patch (the patch breaks the build)