### PR TITLE
Configure log4plus

### DIFF
--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -54,7 +54,14 @@ ExternalProject_Add(Ceres
 fletch_external_project_force_install(PACKAGE Ceres)
 
 set(Ceres_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
-set(Ceres_DIR "${Ceres_ROOT}/share/Ceres" CACHE PATH "" FORCE)
+#Ceres installs its config file in a different location on Windows
+if(WIN32)
+  set(Ceres_DIR "${Ceres_ROOT}/CMake" CACHE PATH "" FORCE)
+else()
+  set(Ceres_DIR "${Ceres_ROOT}/share/Ceres" CACHE PATH "" FORCE)
+endif()
+
+
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################

--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -128,6 +128,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # VXL
 ################################
 set(VXL_ROOT @VXL_ROOT@)
+set(VXL_DIR @VXL_ROOT@/share/vxl/cmake)
 
 set(fletch_ENABLED_VXL TRUE)
 ")

--- a/CMake/External_log4cplus.cmake
+++ b/CMake/External_log4cplus.cmake
@@ -11,16 +11,18 @@ ExternalProject_Add(log4cplus
       ${COMMON_CMAKE_ARGS}
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DUNICODE:BOOL=OFF
     )
 
 fletch_external_project_force_install(PACKAGE log4cplus)
 
-set(LOG4CPLUS_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+set(log4cplus_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # log4cplus
 ########################################
-set(LOG4CPLUS_ROOT    @LOG4CPLUS_ROOT@)
+set(log4cplus_ROOT   @log4cplus_ROOT@)
+set(log4cplus_DIR    @log4cplus_ROOT@/lib/cmake/log4cplus)
 set(fletch_ENABLED_log4cplus TRUE)
 ")


### PR DESCRIPTION
use all lower case, as that is the case used for its log4cplusConfig.cmake
Also, turn unicode off