### PR TITLE
Fix fletch root dir install

### DIFF
--- a/CMake/External_Boost.cmake
+++ b/CMake/External_Boost.cmake
@@ -86,7 +86,7 @@ endif()
 set(Boost_ADDITIONAL_VERSIONS @Boost_version@)
 set(Boost_NO_SYSTEM_PATHS ON)
 set(Boost_NO_BOOST_CMAKE ON)
-set(BOOST_ROOT @BOOST_ROOT@)
+set(BOOST_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_Boost TRUE)
 ")

--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -281,5 +281,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # Caffe
 ########################################
-set(Caffe_ROOT    @Caffe_ROOT@)
+set(Caffe_ROOT    \$\{fletch_ROOT\})
 ")

--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -66,7 +66,12 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # Ceres
 ########################################
-set(Ceres_ROOT @Ceres_ROOT@)
-set(Ceres_DIR @Ceres_DIR@)
+set(Ceres_ROOT \$\{fletch_ROOT\})
+if(WIN32)
+  set(Ceres_DIR \$\{fletch_ROOT\}/CMake)
+else()
+  set(Ceres_DIR \$\{fletch_ROOT\}/share/Ceres)
+endif()
+
 set(fletch_ENABLED_Ceres TRUE)
 ")

--- a/CMake/External_Eigen.cmake
+++ b/CMake/External_Eigen.cmake
@@ -27,9 +27,9 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # EIGEN
 ########################################
-set(EIGEN_ROOT    @EIGEN_ROOT@)
-set(EIGEN3_ROOT    @EIGEN_ROOT@)
-set(EIGEN_INCLUDE_DIR @EIGEN_INCLUDE_DIR@)
-set(EIGEN3_INCLUDE_DIR @EIGEN_INCLUDE_DIR@)
+set(EIGEN_ROOT    \$\{fletch_ROOT\})
+set(EIGEN3_ROOT   \$\{fletch_ROOT\})
+set(EIGEN_INCLUDE_DIR \$\{fletch_ROOT\}/include/eigen3)
+set(EIGEN3_INCLUDE_DIR \$\{fletch_ROOT\}/include/eigen3)
 set(fletch_ENABLED_Eigen TRUE)
 ")

--- a/CMake/External_FFmpeg.cmake
+++ b/CMake/External_FFmpeg.cmake
@@ -1,4 +1,3 @@
-
 if (WIN32)
   # On windows, FFMPEG relies on prebuilt binaries. These binaries come in two
   # archives, dev and shared. An external project is added for each of them just
@@ -85,5 +84,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # FFmpeg
 #######################################
-set(FFmpeg_ROOT @FFmpeg_ROOT@)
+set(FFmpeg_ROOT \$\{fletch_ROOT\})
 ")

--- a/CMake/External_GFlags.cmake
+++ b/CMake/External_GFlags.cmake
@@ -25,5 +25,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # GFlags
 #######################################
-set(GFlags_ROOT @GFlags_ROOT@)
+set(GFlags_ROOT \$\{fletch_ROOT\})
 ")

--- a/CMake/External_GLog.cmake
+++ b/CMake/External_GLog.cmake
@@ -36,5 +36,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # GLog
 #######################################
-set(GLog_ROOT @GLog_ROOT@)
+set(GLog_ROOT \$\{fletch_ROOT\})
 ")

--- a/CMake/External_GeographicLib.cmake
+++ b/CMake/External_GeographicLib.cmake
@@ -24,7 +24,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # GeographicLib
 ########################################
-set(GeographicLib_ROOT @GeographicLib_ROOT@)
+set(GeographicLib_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_GeographicLib TRUE)
 ")

--- a/CMake/External_HDF5.cmake
+++ b/CMake/External_HDF5.cmake
@@ -38,5 +38,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # HDF5
 #######################################
-set(HDF5_ROOT @HDF5_ROOT@)
+set(HDF5_ROOT \$\{fletch_ROOT\})
 ")

--- a/CMake/External_ITK.cmake
+++ b/CMake/External_ITK.cmake
@@ -81,8 +81,8 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # ITK
 ########################################
-set(ITK_ROOT @ITK_ROOT@)
-set(ITK_DIR @ITK_DIR@)
+set(ITK_ROOT \$\{fletch_ROOT\})
+set(ITK_DIR \$\{fletch_ROOT\}/lib/cmake/vtk-${ITK_version})
 
 set(fletch_ENABLED_ITK TRUE)
 ")

--- a/CMake/External_LMDB.cmake
+++ b/CMake/External_LMDB.cmake
@@ -1,4 +1,3 @@
-
 if (WIN32)
 
   # Build option for windows not yet generated
