### PR TITLE
Add a fletch-level option for OpenCV's highgui; defaults to off.

### DIFF
--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -35,6 +35,10 @@ endif()
 option(fletch_ENABLE_EIGEN "Should Eigen Support be turned on for OpenCV?" ${_OpenCV_ENABLE_EIGEN_DEFAULT})
 endif(FALSE)
 
+# Explicitly disable OpenCV's highgui
+option(fletch_ENABLE_OpenCV_highgui "Build OpenCV's highgui (may conflict with system ffmpeg)?" FALSE )
+set(OpenCV_EXTRA_BUILD_FLAGS ${OpenCV_EXTRA_BUILD_FLAGS} -DBUILD_opencv_highgui=${fletch_ENABLE_OpenCV_highgui})
+
 # Handle GPU disable flag
 if(fletch_DISABLE_GPU_SUPPORT)
   set(OpenCV_EXTRA_BUILD_FLAGS ${OpenCV_EXTRA_BUILD_FLAGS} -DWITH_CUBLAS=OFF -DWITH_CUDA=OFF -DWITH_CUFFT=OFF)


### PR DESCRIPTION
This commit defaults fletch to build OpenCV without the highgui
package. When highgui is enabled, OpenCV searches for ffmpeg, but
(at least on my mac) it finds the "system" (macport) include files
before its local ffmpeg, and fails to build. Turning highgui off
allows OpenCV to build.

As far as I know, no fletch clients require highgui... if this
changes, we can revisit with a more nuanced solution.