### PR TITLE
Revert "Latest version of VXL is not compatible with VidTK"

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -176,8 +176,8 @@ set(VTK_md5 "2363432e25e6a2377e1c241cd2954f00")
 list(APPEND fletch_external_sources VTK)
 
 # VXL
-set(VXL_url "https://github.com/vxl/vxl/archive/c57d698f16b8a2f5c6456a490aaf4a8ce91531ce.zip")
-set(VXL_md5 "8d5b5c9623d0ba66531fc525e9a5b424")
+set(VXL_url "https://github.com/vxl/vxl/archive/fee98c789fef1d79db902ad23fbdb92c03476456.zip")
+set(VXL_md5 "ca283418dc04fc736068ae18888fa9aa")
 list(APPEND fletch_external_sources VXL)
 
 #+


### PR DESCRIPTION
The old version of VXL is broken in the way in installs some configured
vnl headers and causes errors building MAP-Tk.  Revert to a newer
version.

This reverts commit 14c5c6b8074bc52781fc6fbbe2fdecf0645250d1.