### PR TITLE
Add alternate symbols for PROJ package.

### DIFF
--- a/CMake/External_PROJ4.cmake
+++ b/CMake/External_PROJ4.cmake
@@ -27,6 +27,8 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # PROJ4
 ########################################
 set(PROJ4_ROOT @PROJ4_ROOT@)
+set(PROJ_ROOT @PROJ4_ROOT@)
 
 set(fletch_ENABLED_PROJ4 TRUE)
+set(fletch_ENABLED_PROJ TRUE)
 ")


### PR DESCRIPTION
Some projects refer to PROJ4 as PROJ4, others use just PROJ.
Add code to export both names for this package.