### PR TITLE
Add FindNumpy script for Caffe

### DIFF
--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -215,7 +215,15 @@ if(fletch_BUILD_WITH_PYTHON AND fletch_ENABLE_Boost)
   if(Boost_Do_BCP_Name_Mangling)
     message(FATAL_ERROR "Cannot have Boost mangling enabled and use pycaffe.")
   endif()
-  set(PYTHON_ARGS -DBUILD_python:BOOL=ON -DBUILD_python_layer:BOOL=ON)
+  set(PYTHON_ARGS 
+      -DBUILD_python:BOOL=ON 
+      -DBUILD_python_layer:BOOL=ON
+      -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+      -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
+      -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR}
+      -DNUMPY_INCLUDE_DIR=${NUMPY_INCLUDE_DIR}
+      -DNUMPY_VERSION=${NUMPY_VERSION}
+      )
 else()
   set(PYTHON_ARGS -DBUILD_python:BOOL=OFF -DBUILD_python_layer:BOOL=OFF)
 endif()

--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -215,8 +215,9 @@ if(fletch_BUILD_WITH_PYTHON AND fletch_ENABLE_Boost)
   if(Boost_Do_BCP_Name_Mangling)
     message(FATAL_ERROR "Cannot have Boost mangling enabled and use pycaffe.")
   endif()
-  set(PYTHON_ARGS 
-      -DBUILD_python:BOOL=ON 
+  find_package(NumPy 1.7 REQUIRED)
+  set(PYTHON_ARGS
+      -DBUILD_python:BOOL=ON
       -DBUILD_python_layer:BOOL=ON
       -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
       -DPYTHON_LIBRARY=${PYTHON_LIBRARY}

--- a/CMake/FindNumPy.cmake
+++ b/CMake/FindNumPy.cmake
@@ -1,0 +1,57 @@
+# - Find the NumPy libraries
+# This module finds if NumPy is installed, and sets the following variables
+# indicating where it is.
+#
+# TODO: Update to provide the libraries and paths for linking npymath lib.
+#
+#  NUMPY_FOUND               - was NumPy found
+#  NUMPY_VERSION             - the version of NumPy found as a string
+#  NUMPY_VERSION_MAJOR       - the major version number of NumPy
+#  NUMPY_VERSION_MINOR       - the minor version number of NumPy
+#  NUMPY_VERSION_PATCH       - the patch version number of NumPy
+#  NUMPY_VERSION_DECIMAL     - e.g. version 1.6.1 is 10601
+#  NUMPY_INCLUDE_DIR         - path to the NumPy include files
+
+unset(NUMPY_VERSION)
+unset(NUMPY_INCLUDE_DIR)
+
+if(PYTHONINTERP_FOUND)
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    "import numpy as n; print(n.__version__); print(n.get_include());"
+    RESULT_VARIABLE __result
+    OUTPUT_VARIABLE __output
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(__result MATCHES 0)
+    string(REGEX REPLACE ";" "\\\\;" __values ${__output})
+    string(REGEX REPLACE "\r?\n" ";"    __values ${__values})
+    list(GET __values 0 NUMPY_VERSION)
+    list(GET __values 1 NUMPY_INCLUDE_DIR)
+
+    string(REGEX MATCH "^([0-9])+\\.([0-9])+\\.([0-9])+" __ver_check "${NUMPY_VERSION}")
+    if(NOT "${__ver_check}" STREQUAL "")
+      set(NUMPY_VERSION_MAJOR ${CMAKE_MATCH_1})
+      set(NUMPY_VERSION_MINOR ${CMAKE_MATCH_2})
+      set(NUMPY_VERSION_PATCH ${CMAKE_MATCH_3})
+      math(EXPR NUMPY_VERSION_DECIMAL
+        "(${NUMPY_VERSION_MAJOR} * 10000) + (${NUMPY_VERSION_MINOR} * 100) + ${NUMPY_VERSION_PATCH}")
+      string(REGEX REPLACE "\\\\" "/"  NUMPY_INCLUDE_DIR ${NUMPY_INCLUDE_DIR})
+    else()
+     unset(NUMPY_VERSION)
+     unset(NUMPY_INCLUDE_DIR)
+     message(STATUS "Requested NumPy version and include path, but got instead:\n${__output}\n")
+    endif()
+  endif()
+else()
+  message(STATUS "To find NumPy Python interpretator is required to be found.")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NumPy REQUIRED_VARS NUMPY_INCLUDE_DIR NUMPY_VERSION
+                                        VERSION_VAR   NUMPY_VERSION)
+
+if(NUMPY_FOUND)
+  message(STATUS "NumPy ver. ${NUMPY_VERSION} found (include: ${NUMPY_INCLUDE_DIR})")
+endif()
+
+# taken from https://github.com/BVLC/caffe/blob/master/cmake/Modules/FindNumPy.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,11 @@ endif()
 #
 option(fletch_BUILD_WITH_PYTHON "Build with Python support where appropriate" FALSE)
 if (fletch_BUILD_WITH_PYTHON)
+
   find_package(PythonInterp 2.7 REQUIRED)
   find_package(PythonLibs 2.7 REQUIRED)
+  find_package(NumPy 1.7)
+
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ if (fletch_BUILD_WITH_PYTHON)
 
   find_package(PythonInterp 2.7 REQUIRED)
   find_package(PythonLibs 2.7 REQUIRED)
-  find_package(NumPy 1.7)
 
 endif()
 

--- a/Doc/release-notes/1.1.0.txt
+++ b/Doc/release-notes/1.1.0.txt
@@ -18,3 +18,4 @@ Fixes since v1.0.0
 
  * Added Visual Studio support for Caffe.
  * Clean up CUDA, CUDNN supoort.
+ * Added numpy requirment when building with Caffe and python


### PR DESCRIPTION
When trying to build Caffe with fletch, it crashed on an error saying that it could not find numpy. I added an explicit find_package for NumPy and passed the python variables down to Caffe. This seems to fix the issue.

Side note: The FindNumpy script that I added is the same one used in Caffe. I find it odd that Caffe wasn't able to find it by itself considering its using the same script. My current guess it that it might have to do with the fact that I installed numpy to my python2 virtual environment.

(This is an updated version of PR #168 with correct branch naming conventions) 