### PR TITLE
Patch Boost build for gcc >= 5.2

### DIFF
--- a/Patches/Boost/Patch.cmake
+++ b/Patches/Boost/Patch.cmake
@@ -16,3 +16,9 @@ file(COPY ${Boost_patch}/cas128strong.hpp ${Boost_patch}/gcc-atomic.hpp
 file(COPY ${Boost_patch}/transform_width.hpp
   DESTINATION ${Boost_source}/boost/archive/iterators/
 )
+
+# Following patch fixes compile errors for gcc>=5.2
+# https://svn.boost.org/trac/boost/ticket/10125
+file(COPY ${Boost_patch}/pthread/once_atomic.hpp ${Boost_patch}/pthread/once.hpp
+  DESTINATION ${Boost_source}/boost/thread/pthread/
+  )

--- a/Patches/Boost/pthread/once.hpp
+++ b/Patches/Boost/pthread/once.hpp
@@ -1,0 +1,540 @@
+#ifndef BOOST_THREAD_PTHREAD_ONCE_HPP
+#define BOOST_THREAD_PTHREAD_ONCE_HPP
+
+//  once.hpp
+//
+//  (C) Copyright 2007-8 Anthony Williams
+//  (C) Copyright 2011-2012 Vicente J. Botet Escriba
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/thread/detail/config.hpp>
+#include <boost/thread/detail/move.hpp>
+#include <boost/thread/detail/invoke.hpp>
+
+#include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
+#include <boost/thread/detail/delete.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+
+#include <boost/bind.hpp>
+#include <boost/assert.hpp>
+#include <boost/config/abi_prefix.hpp>
+
+#include <boost/cstdint.hpp>
+#include <pthread.h>
+#include <csignal>
+
+namespace boost
+{
+
+  struct once_flag;
+
+  #define BOOST_ONCE_INITIAL_FLAG_VALUE 0
+
+  namespace thread_detail
+  {
+    typedef boost::uint32_t  uintmax_atomic_t;
+    #define BOOST_THREAD_DETAIL_UINTMAX_ATOMIC_C2(value) value##u
+    #define BOOST_THREAD_DETAIL_UINTMAX_ATOMIC_MAX_C BOOST_THREAD_DETAIL_UINTMAX_ATOMIC_C2(~0)
+
+  }
+
+#ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    template<typename Function, class ...ArgTypes>
+    inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+#else
+    template<typename Function>
+    inline void call_once(once_flag& flag, Function f);
+    template<typename Function, typename T1>
+    inline void call_once(once_flag& flag, Function f, T1 p1);
+    template<typename Function, typename T1, typename T2>
+    inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2);
+    template<typename Function, typename T1, typename T2, typename T3>
+    inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2, T3 p3);
+#endif
+
+  struct once_flag
+  {
+      BOOST_THREAD_NO_COPYABLE(once_flag)
+      BOOST_CONSTEXPR once_flag() BOOST_NOEXCEPT
+        : epoch(BOOST_ONCE_INITIAL_FLAG_VALUE)
+      {}
+  private:
+      volatile thread_detail::uintmax_atomic_t epoch;
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+      template<typename Function, class ...ArgTypes>
+      friend void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+#else
+      template<typename Function>
+      friend void call_once(once_flag& flag, Function f);
+      template<typename Function, typename T1>
+      friend void call_once(once_flag& flag, Function f, T1 p1);
+      template<typename Function, typename T1, typename T2>
+      friend void call_once(once_flag& flag, Function f, T1 p1, T2 p2);
+      template<typename Function, typename T1, typename T2, typename T3>
+      friend void call_once(once_flag& flag, Function f, T1 p1, T2 p2, T3 p3);
+
+#endif
+
+  };
+
+#define BOOST_ONCE_INIT once_flag()
+
+#else // BOOST_THREAD_PROVIDES_ONCE_CXX11
+
+    struct once_flag
+    {
+      volatile thread_detail::uintmax_atomic_t epoch;
+    };
+
+#define BOOST_ONCE_INIT {BOOST_ONCE_INITIAL_FLAG_VALUE}
+#endif // BOOST_THREAD_PROVIDES_ONCE_CXX11
+
+
+#if defined BOOST_THREAD_PROVIDES_INVOKE
+#define BOOST_THREAD_INVOKE_RET_VOID detail::invoke
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL
+#elif defined BOOST_THREAD_PROVIDES_INVOKE_RET
+#define BOOST_THREAD_INVOKE_RET_VOID detail::invoke<void>
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL
+#else
+#define BOOST_THREAD_INVOKE_RET_VOID boost::bind
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL ()
+#endif
+
+    namespace thread_detail
+    {
+        BOOST_THREAD_DECL uintmax_atomic_t& get_once_per_thread_epoch();
+        BOOST_THREAD_DECL extern uintmax_atomic_t once_global_epoch;
+        BOOST_THREAD_DECL extern pthread_mutex_t once_epoch_mutex;
+        BOOST_THREAD_DECL extern pthread_cond_t once_epoch_cv;
+    }
+
+    // Based on Mike Burrows fast_pthread_once algorithm as described in
+    // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2444.html
+
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+
+  template<typename Function, class ...ArgTypes>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(
+                        thread_detail::decay_copy(boost::forward<Function>(f)),
+                        thread_detail::decay_copy(boost::forward<ArgTypes>(args))...
+                    ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+
+    }
+  }
+#else
+  template<typename Function>
+  inline void call_once(once_flag& flag, Function f)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    f();
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+  template<typename Function, typename T1>
+  inline void call_once(once_flag& flag, Function f, T1 p1)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(f,p1) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+  template<typename Function, typename T1, typename T2>
+  inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(f,p1, p2) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+        }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+  template<typename Function, typename T1, typename T2, typename T3>
+  inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2, T3 p3)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(f,p1, p2, p3) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+        }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+  template<typename Function>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    f();
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+  template<typename Function, typename T1>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(
+                        thread_detail::decay_copy(boost::forward<Function>(f)),
+                        thread_detail::decay_copy(boost::forward<T1>(p1))
+                    ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+  template<typename Function, typename T1, typename T2>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1, BOOST_THREAD_RV_REF(T2) p2)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(
+                        thread_detail::decay_copy(boost::forward<Function>(f)),
+                        thread_detail::decay_copy(boost::forward<T1>(p1)),
+                        thread_detail::decay_copy(boost::forward<T1>(p2))
+                    ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+  template<typename Function, typename T1, typename T2, typename T3>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1, BOOST_THREAD_RV_REF(T2) p2, BOOST_THREAD_RV_REF(T3) p3)
+  {
+    static thread_detail::uintmax_atomic_t const uninitialized_flag=BOOST_ONCE_INITIAL_FLAG_VALUE;
+    static thread_detail::uintmax_atomic_t const being_initialized=uninitialized_flag+1;
+    thread_detail::uintmax_atomic_t const epoch=flag.epoch;
+    thread_detail::uintmax_atomic_t& this_thread_epoch=thread_detail::get_once_per_thread_epoch();
+
+    if(epoch<this_thread_epoch)
+    {
+        pthread::pthread_mutex_scoped_lock lk(&thread_detail::once_epoch_mutex);
+
+        while(flag.epoch<=being_initialized)
+        {
+            if(flag.epoch==uninitialized_flag)
+            {
+                flag.epoch=being_initialized;
+                BOOST_TRY
+                {
+                    pthread::pthread_mutex_scoped_unlock relocker(&thread_detail::once_epoch_mutex);
+                    BOOST_THREAD_INVOKE_RET_VOID(
+                        thread_detail::decay_copy(boost::forward<Function>(f)),
+                        thread_detail::decay_copy(boost::forward<T1>(p1)),
+                        thread_detail::decay_copy(boost::forward<T1>(p2)),
+                        thread_detail::decay_copy(boost::forward<T1>(p3))
+                    ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+                }
+                BOOST_CATCH (...)
+                {
+                    flag.epoch=uninitialized_flag;
+                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_RETHROW
+                }
+                BOOST_CATCH_END
+                flag.epoch=--thread_detail::once_global_epoch;
+                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+            }
+            else
+            {
+                while(flag.epoch==being_initialized)
+                {
+                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                }
+            }
+        }
+        this_thread_epoch=thread_detail::once_global_epoch;
+    }
+  }
+
+#endif
+
+}
+
+#include <boost/config/abi_suffix.hpp>
+
+#endif

