### PR TITLE
Use glog in ceres

### DIFF
--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -2,8 +2,7 @@
 # Set Eigen dependency
 if (fletch_ENABLE_Eigen)
   message(STATUS "Ceres depending on internal Eigen")
-  set(Ceres_DEPENDS Eigen ${Ceres_DEPENDS})
-  set(Ceres_EXTRA_BUILD_FLAGS )
+  list(APPEND Ceres_DEPENDS Eigen)
 else()
   message(FATAL_ERROR "Eigen is required for Ceres Solver, please enable")
 endif()
@@ -11,10 +10,20 @@ endif()
 # Set SuiteSparse dependency
 if (fletch_ENABLE_SuiteSparse)
   message(STATUS "Ceres depending on internal SuiteSparse")
-  set(Ceres_DEPENDS SuiteSparse ${Ceres_DEPENDS})
-  set(Ceres_EXTRA_BUILD_FLAGS CXSparse:BOOL=ON )
+  list(APPEND Ceres_DEPENDS SuiteSparse)
 else()
   message(FATAL_ERROR "SuiteSparse is required for Ceres Solver, please enable")
+endif()
+
+if (fletch_ENABLE_GLog)
+  list(APPEND Ceres_DEPENDS GLog)
+  get_system_library_name( glog glog_libname )
+  list(APPEND Ceres_EXTRA_BUILD_FLAGS
+         -DGLOG_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+         -DGLOG_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${glog_libname}
+      )
+else()
+  list(APPEND Ceres_EXTRA_BUILD_FLAGS MINIGLOG:BOOL=ON)
 endif()
 
 ExternalProject_Add(Ceres
@@ -38,11 +47,11 @@ ExternalProject_Add(Ceres
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-    -DMINIGLOG:BOOL=TRUE
     -DEIGEN_INCLUDE_DIR=${EIGEN_INCLUDE_DIR}
     -DCXSPARSE_INCLUDE_DIR=${SuiteSparse_INCLUDE_DIR}
     -DCXSPARSE_LIBRARY_DIR_HINTS=${SuiteSparse_ROOT}/lib
     -DLIB_SUFFIX:STRING=
+    ${Ceres_EXTRA_BUILD_FLAGS}
   )
 
 set(Ceres_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -80,6 +80,28 @@ set(Eigen_md5 "135d8d43aaee5fb54cf5f3e981b1a6db")
 set(Eigen_dlname "eigen-${Eigen_version}.tar.gz")
 list(APPEND fletch_external_sources Eigen)
 
+# GLog
+if(NOT WIN32)
+  set(GLog_version "0.3.3")
+  set(GLog_url "https://github.com/google/glog/archive/v${GLog_version}.tar.gz")
+  set(GLog_md5 "c1f86af27bd9c73186730aa957607ed0")
+  list(APPEND fletch_external_sources GLog)
+endif()
+
+# GFlags
+set(GFlags_version "2.1.2")
+set(GFlags_url "https://github.com/gflags/gflags/archive/v${GFlags_version}.tar.gz")
+set(GFlags_md5 "ac432de923f9de1e9780b5254884599f")
+list(APPEND fletch_external_sources GFlags)
+
+#OpenBLAS
+if(NOT WIN32)
+  set(OpenBLAS_version "0.2.15")
+  set(OpenBLAS_url "https://github.com/xianyi/OpenBLAS/archive/v${OpenBLAS_version}.tar.gz")
+  set(OpenBLAS_md5 "b1190f3d3471685f17cfd1ec1d252ac9")
+  list(APPEND fletch_external_sources OpenBLAS)
+endif()
+
 # OpenCV
 set(OpenCV_version "2.4.11")
 set(OpenCV_url "http://downloads.sourceforge.net/project/opencvlibrary/opencv-unix/${OpenCV_version}/opencv-${OpenCV_version}.zip")
@@ -206,28 +228,6 @@ if(NOT WIN32)
   set(LevelDB_url "https://github.com/google/leveldb/archive/v${LevelDB_version}.tar.gz")
   set(LevelDB_md5 "73770de34a2a5ab34498d2e05b2b7fa0")
   list(APPEND fletch_external_sources LevelDB)
-endif()
-
-# GLog
-if(NOT WIN32)
-  set(GLog_version "0.3.3")
-  set(GLog_url "https://github.com/google/glog/archive/v${GLog_version}.tar.gz")
-  set(GLog_md5 "c1f86af27bd9c73186730aa957607ed0")
-  list(APPEND fletch_external_sources GLog)
-endif()
-
-# GFlags
-set(GFlags_version "2.1.2")
-set(GFlags_url "https://github.com/gflags/gflags/archive/v${GFlags_version}.tar.gz")
-set(GFlags_md5 "ac432de923f9de1e9780b5254884599f")
-list(APPEND fletch_external_sources GFlags)
-
-#OpenBLAS
-if(NOT WIN32)
-  set(OpenBLAS_version "0.2.15")
-  set(OpenBLAS_url "https://github.com/xianyi/OpenBLAS/archive/v${OpenBLAS_version}.tar.gz")
-  set(OpenBLAS_md5 "b1190f3d3471685f17cfd1ec1d252ac9")
-  list(APPEND fletch_external_sources OpenBLAS)
 endif()
 
 # Protobuf


### PR DESCRIPTION
Now that GLog is in Fletch, make Ceres use GLog if GLog was enabled.

I found that I was actually getting linking errors in MAP-Tk if GLog was being built in Fletch but not used in Ceres.  I'm not sure why, but this fixes it.  It's also the right thing to do since Ceres highly recommends using GLog when available.