### PR TITLE
Disable ld-version-script in libtiff.

### DIFF
--- a/Patches/libtiff/CMakeLists.txt
+++ b/Patches/libtiff/CMakeLists.txt
@@ -184,7 +184,7 @@ if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
-option(ld-version-script "Enable linker version script" ON)
+option(ld-version-script "Enable linker version script" OFF)
 # Check if LD supports linker scripts.
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/conftest.map" "VERS_1 {
         global: sym;


### PR DESCRIPTION
On newer gcc, the linker versions the symbols and causes linker issues with packages that try to link libtiff.