### PR TITLE
Configure OpenCV when fletch_ENABLE_ALL_PACKAGES is set on cli.

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -77,8 +77,8 @@ list(APPEND fletch_external_sources Eigen)
 
 # OpenCV
 # Support 2.4.11 and 3.1 optionally
-if (fletch_ENABLE_OpenCV)
-  set(OpenCV_SELECT_VERSION 2.4.11 CACHE STRING "Select the  version of OpenCV to build.")
+if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES)
+  set(OpenCV_SELECT_VERSION 3.1.0 CACHE STRING "Select the  version of OpenCV to build.")
   set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS 2.4.11 3.1.0)
 
   # Expose optional contrib repo when enabling OpenCV version >= 3.x


### PR DESCRIPTION
When fletch_ENABLE_ALL_PACKAGES is set from the command line cmake, OpenCV doesn't fully configure because technically it isn't enabled yet when fletch-tarballs is included. Exand the OpenCV conditional to include fletch_ENABLE_ALL_PACKAGES so it will provide its defaults when only fletch_ENABLE_ALL_PACKAGES is selected.

This patch also sets the default OpenCV version to 3.