### PR TITLE
Fix KWIVER link in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Fletch
 
-Fletch is part of Kitware's [KWIVER](www.kwiver.org) project.  Its purpose is to make it a little easier to
+Fletch is part of Kitware's [KWIVER](http://www.kwiver.org) project.  Its purpose is to make it a little easier to
 obtain, configure and build KWIVER's dependencies


### PR DESCRIPTION
The link that was in this file did not work from github.  Github added github.com in front of the link. If you put http:: in the link it works from github.