### PR TITLE
Kml find expat

### DIFF
--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -13,7 +13,6 @@ else()
     set(libkml_use_external_expat
       -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=OFF
       )
-    set(_KML_DEPENDS ${_KML_DEPENDS} GDAL)
   else()
     set(libkml_use_external_expat
       -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=ON
@@ -63,6 +62,6 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 set(LIBKML_ROOT    @LIBKML_ROOT@)
 set(LIBKML_LIBNAME @LIBKML_LIBNAME@)
 
-set(fletch_ENABLED_libml TRUE)
+set(fletch_ENABLED_libkml TRUE)
 ")
 

--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -6,9 +6,19 @@ if(WIN32)
     -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=OFF
     )
 else()
-  set(libkml_use_external_expat
-    -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=ON
-    )
+  #Using an external EXPAT library requires installation of expat-devel,
+  #which may not be installed on some systems.
+  find_package( EXPAT )
+  if (NOT ${EXPAT_FOUND})
+    set(libkml_use_external_expat
+      -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=OFF
+      )
+    set(_KML_DEPENDS ${_KML_DEPENDS} GDAL)
+  else()
+    set(libkml_use_external_expat
+      -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=ON
+      )
+  endif()
 endif()
 
 # If we're building Boost, use that one.

--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -28,6 +28,7 @@ if(fletch_ENABLE_Boost)
     )
   set(_KML_DEPENDS ${_KML_DEPENDS} Boost)
 else()
+  # TODO: This else really should do a find_package(Boost) before blindly having kml build it.
   set(libkml_use_external_boost
     -DLIBKML_USE_EXTERNAL_BOOST:BOOL=OFF
     )


### PR DESCRIPTION
Ensure we have expat intalled before telling libkml to use an external expat