### PR TITLE
Fix FletchConfig.cmake package_DIR variables

### DIFF
--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -54,7 +54,11 @@ ExternalProject_Add(Ceres
 fletch_external_project_force_install(PACKAGE Ceres)
 
 set(Ceres_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
-set(Ceres_DIR "${Ceres_ROOT}/share/Ceres" CACHE PATH "" FORCE)
+if(WIN32)
+  set(Ceres_DIR "${Ceres_ROOT}/CMake" CACHE PATH "" FORCE)
+else()
+  set(Ceres_DIR "${Ceres_ROOT}/share/Ceres" CACHE PATH "" FORCE)
+endif()
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################

--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -123,11 +123,13 @@ include_directories( SYSTEM ${KWIVER_BUILD_INSTALL_PREFIX}/include/vxl
                             ${KWIVER_BUILD_INSTALL_PREFIX}/include/vxl/core )
 
 set(VXL_ROOT "${fletch_BUILD_INSTALL_PREFIX}" CACHE PATH "" FORCE)
+set(VXL_DIR "${VXL_ROOT}/share/vxl/cmake" CACHE PATH "" FORCE)
 file(APPEND ${fletch_CONFIG_INPUT} "
 ################################
 # VXL
 ################################
 set(VXL_ROOT @VXL_ROOT@)
+set(VXL_DIR @VXL_DIR@)
 
 set(fletch_ENABLED_VXL TRUE)
 ")

--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -46,6 +46,7 @@ ExternalProject_Add(libkml
 fletch_external_project_force_install(PACKAGE libkml)
 
 set(LIBKML_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "" FORCE)
+set(LIBKML_DIR "${LIBKML_ROOT}/lib/cmake" CACHE PATH "" FORCE)
 set(LIBKML_LIBNAME kml)
 
 file(APPEND ${fletch_CONFIG_INPUT} "
@@ -53,6 +54,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # libkml
 ########################################
 set(LIBKML_ROOT    @LIBKML_ROOT@)
+set(LIBKML_DIR     @LIBKML_DIR@)
 set(LIBKML_LIBNAME @LIBKML_LIBNAME@)
 
 set(fletch_ENABLED_libml TRUE)

--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -57,6 +57,6 @@ set(LIBKML_ROOT    @LIBKML_ROOT@)
 set(LIBKML_DIR     @LIBKML_DIR@)
 set(LIBKML_LIBNAME @LIBKML_LIBNAME@)
 
-set(fletch_ENABLED_libml TRUE)
+set(fletch_ENABLED_libkml TRUE)
 ")
 

--- a/CMake/External_log4cplus.cmake
+++ b/CMake/External_log4cplus.cmake
@@ -16,11 +16,13 @@ ExternalProject_Add(log4cplus
 fletch_external_project_force_install(PACKAGE log4cplus)
 
 set(LOG4CPLUS_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+set(LOG4CPLUS_DIR "${LOG4CPLUS_ROOT}/lib/cmake/log4cplus" CACHE PATH "" FORCE)
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # log4cplus
 ########################################
 set(LOG4CPLUS_ROOT    @LOG4CPLUS_ROOT@)
+set(LOG4CPLUS_DIR    @LOG4CPLUS_DIR@)
 set(fletch_ENABLED_log4cplus TRUE)
 ")

--- a/CMake/External_log4cplus.cmake
+++ b/CMake/External_log4cplus.cmake
@@ -15,14 +15,14 @@ ExternalProject_Add(log4cplus
 
 fletch_external_project_force_install(PACKAGE log4cplus)
 
-set(LOG4CPLUS_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
-set(LOG4CPLUS_DIR "${LOG4CPLUS_ROOT}/lib/cmake/log4cplus" CACHE PATH "" FORCE)
+set(Log4cplus_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+set(Log4cplus_DIR "${Log4cplus_ROOT}/lib/cmake/log4cplus" CACHE PATH "" FORCE)
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # log4cplus
 ########################################
-set(LOG4CPLUS_ROOT    @LOG4CPLUS_ROOT@)
-set(LOG4CPLUS_DIR    @LOG4CPLUS_DIR@)
-set(fletch_ENABLED_log4cplus TRUE)
+set(Log4cplus_ROOT    @Log4cplus_ROOT@)
+set(Log4cplus_DIR     @Log4cplus_DIR@)
+set(fletch_ENABLED_Log4cplus TRUE)
 ")


### PR DESCRIPTION
This patch fixes numerous issues with the variables exported by Fletch and used by KWIVER to find the Fletch packages.

There are likely other missing variables and variable naming issues (e.g. name case) that need to be fixed, but these fixes are the ones needed to address current build issues, especially on Windows.