--- a/Patches/Boost/pthread/once_atomic.hpp
+++ b/Patches/Boost/pthread/once_atomic.hpp
@@ -1,0 +1,313 @@
+#ifndef BOOST_THREAD_PTHREAD_ONCE_ATOMIC_HPP
+#define BOOST_THREAD_PTHREAD_ONCE_ATOMIC_HPP
+
+//  once.hpp
+//
+//  (C) Copyright 2013 Andrey Semashev
+//  (C) Copyright 2013 Vicente J. Botet Escriba
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/thread/detail/config.hpp>
+
+#include <boost/cstdint.hpp>
+#include <boost/thread/detail/move.hpp>
+#include <boost/thread/detail/invoke.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/bind.hpp>
+#include <boost/atomic.hpp>
+
+#include <boost/config/abi_prefix.hpp>
+
+namespace boost
+{
+
+  struct once_flag;
+
+  namespace thread_detail
+  {
+
+#if BOOST_ATOMIC_INT_LOCK_FREE == 2
+    typedef unsigned int atomic_int_type;
+#elif BOOST_ATOMIC_SHORT_LOCK_FREE == 2
+    typedef unsigned short atomic_int_type;
+#elif BOOST_ATOMIC_CHAR_LOCK_FREE == 2
+    typedef unsigned char atomic_int_type;
+#elif BOOST_ATOMIC_LONG_LOCK_FREE == 2
+    typedef unsigned long atomic_int_type;
+#elif defined(BOOST_HAS_LONG_LONG) && BOOST_ATOMIC_LLONG_LOCK_FREE == 2
+    typedef ulong_long_type atomic_int_type;
+#else
+    // All tested integer types are not atomic, the spinlock pool will be used
+    typedef unsigned int atomic_int_type;
+#endif
+
+    typedef boost::atomic<atomic_int_type> atomic_type;
+
+    BOOST_THREAD_DECL bool enter_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    BOOST_THREAD_DECL void commit_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    BOOST_THREAD_DECL void rollback_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    inline atomic_type& get_atomic_storage(once_flag& flag)  BOOST_NOEXCEPT;
+  }
+
+#ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
+
+  struct once_flag
+  {
+    BOOST_THREAD_NO_COPYABLE(once_flag)
+    BOOST_CONSTEXPR once_flag() BOOST_NOEXCEPT : storage(0)
+    {
+    }
+
+  private:
+    thread_detail::atomic_type storage;
+
+    friend BOOST_THREAD_DECL bool thread_detail::enter_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    friend BOOST_THREAD_DECL void thread_detail::commit_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    friend BOOST_THREAD_DECL void thread_detail::rollback_once_region(once_flag& flag) BOOST_NOEXCEPT;
+    friend thread_detail::atomic_type& thread_detail::get_atomic_storage(once_flag& flag) BOOST_NOEXCEPT;
+  };
+
+#define BOOST_ONCE_INIT boost::once_flag()
+
+  namespace thread_detail
+  {
+    inline atomic_type& get_atomic_storage(once_flag& flag) BOOST_NOEXCEPT
+    {
+      //return reinterpret_cast< atomic_type& >(flag.storage);
+      return flag.storage;
+    }
+  }
+
+#else // BOOST_THREAD_PROVIDES_ONCE_CXX11
+  struct once_flag
+  {
+    // The thread_detail::atomic_int_type storage is marked
+    // with this attribute in order to let the compiler know that it will alias this member
+    // and silence compilation warnings.
+    BOOST_THREAD_ATTRIBUTE_MAY_ALIAS thread_detail::atomic_int_type storage;
+  };
+
+  #define BOOST_ONCE_INIT {0}
+
+  namespace thread_detail
+  {
+    inline atomic_type& get_atomic_storage(once_flag& flag) BOOST_NOEXCEPT
+    {
+      return reinterpret_cast< atomic_type& >(flag.storage);
+    }
+
+  }
+
+#endif // BOOST_THREAD_PROVIDES_ONCE_CXX11
+
+#if defined BOOST_THREAD_PROVIDES_INVOKE
+#define BOOST_THREAD_INVOKE_RET_VOID detail::invoke
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL
+#elif defined BOOST_THREAD_PROVIDES_INVOKE_RET
+#define BOOST_THREAD_INVOKE_RET_VOID detail::invoke<void>
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL
+#else
+#define BOOST_THREAD_INVOKE_RET_VOID boost::bind
+#define BOOST_THREAD_INVOKE_RET_VOID_CALL ()
+#endif
+
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+  template<typename Function, class ...ArgTypes>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(
+                        thread_detail::decay_copy(boost::forward<Function>(f)),
+                        thread_detail::decay_copy(boost::forward<ArgTypes>(args))...
+        ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+#else
+  template<typename Function>
+  inline void call_once(once_flag& flag, Function f)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        f();
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+  template<typename Function, typename T1>
+  inline void call_once(once_flag& flag, Function f, T1 p1)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(f, p1) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+  template<typename Function, typename T1, typename T2>
+  inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(f, p1, p2) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+  template<typename Function, typename T1, typename T2, typename T3>
+  inline void call_once(once_flag& flag, Function f, T1 p1, T2 p2, T3 p3)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(f, p1, p2, p3) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+  template<typename Function>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        f();
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+  template<typename Function, typename T1>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(
+            thread_detail::decay_copy(boost::forward<Function>(f)),
+            thread_detail::decay_copy(boost::forward<T1>(p1))
+        ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+  template<typename Function, typename T1, typename T2>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1, BOOST_THREAD_RV_REF(T2) p2)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(
+            thread_detail::decay_copy(boost::forward<Function>(f)),
+            thread_detail::decay_copy(boost::forward<T1>(p1)),
+            thread_detail::decay_copy(boost::forward<T1>(p2))
+        ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+  template<typename Function, typename T1, typename T2, typename T3>
+  inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1, BOOST_THREAD_RV_REF(T2) p2, BOOST_THREAD_RV_REF(T3) p3)
+  {
+    if (thread_detail::enter_once_region(flag))
+    {
+      BOOST_TRY
+      {
+        BOOST_THREAD_INVOKE_RET_VOID(
+            thread_detail::decay_copy(boost::forward<Function>(f)),
+            thread_detail::decay_copy(boost::forward<T1>(p1)),
+            thread_detail::decay_copy(boost::forward<T1>(p2)),
+            thread_detail::decay_copy(boost::forward<T1>(p3))
+        ) BOOST_THREAD_INVOKE_RET_VOID_CALL;
+
+      }
+      BOOST_CATCH (...)
+      {
+        thread_detail::rollback_once_region(flag);
+        BOOST_RETHROW
+      }
+      BOOST_CATCH_END
+      thread_detail::commit_once_region(flag);
+    }
+  }
+
+
+
+#endif
+}
+
+#include <boost/config/abi_suffix.hpp>
+
+#endif
+


### PR DESCRIPTION
Boost fails to build on gcc >= 5.2. The following patch addresses the issue in its pthread related code, once and once_atomic.