### PR TITLE
Dev/update protobuf url

### DIFF
--- a/CMake/External_Protobuf.cmake
+++ b/CMake/External_Protobuf.cmake
@@ -10,9 +10,14 @@ ExternalProject_Add(Protobuf
   PREFIX ${fletch_BUILD_PREFIX}
   DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
   INSTALL_DIR ${fletch_BUILD_INSTALL_PREFIX}
+  PATCH_COMMAND ${CMAKE_COMMAND}
+    -DProtobuf_patch:PATH=${fletch_SOURCE_DIR}/Patches/Protobuf
+    -DProtobuf_source:PATH=${fletch_BUILD_PREFIX}/src/Protobuf
+    -P ${fletch_SOURCE_DIR}/Patches/Protobuf/Patch.cmake
   BUILD_IN_SOURCE 1
   ${PROTOBUF_PATCH_ARG}
-  CONFIGURE_COMMAND ./configure
+  CONFIGURE_COMMAND ./autogen.sh
+            COMMAND ./configure
     --prefix=${fletch_BUILD_INSTALL_PREFIX}
   BUILD_COMMAND ${MAKE_EXECUTABLE}
   INSTALL_COMMAND ${MAKE_EXECUTABLE} install

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -213,8 +213,8 @@ endif()
 # GLog
 if(NOT WIN32)
   set(GLog_version "0.3.3")
-  set(GLog_url "https://google-glog.googlecode.com/files/glog-${GLog_version}.tar.gz")
-  set(GLog_md5 "a6fd2c22f8996846e34c763422717c18")
+  set(GLog_url "https://github.com/google/glog/archive/v${GLog_version}.tar.gz")
+  set(GLog_md5 "c1f86af27bd9c73186730aa957607ed0")
   list(APPEND fletch_external_sources GLog)
 endif()
 
@@ -235,8 +235,8 @@ endif()
 # Protobuf
 if(NOT WIN32)
   set(Protobuf_version "2.5.0" )
-  set(Protobuf_url "http://protobuf.googlecode.com/files/protobuf-${Protobuf_version}.tar.bz2" )
-  set(Protobuf_md5 "a72001a9067a4c2c4e0e836d0f92ece4" )
+  set(Protobuf_url "https://github.com/google/protobuf/archive/v${Protobuf_version}.tar.gz" )
+  set(Protobuf_md5 "9c21577a03adc1879aba5b52d06e25cf" )
   list(APPEND fletch_external_sources Protobuf )
 endif()
 

--- a/Patches/Protobuf/Patch.cmake
+++ b/Patches/Protobuf/Patch.cmake
@@ -6,6 +6,6 @@
 message ("Patching Protobuf in ${Protobuf_source}")
 
 file(COPY ${Protobuf_patch}/autogen.sh
-  DESTINATION ${Protobuf_source}/autogen.sh
+  DESTINATION ${Protobuf_source}/
 )
 

--- a/Patches/Protobuf/Patch.cmake
+++ b/Patches/Protobuf/Patch.cmake
@@ -1,0 +1,11 @@
+#+
+# This file is called as CMake -P script for the patch step of
+# External_Protobuf to fix a broken URL
+#-
+
+message ("Patching Protobuf in ${Protobuf_source}")
+
+file(COPY ${Protobuf_patch}/autogen.sh
+  DESTINATION ${Protobuf_source}/autogen.sh
+)
+

--- a/Patches/Protobuf/autogen.sh
+++ b/Patches/Protobuf/autogen.sh
@@ -19,8 +19,8 @@ fi
 # directory is set up as an SVN external.
 if test ! -e gtest; then
   echo "Google Test not present.  Fetching gtest-1.5.0 from the web..."
-  curl http://googletest.googlecode.com/files/gtest-1.5.0.tar.bz2 | tar jx
-  mv gtest-1.5.0 gtest
+  curl https://codeload.github.com/google/googletest/tar.gz/release-1.5.0 | tar zx
+  mv googletest-release-1.5.0 gtest
 fi
 
 set -ex

--- a/Patches/Protobuf/autogen.sh
+++ b/Patches/Protobuf/autogen.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Run this script to generate the configure script and other files that will
+# be included in the distribution.  These files are not checked in because they
+# are automatically generated.
+
+set -e
+
+# Check that we're being run from the right directory.
+if test ! -f src/google/protobuf/stubs/common.h; then
+  cat >&2 << __EOF__
+Could not find source code.  Make sure you are running this script from the
+root of the distribution tree.
+__EOF__
+  exit 1
+fi
+
+# Check that gtest is present.  Usually it is already there since the
+# directory is set up as an SVN external.
+if test ! -e gtest; then
+  echo "Google Test not present.  Fetching gtest-1.5.0 from the web..."
+  curl http://googletest.googlecode.com/files/gtest-1.5.0.tar.bz2 | tar jx
+  mv gtest-1.5.0 gtest
+fi
+
+set -ex
+
+# Temporary hack:  Must change C runtime library to "multi-threaded DLL",
+#   otherwise it will be set to "multi-threaded static" when MSVC upgrades
+#   the project file to MSVC 2005/2008.  vladl of Google Test says gtest will
+#   probably change their default to match, then this will be unnecessary.
+#   One of these mappings converts the debug configuration and the other
+#   converts the release configuration.  I don't know which is which.
+sed -i -e 's/RuntimeLibrary="5"/RuntimeLibrary="3"/g;
+           s/RuntimeLibrary="4"/RuntimeLibrary="2"/g;' gtest/msvc/*.vcproj
+
+# TODO(kenton):  Remove the ",no-obsolete" part and fix the resulting warnings.
+autoreconf -f -i -Wall,no-obsolete
+
+rm -rf autom4te.cache config.h.in~
+exit 0


### PR DESCRIPTION
Protobuf has been moved from googlecode to github, the tarball URL needs to be updated and the gtest URL in autogen.sh needs to be updated