### PR TITLE
Add experimental flag to avoid building ITK in dashboards

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -267,6 +267,7 @@ set(ITK_version 4.11)
 set(ITK_minor 0)
 set(ITK_url "http://downloads.sourceforge.net/project/itk/itk/${ITK_version}/InsightToolkit-${ITK_version}.${ITK_minor}.tar.xz")
 set(ITK_md5 "415b966dd32fd543accf3a1bb689b7e1")
+set(ITK_experimental TRUE)
 list(APPEND fletch_external_sources ITK)
 
 # LMDB

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,10 @@ set (COMMON_CMAKE_ARGS
 #
 set_property(DIRECTORY PROPERTY EP_STEP_TARGETS download)
 foreach(source ${fletch_external_sources})
+
+  # fletch_ENABLE_ALL_PACKAGES will automatically enable all commonly used packages
+  # Avoid building unused packages by adding an _experimental flag in CMake/fletch-tarballs.cmake
+  # For example, "set(ITK_experimental TRUE)" to avoid building ITK
   if (fletch_ENABLE_ALL_PACKAGES  AND NOT ${source}_experimental)
     set(fletch_ENABLE_${source} TRUE CACHE BOOL "" FORCE)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ set (COMMON_CMAKE_ARGS
 #
 set_property(DIRECTORY PROPERTY EP_STEP_TARGETS download)
 foreach(source ${fletch_external_sources})
-  if (fletch_ENABLE_ALL_PACKAGES)
+  if (fletch_ENABLE_ALL_PACKAGES  AND NOT ${source}_experimental)
     set(fletch_ENABLE_${source} TRUE CACHE BOOL "" FORCE)
   endif()
 


### PR DESCRIPTION
ITK isn't actually being used, but takes up a significant amount of dashboard time when python is enabled. We don't want to get rid of ITK, so to compromise a flag was added to exclude it from fletch_ENABLE_ALL_PACKAGES.