@@ -34,5 +33,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # LMDB
 ########################################
-set(LMDB_ROOT    @LMDB_ROOT@)
+set(LMDB_ROOT    \$\{fletch_ROOT\})
 ")

--- a/CMake/External_LevelDB.cmake
+++ b/CMake/External_LevelDB.cmake
@@ -52,5 +52,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # LevelDB
 ########################################
-set(LevelDB_ROOT    @LevelDB_ROOT@)
+set(LevelDB_ROOT    \$\{fletch_ROOT\})
 ")

--- a/CMake/External_OpenBLAS.cmake
+++ b/CMake/External_OpenBLAS.cmake
@@ -40,5 +40,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # OpenBLAS
 ########################################
-set(OpenBLAS_ROOT    @OpenBLAS_ROOT@)
+set(OpenBLAS_ROOT    \$\{fletch_ROOT\})
 ")

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -218,8 +218,12 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # OpenCV
 ########################################
-set(OpenCV_ROOT @OpenCV_ROOT@)
-set(OpenCV_DIR @OpenCV_DIR@)
+set(OpenCV_ROOT \$\{fletch_ROOT\})
+if(WIN32)
+  set(OpenCV_DIR \$\{OpenCV_ROOT\})
+else()
+  set(OpenCV_DIR \$\{OpenCV_ROOT\}/share/OpenCV)
+endif()
 
 set(fletch_ENABLED_OpenCV TRUE)
 ")

--- a/CMake/External_PNG.cmake
+++ b/CMake/External_PNG.cmake
@@ -40,7 +40,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ################################
 # PNG
 ################################
-set(PNG_ROOT @PNG_ROOT@)
+set(PNG_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_PNG TRUE)
 ")

--- a/CMake/External_PROJ4.cmake
+++ b/CMake/External_PROJ4.cmake
@@ -26,9 +26,9 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # PROJ4
 ########################################
-set(PROJ4_ROOT @PROJ4_ROOT@)
-set(PROJ4_INCLUDE_DIR @PROJ4_INCLUDE_DIR@)
-set(PROJ_INCLUDE_DIR @PROJ4_INCLUDE_DIR@)
+set(PROJ4_ROOT \$\{fletch_ROOT\})
+set(PROJ4_INCLUDE_DIR \$\{fletch_ROOT\}/include)
+set(PROJ_INCLUDE_DIR \$\{fletch_ROOT\}/include)
 
 set(fletch_ENABLED_PROJ4 TRUE)
 ")

--- a/CMake/External_Protobuf.cmake
+++ b/CMake/External_Protobuf.cmake
@@ -26,6 +26,6 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # Google Protobuf
 #######################################
-set(Protobuf_ROOT @Protobuf_ROOT@)
+set(Protobuf_ROOT \$\{fletch_ROOT\})
 ")
 

--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -200,7 +200,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # Qt
 ########################################
-set(QT_QMAKE_EXECUTABLE @QT_QMAKE_EXECUTABLE@)
+set(QT_QMAKE_EXECUTABLE \$\{fletch_ROOT\}/bin/qmake)
 
 set(fletch_ENABLED_Qt TRUE)
 ")

--- a/CMake/External_Snappy.cmake
+++ b/CMake/External_Snappy.cmake
@@ -31,5 +31,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # Snappy
 ########################################
-set(SNAPPY_ROOT    @SNAPPY_ROOT@)
+set(SNAPPY_ROOT    \$\{fletch_ROOT\})
 ")

--- a/CMake/External_SuiteSparse.cmake
+++ b/CMake/External_SuiteSparse.cmake
@@ -108,7 +108,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # SuiteSparse
 ########################################
-set(SuiteSparse_ROOT @SuiteSparse_ROOT@)
-set(SuiteSparse_INCLUDE_DIR @SuiteSparse_INCLUDE_DIR@)
+set(SuiteSparse_ROOT \$\{fletch_ROOT\})
+set(SuiteSparse_INCLUDE_DIR \$\{fletch_ROOT\}/include)
 set(fletch_ENABLED_SuiteSparse TRUE)
 ")

--- a/CMake/External_TinyXML.cmake
+++ b/CMake/External_TinyXML.cmake
@@ -29,7 +29,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # TinyXML
 ########################################
-set(TinyXML_ROOT @TinyXML_ROOT@)
+set(TinyXML_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_TinyXML TRUE)
 ")

--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -219,8 +219,8 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # VTK
 ########################################
-set(VTK_ROOT @VTK_ROOT@)
-set(VTK_DIR @VTK_DIR@)
+set(VTK_ROOT \$\{fletch_ROOT\})
+set(VTK_DIR \$\{fletch_ROOT\}/lib/cmake/vtk-${VTK_version})
 
 set(fletch_ENABLED_VTK TRUE)
 ")

