### PR TITLE
Upgrade Ceres Solver

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -177,9 +177,9 @@ set(SuiteSparse_md5 "a2926c27f8a5285e4a10265cc68bbc18")
 list(APPEND fletch_external_sources SuiteSparse)
 
 # Ceres Solver
-set(Ceres_version 1.10.0)
+set(Ceres_version 1.13.0)
 set(Ceres_url "http://ceres-solver.org/ceres-solver-${Ceres_version}.tar.gz")
-set(Ceres_md5 "dbf9f452bd46e052925b835efea9ab16")
+set(Ceres_md5 "cd568707571c92af3d69c1eb28d63d72")
 set(Ceres_dlname "ceres-${Ceres_version}.tar.gz")
 list(APPEND fletch_external_sources Ceres)
 

--- a/Doc/release-notes/1.1.0.txt
+++ b/Doc/release-notes/1.1.0.txt
@@ -13,5 +13,7 @@ Package Upgrades
  * Updated Caffe to pull from a Kitware clone of the project and applied
    various patches to allow it to build on Windows.
 
+ * Updated Ceres Solver from v1.10.0 to v1.13.0
+
 Fixes since v1.0.0
 ------------------


### PR DESCRIPTION
Upgrading the version of Ceres Solver seem to build fine in Fletch, but it still needs more testing in KWIVER before we merge.