### PR TITLE
get_filename_component ( DIRECTORY [CACHE]) requires CMake 2.8.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 2.8.12)
 project(fletch)
 
 # Policy to address @foo@ variable expansion


### PR DESCRIPTION
Title is self-explanitory. We need 2.8.12 minimum for the listed signature of get_filename_component.