--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -128,8 +128,8 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ################################
 # VXL
 ################################
-set(VXL_ROOT @VXL_ROOT@)
-set(VXL_DIR @VXL_DIR@)
+set(VXL_ROOT \$\{fletch_ROOT\})
+set(VXL_DIR \$\{fletch_ROOT\}/share/vxl/cmake)
 
 set(fletch_ENABLED_VXL TRUE)
 ")

--- a/CMake/External_ZLib.cmake
+++ b/CMake/External_ZLib.cmake
@@ -38,7 +38,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # ZLib
 ########################################
-set(ZLIB_ROOT @ZLIB_ROOT@)
+set(ZLIB_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_ZLib TRUE)
 ")

--- a/CMake/External_libjpeg-turbo.cmake
+++ b/CMake/External_libjpeg-turbo.cmake
@@ -74,7 +74,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ################################
 # libjpeg-turbo
 ################################
-set(libjpeg-turbo_ROOT @libjpeg-turbo_ROOT@)
+set(libjpeg-turbo_ROOT \$\{fletch_ROOT\})
 
 
 set(fletch_ENABLED_libjpeg-turbo TRUE)

--- a/CMake/External_libjson.cmake
+++ b/CMake/External_libjson.cmake
@@ -32,7 +32,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # libjson
 ########################################
-set(LIBJSON_ROOT    @LIBJSON_ROOT@)
+set(LIBJSON_ROOT    \$\{fletch_ROOT\})
 set(LIBJSON_LIBNAME @LIBJSON_LIBNAME@)
 
 set(fletch_ENABLED_libjson TRUE)

--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -53,8 +53,8 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # libkml
 ########################################
-set(LIBKML_ROOT    @LIBKML_ROOT@)
-set(LIBKML_DIR     @LIBKML_DIR@)
+set(LIBKML_ROOT    \$\{fletch_ROOT\})
+set(LIBKML_DIR     \$\{fletch_ROOT\}/lib/cmake)
 set(LIBKML_LIBNAME @LIBKML_LIBNAME@)
 
 set(fletch_ENABLED_libkml TRUE)

--- a/CMake/External_libtiff.cmake
+++ b/CMake/External_libtiff.cmake
@@ -76,7 +76,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ################################
 # libtiff
 ################################
-set(libtiff_ROOT @libtiff_ROOT@)
+set(libtiff_ROOT \$\{fletch_ROOT\})
 
 set(fletch_ENABLED_libtiff TRUE)
 ")

--- a/CMake/External_libxml2.cmake
+++ b/CMake/External_libxml2.cmake
@@ -28,7 +28,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # libxml2
 ########################################
-set(LIBXML2_ROOT    @LIBXML2_ROOT@)
+set(LIBXML2_ROOT    \$\{fletch_ROOT\})
 set(LIBXML2_LIBNAME @LIBXML2_LIBNAME@)
 
 set(fletch_ENABLED_libxml2 TRUE)

--- a/CMake/External_log4cplus.cmake
+++ b/CMake/External_log4cplus.cmake
@@ -22,7 +22,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # log4cplus
 ########################################
-set(log4cplus_ROOT   @log4cplus_ROOT@)
-set(log4cplus_DIR    @log4cplus_ROOT@/lib/cmake/log4cplus)
+set(log4cplus_ROOT   \$\{fletch_ROOT\})
+set(log4cplus_DIR    \$\{fletch_ROOT\}/lib/cmake/log4cplus)
 set(fletch_ENABLED_log4cplus TRUE)
 ")

--- a/CMake/External_shapelib.cmake
+++ b/CMake/External_shapelib.cmake
@@ -28,7 +28,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # shapelib
 ########################################
-set(SHAPELIB_ROOT    @SHAPELIB_ROOT@)
+set(SHAPELIB_ROOT    \$\{fletch_ROOT\})
 set(SHAPELIB_LIBNAME @SHAPELIB_LIBNAME@)
 
 set(fletch_ENABLED_shapelib TRUE)

--- a/CMake/fletch-install.cmake
+++ b/CMake/fletch-install.cmake
@@ -26,3 +26,10 @@ install(
   RENAME
   fletchConfig.cmake
   )
+
+install(
+  FILES
+  ${fletch_BUILD_DIR}/fletchConfig-version.cmake
+  DESTINATION
+  ${CMAKE_INSTALL_PREFIX}/lib/cmake/fletch/
+  )

