### PR TITLE
Fixed error in passing a CMake variable.

### DIFF
--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -23,7 +23,7 @@ if (fletch_ENABLE_GLog)
          -DGLOG_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${glog_libname}
       )
 else()
-  list(APPEND Ceres_EXTRA_BUILD_FLAGS MINIGLOG:BOOL=ON)
+  list(APPEND Ceres_EXTRA_BUILD_FLAGS -DMINIGLOG:BOOL=ON)
 endif()
 
 ExternalProject_Add(Ceres


### PR DESCRIPTION
A variable passed to CMake was missing a "-D" prefix causing the
variable to not be set in CMake correctly.