--- a/CMake/fletch-install.cmake
+++ b/CMake/fletch-install.cmake
@@ -4,5 +4,25 @@
 
 install(DIRECTORY ${fletch_BUILD_INSTALL_PREFIX}/ DESTINATION ${CMAKE_INSTALL_PREFIX})
 
+
+set(fletch_INSTALL_BUILD_DIR ${CMAKE_INSTALL_PREFIX})
+set(fletch_CONFIG_OUTPUT ${CMAKE_INSTALL_PREFIX}/lib/cmake/fletch/fletchConfig.cmake )
 # Also install the Config file so it can be found.
-install(FILES ${fletch_CONFIG_OUTPUT} DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+
+# We need to configure the 'install' version of the config into an 'export' directory, then install it.
+# The export directory was chosen because it make sense semantically as is not likely to confuse users.
+#
+configure_file(
+  ${fletch_CONFIG_INPUT} ${fletch_BUILD_PREFIX}/config/export/fletchConfig_install.cmake
+  @ONLY
+  )
+
+install(
+  FILES
+  ${fletch_BUILD_PREFIX}/config/export/fletchConfig_install.cmake
+  DESTINATION
+  ${CMAKE_INSTALL_PREFIX}/lib/cmake/fletch/
+  RENAME
+  fletchConfig.cmake
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,10 +108,13 @@ set(fletch_BUILD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build)
 #  DESTINATION ${fletch_BUILD_INSTALL_SHARE_CMAKE_PREFIX} )
 
 
+# We are using fletch_INSTALL_BUILD_DIR to define where Fletch_ROOT is at configure time
+# If installed, it is set to CMAKE_PREFIX before configure, otherwise, set to fletch_ROOT
+set(fletch_INSTALL_BUILD_DIR ${fletch_BUILD_INSTALL_PREFIX})
 file(WRITE ${fletch_CONFIG_INPUT} "
 # Configuration file for the fletch build
 set(fletch_VERSION ${fletch_VERSION})
-set(fletch_ROOT ${fletch_BUILD_INSTALL_PREFIX})
+set(fletch_ROOT @fletch_INSTALL_BUILD_DIR@)
 set(fletch_WITH_PYTHON ${fletch_BUILD_WITH_PYTHON})
 ")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(fletch_BUILD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build)
 file(WRITE ${fletch_CONFIG_INPUT} "
 # Configuration file for the fletch build
 set(fletch_VERSION ${fletch_VERSION})
+set(fletch_ROOT ${fletch_BUILD_INSTALL_PREFIX})
 set(fletch_WITH_PYTHON ${fletch_BUILD_WITH_PYTHON})
 ")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ option(fletch_ENABLE_ALL_PACKAGES "Enable all available packages" FALSE)
 # allow the configuring package to set the install prefix.
 if (NOT fletch_BUILD_INSTALL_PREFIX)
   set(fletch_BUILD_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install)
+  # If building fletch from inside, change config out directory to the build directory
+  set(fletch_CONFIG_OUTPUT ${fletch_BINARY_DIR}/fletchConfig.cmake )
+else()
+  set(fletch_CONFIG_OUTPUT ${fletch_BUILD_INSTALL_PREFIX}/fletchConfig.cmake )
 endif()
 
 #
@@ -97,7 +101,6 @@ configure_file(
 #-
 
 set(fletch_CONFIG_INPUT ${fletch_BINARY_DIR}/fletchConfig.cmake.in )
-set(fletch_CONFIG_OUTPUT ${fletch_BINARY_DIR}/fletchConfig.cmake )
 set(fletch_BUILD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,10 @@ endif()
 #
 # Create a CMake Version file
 #
+set(fletch_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(
   ${fletch_SOURCE_DIR}/fletchConfig-version.cmake.in
-  ${fletch_BUILD_INSTALL_PREFIX}/fletchConfig-version.cmake
+  ${fletch_BUILD_DIR}/fletchConfig-version.cmake
   @ONLY IMMEDIATE)
 
 #+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ configure_file(
 #-
 
 set(fletch_CONFIG_INPUT ${fletch_BINARY_DIR}/fletchConfig.cmake.in )
-set(fletch_CONFIG_OUTPUT ${fletch_BUILD_INSTALL_PREFIX}/fletchConfig.cmake )
+set(fletch_CONFIG_OUTPUT ${fletch_BINARY_DIR}/fletchConfig.cmake )
 set(fletch_BUILD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build)
 
 


### PR DESCRIPTION
The PR accomplishes the following to provide a general level of consistency with fletch and other CMake packages:

1 - Keep the build directory version of fletchConfig.cmake in the build directory, not the install directory. 
2 - Provide an install version of the fletchConfig.cmake file.

