### PR TITLE
Fix qt gcc 6

### DIFF
--- a/CMake/External_HDF5.cmake
+++ b/CMake/External_HDF5.cmake
@@ -19,6 +19,10 @@ ExternalProject_Add(HDF5
   PREFIX ${fletch_BUILD_PREFIX}
   DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
   INSTALL_DIR ${fletch_BUILD_INSTALL_PREFIX}
+  PATCH_COMMAND ${CMAKE_COMMAND}
+    -DHDF5_patch:PATH=${fletch_SOURCE_DIR}/Patches/HDF5
+    -DHDF5_source:PATH=${fletch_BUILD_PREFIX}/src/HDF5
+    -P ${fletch_SOURCE_DIR}/Patches/HDF5/Patch.cmake
 
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS

--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -3,9 +3,9 @@
 option(BUILD_Qt_MINIMAL "Build a reduced set of Qt packages. Removes webkit, javascipt and script" TRUE)
 
 if(BUILD_Qt_MINIMAL)
-  set(Qt_args_package -no-webkit -no-javascript-jit -no-script -no-scripttools)
+  set(Qt_args_package -no-webkit)
 else()
-  set(Qt_args_package -webkit -javascript-jit -script -scripttools)
+  set(Qt_args_package -webkit)
 endif()
 
 if(CMAKE_BUILD_TYPE)
@@ -108,6 +108,12 @@ if(WIN32)
     list(APPEND Qt_args_arch -platform win32-msvc2017 -make nmake)
   endif()
 else()
+
+  if(BUILD_Qt_MINIMAL)
+    list(APPEND Qt_args_package -no-javascript-jit -no-script -no-scripttools)
+  else()
+    set(Qt_args_package -javascript-jit -script -scripttools)
+  endif()
   # If we are using gcc >= 6.0 we need to turn off -no-script -no-scripttools
   # until the build is fixed.
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)

--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -145,7 +145,15 @@ else()
   endif()
 endif()
 
-set(Qt_configure ${Qt_configure}
+# If we are using gcc >= 6.0 we need to turn off -no-script -no-scripttools
+# until the build is fixed.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+  message("disabling script for GNU 6.0")
+  list( APPEND Qt_configure
+    -no-script
+    )
+endif()
+list( APPEND Qt_configure
   -prefix ${fletch_BUILD_INSTALL_PREFIX}
   -docdir ${fletch_BUILD_INSTALL_PREFIX}/share/doc/qt4-${Qt_version}
   -datadir ${fletch_BUILD_INSTALL_PREFIX}/lib/qt4

--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -148,7 +148,7 @@ endif()
 # If we are using gcc >= 6.0 we need to turn off -no-script -no-scripttools
 # until the build is fixed.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
-  message("disabling script for GNU 6.0")
+  message(STATUS "disabling script for GNU 6.0")
   list( APPEND Qt_configure
     -no-script
     )

--- a/Patches/HDF5/CMakeTests.cmake
+++ b/Patches/HDF5/CMakeTests.cmake
@@ -1,0 +1,192 @@
+#
+# Copyright by The HDF Group.
+# All rights reserved.
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
+
+##############################################################################
+##############################################################################
+###           T E S T I N G                                                ###
+##############################################################################
+##############################################################################
+
+set (H5WATCH_TEST_FILES
+    w-help1.ddl
+    w-err-cmpd1.ddl
+    w-err-cmpd2.ddl
+    w-err-cmpd3.ddl
+    w-err-cmpd4.ddl
+    w-err-cmpd5.ddl
+    w-err-dset1.ddl
+    w-err-dset2.ddl
+    w-err-dset-nomax.ddl
+    w-err-dset-none.ddl
+    w-err-file.ddl
+    w-err-poll.ddl
+    w-err-poll0.ddl
+    w-err-width.ddl
+    w-ext-cmpd.ddl
+    w-ext-cmpd-esc.ddl
+    w-ext-cmpd-esc-f1.ddl
+    w-ext-cmpd-esc-f3.ddl
+    w-ext-cmpd-esc-ff2.ddl
+    w-ext-cmpd-f1.ddl
+    w-ext-cmpd-f2.ddl
+    w-ext-cmpd-ff3.ddl
+    w-ext-cmpd-label.ddl
+    w-ext-cmpd-two.ddl
+    w-ext-cmpd-two-f1.ddl
+    w-ext-cmpd-two-f3.ddl
+    w-ext-cmpd-two-ff2.ddl
+    w-ext-early.ddl
+    w-ext-late.ddl
+    w-ext-one.ddl
+    w-ext-one-d.ddl
+    w-ext-one-simple.ddl
+    w-ext-two.ddl
+    w-ext-two-d.ddl
+    w-ext-two-width.ddl
+)
+
+# make test dir
+file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles")
+add_custom_target(h5watch-files ALL COMMENT "Copying files needed by h5watch tests")
+
+foreach (h5watch_file ${H5WATCH_TEST_FILES})
+  HDFTEST_COPY_FILE(
+    "${HDF5_HL_TOOLS_DIR}/testfiles/${h5watch_file}"
+    "${PROJECT_BINARY_DIR}/testfiles/${h5watch_file}"
+    "h5watch-files_files"
+    )
+endforeach ()
+
+add_custom_target(
+  h5watch-files_files
+  ALL
+  COMMENT "Copying files needed by h5watch-files tests"
+  DEPENDS ${h5watch-files_files_list}
+  )
+
+##############################################################################
+##############################################################################
+###           T H E   T E S T S  M A C R O S                               ###
+##############################################################################
+##############################################################################
+
+  macro (ADD_H5_TEST resultfile resultcode)
+    if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+      add_test (
+          NAME H5WATCH_ARGS-h5watch-${resultfile}
+          COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_PROGRAM=$<TARGET_FILE:h5watch>"
+              -D "TEST_ARGS:STRING=${ARGN}"
+              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
+              -D "TEST_OUTPUT=${resultfile}.out"
+              -D "TEST_EXPECT=${resultcode}"
+              -D "TEST_REFERENCE=${resultfile}.ddl"
+              -P "${HDF_RESOURCES_EXT_DIR}/runTest.cmake"
+      )
+      set_tests_properties (H5WATCH_ARGS-h5watch-${resultfile} PROPERTIES DEPENDS ${last_test})
+      set (last_test "H5WATCH_ARGS-h5watch-${resultfile}")
+    endif ()
+  endmacro ()
+
+  macro (ADD_H5_WATCH resultfile resultcode)
+    if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+      add_test (
+          NAME H5WATCH-${resultfile}-clear-objects
+          COMMAND    ${CMAKE_COMMAND}
+              -E remove
+                  ${resultfile}.h5
+      )
+      set_tests_properties (H5WATCH-${resultfile}-clear-objects PROPERTIES WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles")
+      add_test (
+          NAME H5WATCH-${resultfile}
+          COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_PROGRAM=$<TARGET_FILE:h5watch>"
+              -D "TEST_ARGS:STRING=${ARGN}"
+              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
+              -D "TEST_OUTPUT=${resultfile}.out"
+              -D "TEST_EXPECT=${resultcode}"
+              -D "TEST_REFERENCE=${resultfile}.txt"
+              -P "${HDF_RESOURCES_EXT_DIR}/runTest.cmake"
+      )
+      set_tests_properties (H5WATCH-${resultfile} PROPERTIES DEPENDS H5WATCH-${resultfile}-clear-objects)
+    endif ()
+  endmacro ()
+
+##############################################################################
+##############################################################################
+###           T H E   T E S T S                                            ###
+##############################################################################
+##############################################################################
+
+# Check to see if the VFD specified by the HDF5_DRIVER environment variable
+# supports SWMR.
+set (SWMR_INCOMPAT ${hl_swmr_check_compat_vfd})
+
+if (NOT SWMR_INCOMPAT)
+# Remove any output file left over from previous test run
+  add_test (
+    NAME H5WATCH-clearall-objects
+    COMMAND    ${CMAKE_COMMAND}
+        -E remove
+        WATCH.h5
+  )
+  if (NOT "${last_test}" STREQUAL "")
+    set_tests_properties (H5WATCH-clearall-objects PROPERTIES DEPENDS ${last_test})
+  endif ()
+  set (last_test "H5WATCH-clearall-objects")
+
+#################################################################################################
+#                                               #
+# WATCH.h5: file with various types of datasets for testing--                   #
+#   The following datasets are chunked, H5D_ALLOC_TIME_INCR, max. dimensional setting:      #
+#       DSET_ONE: one-dimensional dataset                           #
+#       DSET_TWO: two-dimensional dataset                           #
+#       DSET_CMPD: one-dimensional dataset with compound type                   #
+#       DSET_CMPD_ESC: one-dimensional dataset with compound type & escape/separator characters #
+#       DSET_CMPD_TWO: two-dimensional dataset with compound type               #
+#                                               #
+#   The following datasets are one-dimensional, chunked, max. dimension setting:        #
+#       DSET_ALLOC_EARLY: dataset with H5D_ALLOC_TIME_EARLY                 #
+#       DSET_ALLOC_LATE: dataset H5D_ALLOC_TIME_LATE                        #
+#                                               #
+#   The following datasets are one-dimensional:                         #
+#   DSET_NONE: fixed dimension setting, contiguous, H5D_ALLOC_TIME_LATE         #
+#   DSET_NOMAX: fixed dimension setting, chunked, H5D_ALLOC_TIME_INCR           #
+#                                               #
+#################################################################################################
+# create the output files to be used.
+  add_test (NAME H5WATCH-h5watchgentest COMMAND $<TARGET_FILE:h5watchgentest>)
+  set_tests_properties (H5WATCH-h5watchgentest PROPERTIES WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles")
+  set_tests_properties (H5WATCH-h5watchgentest PROPERTIES DEPENDS "H5WATCH-clearall-objects")
+  set (last_test "H5WATCH-h5watchgentest")
+
+# Test on --help options
+  ADD_H5_TEST (w-help1 0 --help)
+#
+# Tests on expected failures
+  ADD_H5_TEST (w-err-dset1 1 WATCH.h5)
+  ADD_H5_TEST (w-err-dset2 1 WATCH.h5/group/DSET_CMPD)
+  ADD_H5_TEST (w-err-dset-none 1 WATCH.h5/DSET_NONE)
+  ADD_H5_TEST (w-err-dset-nomax 1 WATCH.h5/DSET_NOMAX)
+  ADD_H5_TEST (w-err-file 1 ../WATCH.h5/DSET_CMPD)
+  ADD_H5_TEST (w-err-width 1 --width=-8 WATCH.h5/DSET_ONE)
+  ADD_H5_TEST (w-err-poll 1 --polling=-8 WATCH.h5/DSET_ONE)
+  ADD_H5_TEST (w-err-poll0 1 --polling=0 WATCH.h5/DSET_ONE)
+#
+# Tests on invalid field names via --fields option for a compound typed dataset: DSET_CMPD
+  ADD_H5_TEST (w-err-cmpd1 1 --fields=fieldx WATCH.h5/DSET_CMPD)
+  ADD_H5_TEST (w-err-cmpd2 1 --fields=field1,field2. WATCH.h5/DSET_CMPD)
+  ADD_H5_TEST (w-err-cmpd3 1 --fields=field1,field2, WATCH.h5/DSET_CMPD)
+  ADD_H5_TEST (w-err-cmpd4 1 --fields=field1,field2.b.k WATCH.h5/DSET_CMPD)
+  ADD_H5_TEST (w-err-cmpd5 1 --fields=field1 --fields=field2.b.k WATCH.h5/DSET_CMPD)
+#
+endif ()

--- a/Patches/HDF5/Patch.cmake
+++ b/Patches/HDF5/Patch.cmake
@@ -1,0 +1,14 @@
+#+
+# This file is called as CMake -P script for the patch step of
+# External_HDF5.cmake HDF5_patch and HDF5_source are defined on the command
+# line along with the call.
+#-
+#This patch, is copied from https://github.com/live-clones/hdf5/compare/develop...billhoffman:fix-h5watch-postbuild
+#It fixes an issue with an excessively long install command. The patch will hopefully be part of the next HDF5 release.
+
+message("Patching HDF5 ${HDF5_patch} AND ${HDF5_source}")
+configure_file(
+  ${HDF5_patch}/CMakeTests.cmake
+  ${HDF5_source}/hl/tools/h5watch/
+  COPYONLY
+)

--- a/Patches/Qt/Patch.cmake
+++ b/Patches/Qt/Patch.cmake
@@ -8,7 +8,17 @@ message("Patching Qt in ${Qt_source}")
 # Add a special gcc44 mkspec for RHEL5
 file(COPY ${Qt_patch}/linux-g++44
   DESTINATION ${Qt_source}/mkspecs
-)
+  )
+
+# Patch the following 2 files to fix gcc 6 build issues.
+file(COPY ${Qt_patch}/itemviews.cpp
+  DESTINATION ${Qt_source}/src/plugins/accessible/widgets/
+  )
+
+file(COPY ${Qt_patch}/previewmanager.cpp
+  DESTINATION ${Qt_source}/tools/designer/src/lib/shared/
+  )
+
 
 # Currently disabled as it seems to generate illegal opcodes with gcc44 on
 # SandyBridge CPUs and RHEL5

--- a/Patches/Qt/itemviews.cpp
+++ b/Patches/Qt/itemviews.cpp
@@ -1,0 +1,1100 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "itemviews.h"
+
+#include <qheaderview.h>
+#include <qtableview.h>
+#include <qlistview.h>
+#include <qtreeview.h>
+#include <private/qtreewidget_p.h>
+#include <qaccessible2.h>
+#include <QDebug>
+
+#ifndef QT_NO_ACCESSIBILITY
+
+QT_BEGIN_NAMESPACE
+
+QString Q_GUI_EXPORT qt_accStripAmp(const QString &text);
+
+#ifndef QT_NO_ITEMVIEWS
+/*
+Implementation of the IAccessible2 table2 interface. Much simpler than
+the other table interfaces since there is only the main table and cells:
+
+TABLE/LIST/TREE
+  |- HEADER CELL
+  |- CELL
+  |- CELL
+  ...
+*/
+
+QAbstractItemView *QAccessibleTable2::view() const
+{
+    return qobject_cast<QAbstractItemView*>(object());
+}
+
+int QAccessibleTable2::logicalIndex(const QModelIndex &index) const
+{
+    if (!view()->model() || !index.isValid())
+        return -1;
+    int vHeader = verticalHeader() ? 1 : 0;
+    int hHeader = horizontalHeader() ? 1 : 0;
+    // row * number columns + column + 1 for one based counting
+    return (index.row() + hHeader)*(index.model()->columnCount() + vHeader) + (index.column() + vHeader) + 1;
+}
+
+QAccessibleInterface *QAccessibleTable2::childFromLogical(int logicalIndex) const
+{
+    if (!view()->model())
+        return 0;
+
+    logicalIndex--; // one based counting ftw
+    int vHeader = verticalHeader() ? 1 : 0;
+    int hHeader = horizontalHeader() ? 1 : 0;
+
+    int columns = view()->model()->columnCount() + vHeader;
+
+    int row = logicalIndex / columns;
+    int column = logicalIndex % columns;
+
+    if (vHeader) {
+        if (column == 0) {
+            if (row == 0) {
+                return new QAccessibleTable2CornerButton(view());
+            }
+            return new QAccessibleTable2HeaderCell(view(), row-1, Qt::Vertical);
+        }
+        --column;
+    }
+    if (hHeader) {
+        if (row == 0) {
+            return new QAccessibleTable2HeaderCell(view(), column, Qt::Horizontal);
+        }
+        --row;
+    }
+
+    QModelIndex index = view()->model()->index(row, column, view()->rootIndex());
+    if (!index.isValid()) {
+        qWarning() << "QAccessibleTable2::childFromLogical: Invalid index at: " << row << column;
+        return 0;
+    }
+    return new QAccessibleTable2Cell(view(), index, cellRole());
+}
+
+QAccessibleTable2::QAccessibleTable2(QWidget *w)
+    : QAccessibleObjectEx(w)
+{
+    Q_ASSERT(view());
+
+    if (qobject_cast<const QTableView*>(view())) {
+        m_role = QAccessible::Table;
+    } else if (qobject_cast<const QTreeView*>(view())) {
+        m_role = QAccessible::Tree;
+    } else if (qobject_cast<const QListView*>(view())) {
+        m_role = QAccessible::List;
+    } else {
+        // is this our best guess?
+        m_role = QAccessible::Table;
+    }
+}
+
+QAccessibleTable2::~QAccessibleTable2()
+{
+}
+
+QHeaderView *QAccessibleTable2::horizontalHeader() const
+{
+    QHeaderView *header = 0;
+    if (false) {
+#ifndef QT_NO_TABLEVIEW
+    } else if (const QTableView *tv = qobject_cast<const QTableView*>(view())) {
+        header = tv->horizontalHeader();
+#endif
+#ifndef QT_NO_TREEVIEW
+    } else if (const QTreeView *tv = qobject_cast<const QTreeView*>(view())) {
+        header = tv->header();
+#endif
+    }
+    return header;
+}
+
+QHeaderView *QAccessibleTable2::verticalHeader() const
+{
+    QHeaderView *header = 0;
+    if (false) {
+#ifndef QT_NO_TABLEVIEW
+    } else if (const QTableView *tv = qobject_cast<const QTableView*>(view())) {
+        header = tv->verticalHeader();
+#endif
+    }
+    return header;
+}
+
+void QAccessibleTable2::modelReset()
+{}
+
+void QAccessibleTable2::rowsInserted(const QModelIndex &, int first, int last)
+{
+    lastChange.firstRow = first;
+    lastChange.lastRow = last;
+    lastChange.firstColumn = 0;
+    lastChange.lastColumn = 0;
+    lastChange.type = QAccessible2::TableModelChangeInsert;
+}
+
+void QAccessibleTable2::rowsRemoved(const QModelIndex &, int first, int last)
+{
+    lastChange.firstRow = first;
+    lastChange.lastRow = last;
+    lastChange.firstColumn = 0;
+    lastChange.lastColumn = 0;
+    lastChange.type = QAccessible2::TableModelChangeDelete;
+}
+
+void QAccessibleTable2::columnsInserted(const QModelIndex &, int first, int last)
+{
+    lastChange.firstRow = 0;
+    lastChange.lastRow = 0;
+    lastChange.firstColumn = first;
+    lastChange.lastColumn = last;
+    lastChange.type = QAccessible2::TableModelChangeInsert;
+}
+
+void QAccessibleTable2::columnsRemoved(const QModelIndex &, int first, int last)
+{
+    lastChange.firstRow = 0;
+    lastChange.lastRow = 0;
+    lastChange.firstColumn = first;
+    lastChange.lastColumn = last;
+    lastChange.type = QAccessible2::TableModelChangeDelete;
+}
+
+void QAccessibleTable2::rowsMoved( const QModelIndex &, int, int, const QModelIndex &, int)
+{
+    lastChange.firstRow = 0;
+    lastChange.lastRow = 0;
+    lastChange.firstColumn = 0;
+    lastChange.lastColumn = 0;
+    lastChange.type = QAccessible2::TableModelChangeUpdate;
+}
+
+void QAccessibleTable2::columnsMoved( const QModelIndex &, int, int, const QModelIndex &, int)
+{
+    lastChange.firstRow = 0;
+    lastChange.lastRow = 0;
+    lastChange.firstColumn = 0;
+    lastChange.lastColumn = 0;
+    lastChange.type = QAccessible2::TableModelChangeUpdate;
+}
+
+QAccessibleTable2Cell *QAccessibleTable2::cell(const QModelIndex &index) const
+{
+    if (index.isValid())
+        return new QAccessibleTable2Cell(view(), index, cellRole());
+    return 0;
+}
+
+QAccessibleTable2CellInterface *QAccessibleTable2::cellAt(int row, int column) const
+{
+    if (!view()->model())
+        return 0;
+    Q_ASSERT(role(0) != QAccessible::Tree);
+    QModelIndex index = view()->model()->index(row, column, view()->rootIndex());
+    //Q_ASSERT(index.isValid());
+    if (!index.isValid()) {
+        qWarning() << "QAccessibleTable2::cellAt: invalid index: " << index << " for " << view();
+        return 0;
+    }
+    return cell(index);
+}
+
+QAccessibleInterface *QAccessibleTable2::caption() const
+{
+    return 0;
+}
+
+QString QAccessibleTable2::columnDescription(int column) const
+{
+    if (!view()->model())
+        return QString();
+    return view()->model()->headerData(column, Qt::Horizontal).toString();
+}
+
+int QAccessibleTable2::columnCount() const
+{
+    if (!view()->model())
+        return 0;
+    return view()->model()->columnCount();
+}
+
+int QAccessibleTable2::rowCount() const
+{
+    if (!view()->model())
+        return 0;
+    return view()->model()->rowCount();
+}
+
+int QAccessibleTable2::selectedCellCount() const
+{
+    if (!view()->selectionModel())
+        return 0;
+    return view()->selectionModel()->selectedIndexes().count();
+}
+
+int QAccessibleTable2::selectedColumnCount() const
+{
+    if (!view()->selectionModel())
+        return 0;
+    return view()->selectionModel()->selectedColumns().count();
+}
+
+int QAccessibleTable2::selectedRowCount() const
+{
+    if (!view()->selectionModel())
+        return 0;
+    return view()->selectionModel()->selectedRows().count();
+}
+
+QString QAccessibleTable2::rowDescription(int row) const
+{
+    if (!view()->model())
+        return QString();
+    return view()->model()->headerData(row, Qt::Vertical).toString();
+}
+
+QList<QAccessibleTable2CellInterface*> QAccessibleTable2::selectedCells() const
+{
+    QList<QAccessibleTable2CellInterface*> cells;
+    if (!view()->selectionModel())
+        return cells;
+    Q_FOREACH (const QModelIndex &index, view()->selectionModel()->selectedIndexes()) {
+        cells.append(cell(index));
+    }
+    return cells;
+}
+
+QList<int> QAccessibleTable2::selectedColumns() const
+{
+    QList<int> columns;
+    if (!view()->selectionModel())
+        return columns;
+    Q_FOREACH (const QModelIndex &index, view()->selectionModel()->selectedColumns()) {
+        columns.append(index.column());
+    }
+    return columns;
+}
+
+QList<int> QAccessibleTable2::selectedRows() const
+{
+    if (!view()->selectionModel())
+        return QList<int>();
+    QList<int> rows;
+    Q_FOREACH (const QModelIndex &index, view()->selectionModel()->selectedRows()) {
+        rows.append(index.row());
+    }
+    return rows;
+}
+
+QAccessibleInterface *QAccessibleTable2::summary() const
+{
+    return 0;
+}
+
+bool QAccessibleTable2::isColumnSelected(int column) const
+{
+    if (!view()->selectionModel())
+        return false;
+    return view()->selectionModel()->isColumnSelected(column, QModelIndex());
+}
+
+bool QAccessibleTable2::isRowSelected(int row) const
+{
+    if (!view()->selectionModel())
+        return false;
+    return view()->selectionModel()->isRowSelected(row, QModelIndex());
+}
+
+bool QAccessibleTable2::selectRow(int row)
+{
+    if (!view()->model() || !view()->selectionModel())
+        return false;
+    QModelIndex index = view()->model()->index(row, 0, view()->rootIndex());
+    if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
+        return false;
+    view()->selectionModel()->select(index, QItemSelectionModel::Select);
+    return true;
+}
+
+bool QAccessibleTable2::selectColumn(int column)
+{
+    if (!view()->model() || !view()->selectionModel())
+        return false;
+    QModelIndex index = view()->model()->index(0, column, view()->rootIndex());
+    if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
+        return false;
+    view()->selectionModel()->select(index, QItemSelectionModel::Select);
+    return true;
+}
+
+bool QAccessibleTable2::unselectRow(int row)
+{
+    if (!view()->model() || !view()->selectionModel())
+        return false;
+    QModelIndex index = view()->model()->index(row, 0, view()->rootIndex());
+    if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
+        return false;
+    view()->selectionModel()->select(index, QItemSelectionModel::Deselect);
+    return true;
+}
+
+bool QAccessibleTable2::unselectColumn(int column)
+{
+    if (!view()->model() || !view()->selectionModel())
+        return false;
+    QModelIndex index = view()->model()->index(0, column, view()->rootIndex());
+    if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
+        return false;
+    view()->selectionModel()->select(index, QItemSelectionModel::Columns & QItemSelectionModel::Deselect);
+    return true;
+}
+
+QAccessible2::TableModelChange QAccessibleTable2::modelChange() const
+{
+    QAccessible2::TableModelChange change;
+    // FIXME
+    return change;
+}
+
+QAccessible::Role QAccessibleTable2::role(int child) const
+{
+    Q_ASSERT(child >= 0);
+    if (child > 0)
+        return QAccessible::Cell;
+    return m_role;
+}
+
+QAccessible::State QAccessibleTable2::state(int child) const
+{
+    Q_ASSERT(child == 0);
+    return QAccessible::Normal | HasInvokeExtension;
+}
+
+int QAccessibleTable2::childAt(int x, int y) const
+{
+    QPoint viewportOffset = view()->viewport()->mapTo(view(), QPoint(0,0));
+    QPoint indexPosition = view()->mapFromGlobal(QPoint(x, y) - viewportOffset);
+    // FIXME: if indexPosition < 0 in one coordinate, return header
+
+    QModelIndex index = view()->indexAt(indexPosition);
+    if (index.isValid()) {
+        return logicalIndex(index);
+    }
+    return -1;
+}
+
+int QAccessibleTable2::childCount() const
+{
+    if (!view()->model())
+        return 0;
+    int vHeader = verticalHeader() ? 1 : 0;
+    int hHeader = horizontalHeader() ? 1 : 0;
+    return (view()->model()->rowCount()+hHeader) * (view()->model()->columnCount()+vHeader);
+}
+
+int QAccessibleTable2::indexOfChild(const QAccessibleInterface *iface) const
+{
+    if (!view()->model())
+        return -1;
+    Q_ASSERT(iface->role(0) != QAccessible::TreeItem); // should be handled by tree class
+    if (iface->role(0) == QAccessible::Cell || iface->role(0) == QAccessible::ListItem) {
+        const QAccessibleTable2Cell* cell = static_cast<const QAccessibleTable2Cell*>(iface);
+        return logicalIndex(cell->m_index);
+    } else if (iface->role(0) == QAccessible::ColumnHeader){
+        const QAccessibleTable2HeaderCell* cell = static_cast<const QAccessibleTable2HeaderCell*>(iface);
+        return cell->index + (verticalHeader() ? 1 : 0) + 1;
+    } else if (iface->role(0) == QAccessible::RowHeader){
+        const QAccessibleTable2HeaderCell* cell = static_cast<const QAccessibleTable2HeaderCell*>(iface);
+        return (cell->index+1) * (view()->model()->columnCount()+1)  + 1;
+    } else if (iface->role(0) == QAccessible::Pane) {
+        return 1; // corner button
+    } else {
+        qWarning() << "WARNING QAccessibleTable2::indexOfChild Fix my children..."
+                   << iface->role(0) << iface->text(QAccessible::Name, 0);
+    }
+    // FIXME: we are in denial of our children. this should stop.
+    return -1;
+}
+
+QString QAccessibleTable2::text(Text t, int child) const
+{
+    Q_ASSERT(child == 0);
+    if (t == QAccessible::Description)
+        return view()->accessibleDescription();
+    return view()->accessibleName();
+}
+
+QRect QAccessibleTable2::rect(int child) const
+{
+    Q_ASSERT(!child);
+    if (!view()->isVisible())
+        return QRect();
+    QPoint pos = view()->mapToGlobal(QPoint(0, 0));
+    return QRect(pos.x(), pos.y(), view()->width(), view()->height());
+}
+
+int QAccessibleTable2::navigate(RelationFlag relation, int index, QAccessibleInterface **iface) const
+{
+    *iface = 0;
+    if ((index < 0) || (!view()->model()))
+        return -1;
+
+    switch (relation) {
+    case Ancestor: {
+        if (index == 1 && view()->parent()) {
+            *iface = QAccessible::queryAccessibleInterface(view()->parent());
+            if (*iface)
+                return 0;
+        }
+        break;
+    }
+    case QAccessible::Child: {
+        Q_ASSERT(index > 0);
+        *iface = childFromLogical(index);
+        if (*iface) {
+            return 0;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return -1;
+}
+
+QAccessible::Relation QAccessibleTable2::relationTo(int, const QAccessibleInterface *, int) const
+{
+    return QAccessible::Unrelated;
+}
+
+#ifndef QT_NO_ACTION
+int QAccessibleTable2::userActionCount(int) const
+{
+    return 0;
+}
+QString QAccessibleTable2::actionText(int, Text, int) const
+{
+    return QString();
+}
+bool QAccessibleTable2::doAction(int, int, const QVariantList &)
+{
+    return false;
+}
+#endif
+
+
+// TREE VIEW
+
+QModelIndex QAccessibleTree::indexFromLogical(int row, int column) const
+{
+    if (!isValid() || !view()->model())
+        return QModelIndex();
+
+    const QTreeView *treeView = qobject_cast<const QTreeView*>(view());
+    if (treeView->d_func()->viewItems.count() <= row) {
+        qWarning() << "QAccessibleTree::indexFromLogical: invalid index: " << row << column << " for " << treeView;
+        return QModelIndex();
+    }
+    QModelIndex modelIndex = treeView->d_func()->viewItems.at(row).index;
+
+    if (modelIndex.isValid() && column > 0) {
+        modelIndex = view()->model()->index(modelIndex.row(), column, modelIndex.parent());
+    }
+    return modelIndex;
+}
+
+int QAccessibleTree::childAt(int x, int y) const
+{
+    QPoint viewportOffset = view()->viewport()->mapTo(view(), QPoint(0,0));
+    QPoint indexPosition = view()->mapFromGlobal(QPoint(x, y) - viewportOffset);
+
+    QModelIndex index = view()->indexAt(indexPosition);
+    if (!index.isValid())
+        return -1;
+
+    const QTreeView *treeView = qobject_cast<const QTreeView*>(view());
+    int row = treeView->d_func()->viewIndex(index) + (horizontalHeader() ? 1 : 0);
+    int column = index.column();
+
+    int i = row * view()->model()->columnCount() + column + 1;
+    Q_ASSERT(i > view()->model()->columnCount());
+    return i;
+}
+
+int QAccessibleTree::childCount() const
+{
+    const QTreeView *treeView = qobject_cast<const QTreeView*>(view());
+    Q_ASSERT(treeView);
+    if (!view()->model())
+        return 0;
+
+    int hHeader = horizontalHeader() ? 1 : 0;
+    return (treeView->d_func()->viewItems.count() + hHeader)* view()->model()->columnCount();
+}
+
+int QAccessibleTree::rowCount() const
+{
+    const QTreeView *treeView = qobject_cast<const QTreeView*>(view());
+    Q_ASSERT(treeView);
+    return treeView->d_func()->viewItems.count();
+}
+
+int QAccessibleTree::indexOfChild(const QAccessibleInterface *iface) const
+{
+    if (!view()->model())
+        return -1;
+    if (iface->role(0) == QAccessible::TreeItem) {
+        const QAccessibleTable2Cell* cell = static_cast<const QAccessibleTable2Cell*>(iface);
+        const QTreeView *treeView = qobject_cast<const QTreeView*>(view());
+        Q_ASSERT(treeView);
+        int row = treeView->d_func()->viewIndex(cell->m_index) + (horizontalHeader() ? 1 : 0);
+        int column = cell->m_index.column();
+
+        int index = row * view()->model()->columnCount() + column + 1;
+        //qDebug() << "QAccessibleTree::indexOfChild r " << row << " c " << column << "index " << index;
+        Q_ASSERT(index > treeView->model()->columnCount());
+        return index;
+    } else if (iface->role(0) == QAccessible::ColumnHeader){
+        const QAccessibleTable2HeaderCell* cell = static_cast<const QAccessibleTable2HeaderCell*>(iface);
+        //qDebug() << "QAccessibleTree::indexOfChild header " << cell->index << "is: " << cell->index + 1;
+        return cell->index + 1;
+    } else {
+        qWarning() << "WARNING QAccessibleTable2::indexOfChild invalid child"
+                   << iface->role(0) << iface->text(QAccessible::Name, 0);
+    }
+    // FIXME: add scrollbars and don't just ignore them
+    return -1;
+}
+
+int QAccessibleTree::navigate(RelationFlag relation, int index, QAccessibleInterface **iface) const
+{
+    *iface = 0;
+    if ((index < 0) || (!view()->model()))
+        return -1;
+
+    switch (relation) {
+    case QAccessible::Child: {
+        Q_ASSERT(index > 0);
+        --index;
+        int hHeader = horizontalHeader() ? 1 : 0;
+
+        if (hHeader) {
+            if (index < view()->model()->columnCount()) {
+                *iface = new QAccessibleTable2HeaderCell(view(), index, Qt::Horizontal);
+                return 0;
+            } else {
+                index -= view()->model()->columnCount();
+            }
+        }
+
+        int row = index / view()->model()->columnCount();
+        int column = index % view()->model()->columnCount();
+        QModelIndex modelIndex = indexFromLogical(row, column);
+        if (modelIndex.isValid()) {
+            *iface = cell(modelIndex);
+            return 0;
+        }
+        return -1;
+    }
+    default:
+        break;
+    }
+    // handle everything except child
+    return QAccessibleTable2::navigate(relation, index, iface);
+}
+
+QAccessible::Relation QAccessibleTree::relationTo(int, const QAccessibleInterface *, int) const
+{
+    return QAccessible::Unrelated;
+}
+
+QAccessibleTable2CellInterface *QAccessibleTree::cellAt(int row, int column) const
+{
+    QModelIndex index = indexFromLogical(row, column);
+    if (!index.isValid()) {
+        qWarning() << "Requested invalid tree cell: " << row << column;
+        return 0;
+    }
+    return new QAccessibleTable2Cell(view(), index, cellRole());
+}
+
+QString QAccessibleTree::rowDescription(int) const
+{
+    return QString(); // no headers for rows in trees
+}
+
+bool QAccessibleTree::isRowSelected(int row) const
+{
+    if (!view()->selectionModel())
+        return false;
+    QModelIndex index = indexFromLogical(row);
+    return view()->selectionModel()->isRowSelected(index.row(), index.parent());
+}
+
+bool QAccessibleTree::selectRow(int row)
+{
+    if (!view()->selectionModel())
+        return false;
+    QModelIndex index = indexFromLogical(row);
+    if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
+        return false;
+    view()->selectionModel()->select(index, QItemSelectionModel::Select);
+    return true;
+}
+
+// TABLE CELL
+
+QAccessibleTable2Cell::QAccessibleTable2Cell(QAbstractItemView *view_, const QModelIndex &index_, QAccessible::Role role_)
+    : /* QAccessibleSimpleEditableTextInterface(this), */ view(view_), m_index(index_), m_role(role_)
+{
+    Q_ASSERT(index_.isValid());
+}
+
+int QAccessibleTable2Cell::columnExtent() const { return 1; }
+int QAccessibleTable2Cell::rowExtent() const { return 1; }
+
+QList<QAccessibleInterface*> QAccessibleTable2Cell::rowHeaderCells() const
+{
+    QList<QAccessibleInterface*> headerCell;
+    if (verticalHeader()) {
+        headerCell.append(new QAccessibleTable2HeaderCell(view, m_index.row(), Qt::Vertical));
+    }
+    return headerCell;
+}
+
+QList<QAccessibleInterface*> QAccessibleTable2Cell::columnHeaderCells() const
+{
+    QList<QAccessibleInterface*> headerCell;
+    if (horizontalHeader()) {
+        headerCell.append(new QAccessibleTable2HeaderCell(view, m_index.column(), Qt::Horizontal));
+    }
+    return headerCell;
+}
+
+QHeaderView *QAccessibleTable2Cell::horizontalHeader() const
+{
+    QHeaderView *header = 0;
+
+    if (false) {
+#ifndef QT_NO_TABLEVIEW
+    } else if (const QTableView *tv = qobject_cast<const QTableView*>(view)) {
+        header = tv->horizontalHeader();
+#endif
+#ifndef QT_NO_TREEVIEW
+    } else if (const QTreeView *tv = qobject_cast<const QTreeView*>(view)) {
+        header = tv->header();
+#endif
+    }
+
+    return header;
+}
+
+QHeaderView *QAccessibleTable2Cell::verticalHeader() const
+{
+    QHeaderView *header = 0;
+#ifndef QT_NO_TABLEVIEW
+    if (const QTableView *tv = qobject_cast<const QTableView*>(view))
+        header = tv->verticalHeader();
+#endif
+    return header;
+}
+
+int QAccessibleTable2Cell::columnIndex() const
+{
+    return m_index.column();
+}
+
+int QAccessibleTable2Cell::rowIndex() const
+{
+    if (role(0) == QAccessible::TreeItem) {
+       const QTreeView *treeView = qobject_cast<const QTreeView*>(view);
+       Q_ASSERT(treeView);
+       int row = treeView->d_func()->viewIndex(m_index);
+       return row;
+    }
+    return m_index.row();
+}
+
+bool QAccessibleTable2Cell::isSelected() const
+{
+    return view->selectionModel()->isSelected(m_index);
+}
+
+void QAccessibleTable2Cell::rowColumnExtents(int *row, int *column, int *rowExtents, int *columnExtents, bool *selected) const
+{
+    *row = m_index.row();
+    *column = m_index.column();
+    *rowExtents = 1;
+    *columnExtents = 1;
+    *selected = isSelected();
+}
+
+QAccessibleTable2Interface* QAccessibleTable2Cell::table() const
+{
+    return QAccessible::queryAccessibleInterface(view)->table2Interface();
+}
+
+QAccessible::Role QAccessibleTable2Cell::role(int child) const
+{
+    Q_ASSERT(child == 0);
+    return m_role;
+}
+
+QAccessible::State QAccessibleTable2Cell::state(int child) const
+{
+    Q_ASSERT(child == 0);
+    State st = Normal;
+
+    QRect globalRect = view->rect();
+    globalRect.translate(view->mapToGlobal(QPoint(0,0)));
+    if (!globalRect.intersects(rect(0)))
+        st |= Invisible;
+
+    if (view->selectionModel()->isSelected(m_index))
+        st |= Selected;
+    if (view->selectionModel()->currentIndex() == m_index)
+        st |= Focused;
+    if (m_index.model()->data(m_index, Qt::CheckStateRole).toInt() == Qt::Checked)
+        st |= Checked;
+
+    Qt::ItemFlags flags = m_index.flags();
+    if (flags & Qt::ItemIsSelectable) {
+        st |= Selectable;
+        st |= Focusable;
+        if (view->selectionMode() == QAbstractItemView::MultiSelection)
+            st |= MultiSelectable;
+        if (view->selectionMode() == QAbstractItemView::ExtendedSelection)
+            st |= ExtSelectable;
+    }
+    if (m_role == QAccessible::TreeItem) {
+        const QTreeView *treeView = qobject_cast<const QTreeView*>(view);
+        if (treeView->isExpanded(m_index))
+            st |= Expanded;
+    }
+    return st;
+}
+
+bool QAccessibleTable2Cell::isExpandable() const
+{
+    return view->model()->hasChildren(m_index);
+}
+
+QRect QAccessibleTable2Cell::rect(int child) const
+{
+    Q_ASSERT(child == 0);
+
+    QRect r;
+    r = view->visualRect(m_index);
+
+    if (!r.isNull())
+        r.translate(view->viewport()->mapTo(view, QPoint(0,0)));
+        r.translate(view->mapToGlobal(QPoint(0, 0)));
+    return r;
+}
+
+QString QAccessibleTable2Cell::text(Text t, int child) const
+{
+    Q_ASSERT(child == 0);
+    QAbstractItemModel *model = view->model();
+    QString value;
+    switch (t) {
+    case QAccessible::Value:
+    case QAccessible::Name:
+        value = model->data(m_index, Qt::AccessibleTextRole).toString();
+        if (value.isEmpty())
+            value = model->data(m_index, Qt::DisplayRole).toString();
+        break;
+    case QAccessible::Description:
+        value = model->data(m_index, Qt::AccessibleDescriptionRole).toString();
+        break;
+    default:
+        break;
+    }
+    return value;
+}
+
+void QAccessibleTable2Cell::setText(Text /*t*/, int child, const QString &text)
+{
+    Q_ASSERT(child == 0);
+    if (!(m_index.flags() & Qt::ItemIsEditable))
+        return;
+    view->model()->setData(m_index, text);
+}
+
+bool QAccessibleTable2Cell::isValid() const
+{
+    return view && view->model() && m_index.isValid();
+}
+
+int QAccessibleTable2Cell::navigate(RelationFlag relation, int index, QAccessibleInterface **iface) const
+{
+    if (relation == Ancestor && index == 1) {
+        if (m_role == QAccessible::TreeItem) {
+            *iface = new QAccessibleTree(view);
+        } else {
+            *iface = new QAccessibleTable2(view);
+        }
+        return 0;
+    }
+
+    *iface = 0;
+    if (!view)
+        return -1;
+
+    switch (relation) {
+
+    case Child: {
+        return -1;
+    }
+    case Sibling:
+        if (index > 0) {
+            QAccessibleInterface *parent = queryAccessibleInterface(view);
+            int ret = parent->navigate(QAccessible::Child, index, iface);
+            delete parent;
+            if (*iface)
+                return ret;
+        }
+        return -1;
+
+// From table1 implementation:
+//    case Up:
+//    case Down:
+//    case Left:
+//    case Right: {
+//        // This is in the "not so nice" category. In order to find out which item
+//        // is geometrically around, we have to set the current index, navigate
+//        // and restore the index as well as the old selection
+//        view()->setUpdatesEnabled(false);
+//        const QModelIndex oldIdx = view()->currentIndex();
+//        QList<QModelIndex> kids = children();
+//        const QModelIndex currentIndex = index ? kids.at(index - 1) : QModelIndex(row);
+//        const QItemSelection oldSelection = view()->selectionModel()->selection();
+//        view()->setCurrentIndex(currentIndex);
+//        const QModelIndex idx = view()->moveCursor(toCursorAction(relation), Qt::NoModifier);
+//        view()->setCurrentIndex(oldIdx);
+//        view()->selectionModel()->select(oldSelection, QItemSelectionModel::ClearAndSelect);
+//        view()->setUpdatesEnabled(true);
+//        if (!idx.isValid())
+//            return -1;
+
+//        if (idx.parent() != row.parent() || idx.row() != row.row())
+//            *iface = cell(idx);
+//        return index ? kids.indexOf(idx) + 1 : 0; }
+    default:
+        break;
+    }
+
+    return -1;
+}
+
+QAccessible::Relation QAccessibleTable2Cell::relationTo(int child, const QAccessibleInterface *other, int otherChild) const
+{
+    Q_ASSERT(child == 0);
+    Q_ASSERT(otherChild == 0);
+    // we only check for parent-child relationships in trees
+    if (m_role == QAccessible::TreeItem && other->role(0) == QAccessible::TreeItem) {
+        QModelIndex otherIndex = static_cast<const QAccessibleTable2Cell*>(other)->m_index;
+        // is the other our parent?
+        if (otherIndex.parent() == m_index)
+            return QAccessible::Ancestor;
+        // are we the other's child?
+        if (m_index.parent() == otherIndex)
+            return QAccessible::Child;
+    }
+    return QAccessible::Unrelated;
+}
+
+#ifndef QT_NO_ACTION
+int QAccessibleTable2Cell::userActionCount(int) const
+{
+    return 0;
+}
+
+QString QAccessibleTable2Cell::actionText(int, Text, int) const
+{
+    return QString();
+}
+
+bool QAccessibleTable2Cell::doAction(int, int, const QVariantList &)
+{
+    return false;
+}
+
+QAccessibleTable2HeaderCell::QAccessibleTable2HeaderCell(QAbstractItemView *view_, int index_, Qt::Orientation orientation_)
+    : view(view_), index(index_), orientation(orientation_)
+{
+    Q_ASSERT(index_ >= 0);
+}
+
+QAccessible::Role QAccessibleTable2HeaderCell::role(int child) const
+{
+    Q_ASSERT(child == 0);
+    if (orientation == Qt::Horizontal)
+        return QAccessible::ColumnHeader;
+    return QAccessible::RowHeader;
+}
+
+QAccessible::State QAccessibleTable2HeaderCell::state(int child) const
+{
+    Q_ASSERT(child == 0);
+    return QAccessible::Normal;
+}
+
+QRect QAccessibleTable2HeaderCell::rect(int child) const
+{
+    Q_ASSERT(child == 0);
+
+    QHeaderView *header = 0;
+    if (false) {
+#ifndef QT_NO_TABLEVIEW
+    } else if (const QTableView *tv = qobject_cast<const QTableView*>(view)) {
+        if (orientation == Qt::Horizontal) {
+            header = tv->horizontalHeader();
+        } else {
+            header = tv->verticalHeader();
+        }
+#endif
+#ifndef QT_NO_TREEVIEW
+    } else if (const QTreeView *tv = qobject_cast<const QTreeView*>(view)) {
+        header = tv->header();
+#endif
+    }
+    if (!header)
+        return QRect();
+    QPoint zero = header->mapToGlobal(QPoint(0, 0));
+    int sectionSize = header->sectionSize(index);
+    int sectionPos = header->sectionPosition(index);
+    return orientation == Qt::Horizontal
+            ? QRect(zero.x() + sectionPos, zero.y(), sectionSize, header->height())
+            : QRect(zero.x(), zero.y() + sectionPos, header->width(), sectionSize);
+}
+
+QString QAccessibleTable2HeaderCell::text(Text t, int child) const
+{
+    Q_ASSERT(child == 0);
+    QAbstractItemModel *model = view->model();
+    QString value;
+    switch (t) {
+    case QAccessible::Value:
+    case QAccessible::Name:
+        value = model->headerData(index, orientation, Qt::AccessibleTextRole).toString();
+        if (value.isEmpty())
+            value = model->headerData(index, orientation, Qt::DisplayRole).toString();
+        break;
+    case QAccessible::Description:
+        value = model->headerData(index, orientation, Qt::AccessibleDescriptionRole).toString();
+        break;
+    default:
+        break;
+    }
+    return value;
+}
+
+void QAccessibleTable2HeaderCell::setText(Text, int, const QString &)
+{
+    return;
+}
+
+bool QAccessibleTable2HeaderCell::isValid() const
+{
+    return view && view->model() && (index >= 0)
+            && ((orientation == Qt::Horizontal) ? (index < view->model()->columnCount()) : (index < view->model()->rowCount()));
+}
+
+int QAccessibleTable2HeaderCell::navigate(RelationFlag relation, int index, QAccessibleInterface **iface) const
+{
+    if (relation == QAccessible::Ancestor && index == 1) {
+        if (false) {
+#ifndef QT_NO_TREEVIEW
+        } else if (qobject_cast<const QTreeView*>(view)) {
+            *iface = new QAccessibleTree(view);
+            return 0;
+#endif
+        } else {
+            *iface = new QAccessibleTable2(view);
+            return 0;
+        }
+    }
+    *iface = 0;
+    return -1;
+}
+
+QAccessible::Relation QAccessibleTable2HeaderCell::relationTo(int, const QAccessibleInterface *, int) const
+{
+    return QAccessible::Unrelated;
+}
+
+#ifndef QT_NO_ACTION
+int QAccessibleTable2HeaderCell::userActionCount(int) const
+{
+    return 0;
+}
+
+QString QAccessibleTable2HeaderCell::actionText(int, Text, int) const
+{
+    return QString();
+}
+
+bool QAccessibleTable2HeaderCell::doAction(int, int, const QVariantList &)
+{
+    return false;
+}
+#endif
+
+
+
+#endif
+
+#endif // QT_NO_ITEMVIEWS
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_ACCESSIBILITY

--- a/Patches/Qt/itemviews.cpp
+++ b/Patches/Qt/itemviews.cpp
@@ -393,7 +393,7 @@ bool QAccessibleTable2::unselectColumn(int column)
     QModelIndex index = view()->model()->index(0, column, view()->rootIndex());
     if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
         return false;
-    view()->selectionModel()->select(index, QItemSelectionModel::Columns & QItemSelectionModel::Deselect);
+    view()->selectionModel()->select(index, static_cast<QItemSelectionModel::SelectionFlags> (QItemSelectionModel::Columns & QItemSelectionModel::Deselect));
     return true;
 }
 

--- a/Patches/Qt/previewmanager.cpp
+++ b/Patches/Qt/previewmanager.cpp
@@ -1,0 +1,951 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the Qt Designer of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "abstractsettings_p.h"
+#include "previewmanager_p.h"
+#include "qdesigner_formbuilder_p.h"
+#include "shared_settings_p.h"
+#include "shared_settings_p.h"
+#include "zoomwidget_p.h"
+#include "formwindowbase_p.h"
+#include "widgetfactory_p.h"
+
+#include <deviceskin.h>
+
+#include <QtDesigner/QDesignerFormWindowInterface>
+#include <QtDesigner/QDesignerFormEditorInterface>
+#include <QtDesigner/QDesignerFormWindowManagerInterface>
+
+#include <QtGui/QWidget>
+#include <QtGui/qevent.h>
+#include <QtGui/QDesktopWidget>
+#include <QtGui/QMainWindow>
+#include <QtGui/QDockWidget>
+#include <QtGui/QApplication>
+#include <QtGui/QPixmap>
+#include <QtGui/QVBoxLayout>
+#include <QtGui/QDialog>
+#include <QtGui/QMenu>
+#include <QtGui/QAction>
+#include <QtGui/QActionGroup>
+#include <QtGui/QCursor>
+#include <QtGui/QMatrix>
+
+#include <QtCore/QMap>
+#include <QtCore/QDebug>
+#include <QtCore/QSharedData>
+
+QT_BEGIN_NAMESPACE
+
+static inline int compare(const qdesigner_internal::PreviewConfiguration &pc1, const qdesigner_internal::PreviewConfiguration &pc2)
+{
+    int rc = pc1.style().compare(pc2.style());
+    if (rc)
+        return rc;
+    rc = pc1.applicationStyleSheet().compare(pc2.applicationStyleSheet());
+    if (rc)
+        return rc;
+    return pc1.deviceSkin().compare(pc2.deviceSkin());
+}
+
+namespace {
+    // ------ PreviewData (data associated with a preview window)
+    struct PreviewData {
+        PreviewData(const QPointer<QWidget> &widget, const  QDesignerFormWindowInterface *formWindow, const qdesigner_internal::PreviewConfiguration &pc);
+        QPointer<QWidget> m_widget;
+        const QDesignerFormWindowInterface *m_formWindow;
+        qdesigner_internal::PreviewConfiguration m_configuration;
+    };
+
+    PreviewData::PreviewData(const QPointer<QWidget>& widget,
+                             const QDesignerFormWindowInterface *formWindow,
+                             const qdesigner_internal::PreviewConfiguration &pc) :
+        m_widget(widget),
+        m_formWindow(formWindow),
+        m_configuration(pc)
+    {
+    }
+}
+
+namespace qdesigner_internal {
+
+/* In designer, we have the situation that laid-out maincontainers have
+ * a geometry set (which might differ from their sizeHint()). The QGraphicsItem
+ * should return that in its size hint, else such cases won't work */
+
+class DesignerZoomProxyWidget : public ZoomProxyWidget  {
+    Q_DISABLE_COPY(DesignerZoomProxyWidget)
+public:
+    DesignerZoomProxyWidget(QGraphicsItem *parent = 0, Qt::WindowFlags wFlags = 0);
+protected:
+    virtual QSizeF sizeHint(Qt::SizeHint which, const QSizeF & constraint = QSizeF() ) const;
+};
+
+DesignerZoomProxyWidget::DesignerZoomProxyWidget(QGraphicsItem *parent, Qt::WindowFlags wFlags) :
+    ZoomProxyWidget(parent, wFlags)
+{
+}
+
+QSizeF DesignerZoomProxyWidget::sizeHint(Qt::SizeHint which, const QSizeF & constraint) const
+{
+    if (const QWidget *w = widget())
+            return QSizeF(w->size());
+    return ZoomProxyWidget::sizeHint(which, constraint);
+}
+
+// DesignerZoomWidget which returns DesignerZoomProxyWidget in its factory function
+class DesignerZoomWidget : public ZoomWidget {
+    Q_DISABLE_COPY(DesignerZoomWidget)
+public:
+    DesignerZoomWidget(QWidget *parent = 0);
+private:
+    virtual QGraphicsProxyWidget *createProxyWidget(QGraphicsItem *parent = 0, Qt::WindowFlags wFlags = 0) const;
+};
+
+DesignerZoomWidget::DesignerZoomWidget(QWidget *parent) :
+    ZoomWidget(parent)
+{
+}
+
+QGraphicsProxyWidget *DesignerZoomWidget::createProxyWidget(QGraphicsItem *parent, Qt::WindowFlags wFlags) const
+{
+    return new DesignerZoomProxyWidget(parent, wFlags);
+}
+
+// PreviewDeviceSkin: Forwards the key events to the window and
+// provides context menu with rotation options. Derived class
+// can apply additional transformations to the skin.
+
+class PreviewDeviceSkin : public  DeviceSkin
+{
+    Q_OBJECT
+public:
+    enum Direction { DirectionUp, DirectionLeft,  DirectionRight };
+
+    explicit PreviewDeviceSkin(const DeviceSkinParameters &parameters, QWidget *parent);
+    virtual void setPreview(QWidget *w);
+    QSize screenSize() const { return  m_screenSize; }
+
+private slots:
+    void slotSkinKeyPressEvent(int code, const QString& text, bool autorep);
+    void slotSkinKeyReleaseEvent(int code, const QString& text, bool autorep);
+    void slotPopupMenu();
+
+protected:
+    virtual void populateContextMenu(QMenu *) {}
+
+private slots:
+    void slotDirection(QAction *);
+
+protected:
+    // Fit the widget in case the orientation changes (transposing screensize)
+    virtual void fitWidget(const QSize &size);    
+    //  Calculate the complete transformation for the skin
+    // (base class implementation provides rotation).
+    virtual QMatrix skinTransform() const;
+
+private:
+    const QSize m_screenSize;
+    Direction m_direction;
+
+    QAction *m_directionUpAction;
+    QAction *m_directionLeftAction;
+    QAction *m_directionRightAction;
+    QAction *m_closeAction;
+};
+
+PreviewDeviceSkin::PreviewDeviceSkin(const DeviceSkinParameters &parameters, QWidget *parent) :
+    DeviceSkin(parameters, parent),    
+    m_screenSize(parameters.screenSize()),
+    m_direction(DirectionUp),
+    m_directionUpAction(0),
+    m_directionLeftAction(0),
+    m_directionRightAction(0),
+    m_closeAction(0)
+{
+    connect(this, SIGNAL(skinKeyPressEvent(int,QString,bool)),
+            this, SLOT(slotSkinKeyPressEvent(int,QString,bool)));
+    connect(this, SIGNAL(skinKeyReleaseEvent(int,QString,bool)),
+            this, SLOT(slotSkinKeyReleaseEvent(int,QString,bool)));
+    connect(this, SIGNAL(popupMenu()), this, SLOT(slotPopupMenu()));
+}
+
+void PreviewDeviceSkin::setPreview(QWidget *formWidget)
+{
+    formWidget->setFixedSize(m_screenSize);
+    formWidget->setParent(this, Qt::SubWindow);
+    formWidget->setAutoFillBackground(true);
+    setView(formWidget);
+}
+
+void PreviewDeviceSkin::slotSkinKeyPressEvent(int code, const QString& text, bool autorep)
+{
+    if (QWidget *focusWidget =  QApplication::focusWidget()) {
+        QKeyEvent e(QEvent::KeyPress,code,0,text,autorep);
+        QApplication::sendEvent(focusWidget, &e);
+    }
+}
+
+void PreviewDeviceSkin::slotSkinKeyReleaseEvent(int code, const QString& text, bool autorep)
+{
+    if (QWidget *focusWidget =  QApplication::focusWidget()) {
+        QKeyEvent e(QEvent::KeyRelease,code,0,text,autorep);
+        QApplication::sendEvent(focusWidget, &e);
+    }
+}
+
+// Create a checkable action with integer data and
+// set it checked if it matches the currentState.
+static inline QAction
+        *createCheckableActionIntData(const QString &label,
+                                      int actionValue, int currentState,
+                                      QActionGroup *ag, QObject *parent)
+{
+    QAction *a = new QAction(label, parent);
+    a->setData(actionValue);
+    a->setCheckable(true);
+    if (actionValue == currentState)
+        a->setChecked(true);
+    ag->addAction(a);
+    return a;
+}
+
+void PreviewDeviceSkin::slotPopupMenu()
+{
+    QMenu menu(this);
+    // Create actions
+    if (!m_directionUpAction) {
+        QActionGroup *directionGroup = new QActionGroup(this);
+        connect(directionGroup, SIGNAL(triggered(QAction*)), this, SLOT(slotDirection(QAction*)));
+        directionGroup->setExclusive(true);
+        m_directionUpAction = createCheckableActionIntData(tr("&Portrait"), DirectionUp, m_direction, directionGroup, this);
+	//: Rotate form preview counter-clockwise
+        m_directionLeftAction = createCheckableActionIntData(tr("Landscape (&CCW)"), DirectionLeft, m_direction, directionGroup, this);
+        //: Rotate form preview clockwise
+        m_directionRightAction = createCheckableActionIntData(tr("&Landscape (CW)"), DirectionRight, m_direction, directionGroup, this);
+        m_closeAction = new QAction(tr("&Close"), this);
+        connect(m_closeAction, SIGNAL(triggered()), parentWidget(), SLOT(close()));
+    }
+    menu.addAction(m_directionUpAction);
+    menu.addAction(m_directionLeftAction);
+    menu.addAction(m_directionRightAction);
+    menu.addSeparator();
+    populateContextMenu(&menu);
+    menu.addAction(m_closeAction);
+    menu.exec(QCursor::pos());
+}
+
+void PreviewDeviceSkin::slotDirection(QAction *a)
+{
+    const Direction newDirection = static_cast<Direction>(a->data().toInt());
+    if (m_direction == newDirection)
+        return;
+    const Qt::Orientation newOrientation = newDirection == DirectionUp ? Qt::Vertical : Qt::Horizontal;
+    const Qt::Orientation oldOrientation = m_direction  == DirectionUp ? Qt::Vertical : Qt::Horizontal;
+    m_direction = newDirection;
+#ifndef QT_NO_CURSOR
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+#endif
+    if (oldOrientation != newOrientation) {
+        QSize size = screenSize();
+        if (newOrientation == Qt::Horizontal)
+            size.transpose();
+        fitWidget(size);
+    }
+    setTransform(skinTransform());
+#ifndef QT_NO_CURSOR
+    QApplication::restoreOverrideCursor();
+#endif
+}
+
+void PreviewDeviceSkin::fitWidget(const QSize &size)
+{
+    view()->setFixedSize(size);
+}
+
+QMatrix PreviewDeviceSkin::skinTransform() const
+{
+    QMatrix newTransform;    
+    switch (m_direction)  {
+        case DirectionUp:
+            break;
+        case DirectionLeft:
+            newTransform.rotate(270.0);
+            break;
+        case DirectionRight:
+            newTransform.rotate(90.0);
+            break;
+    }
+    return newTransform;
+}
+
+// ------------ PreviewConfigurationPrivate
+class PreviewConfigurationData : public QSharedData {
+public:
+    PreviewConfigurationData() {}
+    explicit PreviewConfigurationData(const QString &style, const QString &applicationStyleSheet, const QString &deviceSkin);
+
+    QString m_style;
+    // Style sheet to prepend (to simulate the effect od QApplication::setSyleSheet()).
+    QString m_applicationStyleSheet;
+    QString m_deviceSkin;
+};
+
+PreviewConfigurationData::PreviewConfigurationData(const QString &style, const QString &applicationStyleSheet, const QString &deviceSkin) :
+    m_style(style),
+    m_applicationStyleSheet(applicationStyleSheet),
+    m_deviceSkin(deviceSkin)
+{
+}
+
+/* ZoomablePreviewDeviceSkin: A Zoomable Widget Preview skin. Embeds preview
+ *  into a ZoomWidget and this in turn into the DeviceSkin view and keeps
+ * Device skin zoom + ZoomWidget zoom in sync. */
+
+class ZoomablePreviewDeviceSkin : public PreviewDeviceSkin
+{
+    Q_OBJECT
+public:
+    explicit ZoomablePreviewDeviceSkin(const DeviceSkinParameters &parameters, QWidget *parent);
+    virtual void setPreview(QWidget *w);
+
+    int zoomPercent() const; // Device Skins have a double 'zoom' property
+
+public slots:
+    void setZoomPercent(int);
+
+signals:
+    void zoomPercentChanged(int);
+
+protected:
+    virtual void populateContextMenu(QMenu *m);    
+    virtual QMatrix skinTransform() const;
+    virtual void fitWidget(const QSize &size);
+
+private:
+    ZoomMenu *m_zoomMenu;
+    QAction *m_zoomSubMenuAction;
+    ZoomWidget *m_zoomWidget;
+};
+
+ZoomablePreviewDeviceSkin::ZoomablePreviewDeviceSkin(const DeviceSkinParameters &parameters, QWidget *parent) :
+    PreviewDeviceSkin(parameters, parent),
+    m_zoomMenu(new ZoomMenu(this)),
+    m_zoomSubMenuAction(0),
+    m_zoomWidget(new DesignerZoomWidget)
+{
+    connect(m_zoomMenu, SIGNAL(zoomChanged(int)), this, SLOT(setZoomPercent(int)));
+    connect(m_zoomMenu, SIGNAL(zoomChanged(int)), this, SIGNAL(zoomPercentChanged(int)));
+    m_zoomWidget->setZoomContextMenuEnabled(false);
+    m_zoomWidget->setWidgetZoomContextMenuEnabled(false);
+    m_zoomWidget->resize(screenSize());
+    m_zoomWidget->setParent(this, Qt::SubWindow);
+    m_zoomWidget->setAutoFillBackground(true);
+    setView(m_zoomWidget);
+}
+
+static inline qreal zoomFactor(int percent)
+{
+    return qreal(percent) / 100.0;
+}
+
+static inline QSize scaleSize(int zoomPercent, const QSize &size)
+{
+    return zoomPercent == 100 ? size : (QSizeF(size) * zoomFactor(zoomPercent)).toSize();
+}
+
+void ZoomablePreviewDeviceSkin::setPreview(QWidget *formWidget)
+{    
+    m_zoomWidget->setWidget(formWidget);
+    m_zoomWidget->resize(scaleSize(zoomPercent(), screenSize()));
+}
+
+int ZoomablePreviewDeviceSkin::zoomPercent() const
+{
+    return m_zoomWidget->zoom();
+}
+
+void ZoomablePreviewDeviceSkin::setZoomPercent(int zp)
+{
+    if (zp == zoomPercent())
+        return;
+
+    // If not triggered by the menu itself: Update it
+    if (m_zoomMenu->zoom() != zp)
+        m_zoomMenu->setZoom(zp);
+
+#ifndef QT_NO_CURSOR
+    QApplication::setOverrideCursor(Qt::WaitCursor);    
+#endif
+    m_zoomWidget->setZoom(zp);
+    setTransform(skinTransform());
+#ifndef QT_NO_CURSOR
+    QApplication::restoreOverrideCursor();
+#endif
+}
+
+void ZoomablePreviewDeviceSkin::populateContextMenu(QMenu *menu)
+{
+    if (!m_zoomSubMenuAction) {
+        m_zoomSubMenuAction = new QAction(tr("&Zoom"), this);
+        QMenu *zoomSubMenu = new QMenu;
+        m_zoomSubMenuAction->setMenu(zoomSubMenu);
+        m_zoomMenu->addActions(zoomSubMenu);
+    }
+    menu->addAction(m_zoomSubMenuAction);
+    menu->addSeparator();
+}
+
+QMatrix ZoomablePreviewDeviceSkin::skinTransform() const
+{
+    // Complete transformation consisting of base class rotation and zoom.
+    QMatrix rc = PreviewDeviceSkin::skinTransform();
+    const int zp = zoomPercent();
+    if (zp != 100) {
+        const qreal factor = zoomFactor(zp);
+        rc.scale(factor, factor);
+    }
+    return rc;
+}
+
+void ZoomablePreviewDeviceSkin::fitWidget(const QSize &size)
+{
+    m_zoomWidget->resize(scaleSize(zoomPercent(), size));
+}
+
+// ------------- PreviewConfiguration
+
+static const char *styleKey = "Style";
+static const char *appStyleSheetKey = "AppStyleSheet";
+static const char *skinKey = "Skin";
+
+PreviewConfiguration::PreviewConfiguration() :
+    m_d(new PreviewConfigurationData)
+{
+}
+
+PreviewConfiguration::PreviewConfiguration(const QString &sty, const QString &applicationSheet, const QString &skin) :
+    m_d(new PreviewConfigurationData(sty, applicationSheet, skin))
+{
+}
+
+PreviewConfiguration::PreviewConfiguration(const PreviewConfiguration &o) :
+    m_d(o.m_d)
+{
+}
+
+PreviewConfiguration &PreviewConfiguration::operator=(const PreviewConfiguration &o)
+{
+    m_d.operator=(o.m_d);
+    return *this;
+}
+
+PreviewConfiguration::~PreviewConfiguration()
+{
+}
+
+void PreviewConfiguration::clear()
+{
+    PreviewConfigurationData &d = *m_d;
+    d.m_style.clear();
+    d.m_applicationStyleSheet.clear();
+    d.m_deviceSkin.clear();
+}
+
+QString PreviewConfiguration::style() const
+{
+    return m_d->m_style;
+}
+
+void PreviewConfiguration::setStyle(const QString &s)
+{
+    m_d->m_style = s;
+}
+
+// Style sheet to prepend (to simulate the effect od QApplication::setSyleSheet()).
+QString PreviewConfiguration::applicationStyleSheet() const
+{
+    return m_d->m_applicationStyleSheet;
+}
+
+void PreviewConfiguration::setApplicationStyleSheet(const QString &as)
+{
+    m_d->m_applicationStyleSheet = as;
+}
+
+QString PreviewConfiguration::deviceSkin() const
+{
+    return m_d->m_deviceSkin;
+}
+
+void PreviewConfiguration::setDeviceSkin(const QString &s)
+{
+     m_d->m_deviceSkin = s;
+}
+
+void PreviewConfiguration::toSettings(const QString &prefix, QDesignerSettingsInterface *settings) const
+{
+    const PreviewConfigurationData &d = *m_d;
+    settings->beginGroup(prefix);
+    settings->setValue(QLatin1String(styleKey),  d.m_style);
+    settings->setValue(QLatin1String(appStyleSheetKey), d.m_applicationStyleSheet);
+    settings->setValue(QLatin1String(skinKey), d.m_deviceSkin);
+    settings->endGroup();
+}
+
+void PreviewConfiguration::fromSettings(const QString &prefix, const QDesignerSettingsInterface *settings)
+{
+    clear();
+    QString key = prefix;
+    key += QLatin1Char('/');
+    const int prefixSize = key.size();
+
+    PreviewConfigurationData &d = *m_d;
+
+    const QVariant emptyString = QVariant(QString());
+
+    key += QLatin1String(styleKey);
+    d.m_style = settings->value(key, emptyString).toString();
+
+    key.replace(prefixSize, key.size() - prefixSize, QLatin1String(appStyleSheetKey));
+    d.m_applicationStyleSheet = settings->value(key, emptyString).toString();
+
+    key.replace(prefixSize, key.size() - prefixSize, QLatin1String(skinKey));
+    d.m_deviceSkin = settings->value(key, emptyString).toString();
+}
+
+
+QDESIGNER_SHARED_EXPORT bool operator<(const PreviewConfiguration &pc1, const PreviewConfiguration &pc2)
+{
+    return compare(pc1, pc2) < 0;
+}
+
+QDESIGNER_SHARED_EXPORT bool operator==(const PreviewConfiguration &pc1, const PreviewConfiguration &pc2)
+{
+    return compare(pc1, pc2) == 0;
+}
+
+QDESIGNER_SHARED_EXPORT bool operator!=(const PreviewConfiguration &pc1, const PreviewConfiguration &pc2)
+{
+    return compare(pc1, pc2) != 0;
+}
+
+// ------------- PreviewManagerPrivate
+class PreviewManagerPrivate {
+public:
+    PreviewManagerPrivate(PreviewManager::PreviewMode mode);
+
+    const PreviewManager::PreviewMode m_mode;
+
+    QPointer<QWidget> m_activePreview;
+
+    typedef QList<PreviewData> PreviewDataList;
+
+    PreviewDataList m_previews;
+
+    typedef QMap<QString, DeviceSkinParameters> DeviceSkinConfigCache;
+    DeviceSkinConfigCache m_deviceSkinConfigCache;
+
+    QDesignerFormEditorInterface *m_core;
+    bool m_updateBlocked;
+};
+
+PreviewManagerPrivate::PreviewManagerPrivate(PreviewManager::PreviewMode mode) :
+    m_mode(mode),
+    m_core(0),
+    m_updateBlocked(false)
+{
+}
+
+// ------------- PreviewManager
+
+PreviewManager::PreviewManager(PreviewMode mode, QObject *parent) :
+   QObject(parent),
+   d(new PreviewManagerPrivate(mode))
+{
+}
+
+PreviewManager:: ~PreviewManager()
+{
+    delete d;
+}
+
+
+Qt::WindowFlags PreviewManager::previewWindowFlags(const QWidget *widget) const
+{
+#ifdef Q_WS_WIN
+    Qt::WindowFlags windowFlags = (widget->windowType() == Qt::Window) ? Qt::Window | Qt::WindowMaximizeButtonHint : Qt::WindowFlags(Qt::Dialog);
+#else
+    Q_UNUSED(widget)
+    // Only Dialogs have close buttons on Mac.
+    // On Linux, we don't want an additional task bar item and we don't want a minimize button;
+    // we want the preview to be on top.
+    Qt::WindowFlags windowFlags = Qt::Dialog;
+#endif
+    return windowFlags;
+}
+
+QWidget *PreviewManager::createDeviceSkinContainer(const QDesignerFormWindowInterface *fw) const
+{
+    return new QDialog(fw->window());
+}
+
+// Some widgets might require fake containers
+
+static QWidget *fakeContainer(QWidget *w)
+{
+    // Prevent a dock widget from trying to dock to Designer's main window
+    // (which can be found in the parent hierarchy in MDI mode) by
+    // providing a fake mainwindow
+    if (QDockWidget *dock = qobject_cast<QDockWidget *>(w)) {
+        // Reparent: Clear modality, propagate title and resize outer container
+        const QSize size = w->size();
+        w->setWindowModality(Qt::NonModal);
+        dock->setFeatures(dock->features() & ~(QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetClosable));
+        dock->setAllowedAreas(Qt::LeftDockWidgetArea);
+        QMainWindow *mw = new QMainWindow;
+        int leftMargin, topMargin, rightMargin, bottomMargin;
+        mw->getContentsMargins(&leftMargin, &topMargin, &rightMargin, &bottomMargin);
+        mw->addDockWidget(Qt::LeftDockWidgetArea, dock);
+        mw->resize(size + QSize(leftMargin + rightMargin, topMargin + bottomMargin));
+        return mw;
+    }
+    return w;
+}
+
+static PreviewConfiguration configurationFromSettings(QDesignerFormEditorInterface *core, const QString &style)
+{
+    qdesigner_internal::PreviewConfiguration pc;
+    const QDesignerSharedSettings settings(core);
+    if (settings.isCustomPreviewConfigurationEnabled())
+        pc = settings.customPreviewConfiguration();
+    if (!style.isEmpty())
+        pc.setStyle(style);
+    return pc;
+}
+
+QWidget *PreviewManager::showPreview(const QDesignerFormWindowInterface *fw, const QString &style, int deviceProfileIndex, QString *errorMessage)
+{
+    return showPreview(fw, configurationFromSettings(fw->core(), style), deviceProfileIndex, errorMessage);
+}
+
+QWidget *PreviewManager::showPreview(const QDesignerFormWindowInterface *fw, const QString &style, QString *errorMessage)
+{
+    return showPreview(fw, style, -1, errorMessage);
+}
+
+QWidget *PreviewManager::createPreview(const QDesignerFormWindowInterface *fw,
+                                       const PreviewConfiguration &pc,
+                                       int deviceProfileIndex,
+                                       QString *errorMessage,
+                                       int initialZoom)
+{
+    if (!d->m_core)
+        d->m_core = fw->core();
+
+    const bool zoomable = initialZoom > 0;
+    // Figure out which profile to apply
+    DeviceProfile deviceProfile;
+    if (deviceProfileIndex >= 0) {
+        deviceProfile = QDesignerSharedSettings(fw->core()).deviceProfileAt(deviceProfileIndex);
+    } else {
+        if (const FormWindowBase *fwb = qobject_cast<const FormWindowBase *>(fw))
+            deviceProfile = fwb->deviceProfile();
+    }
+    // Create
+    QWidget *formWidget = QDesignerFormBuilder::createPreview(fw, pc.style(), pc.applicationStyleSheet(), deviceProfile, errorMessage);
+    if (!formWidget)
+        return 0;
+
+    const QString title = tr("%1 - [Preview]").arg(formWidget->windowTitle());
+    formWidget = fakeContainer(formWidget);
+    formWidget->setWindowTitle(title);
+
+    // Clear any modality settings, child widget modalities must not be higher than parent's
+    formWidget->setWindowModality(Qt::NonModal);
+    // No skin
+    const QString deviceSkin = pc.deviceSkin();
+    if (deviceSkin.isEmpty()) {
+        if (zoomable) { // Embed into ZoomWidget
+            ZoomWidget *zw = new DesignerZoomWidget;
+            connect(zw->zoomMenu(), SIGNAL(zoomChanged(int)), this, SLOT(slotZoomChanged(int)));
+            zw->setWindowTitle(title);
+            zw->setWidget(formWidget);
+            // Keep any widgets' context menus working, do not use global menu
+            zw->setWidgetZoomContextMenuEnabled(true);
+            zw->setParent(fw->window(), previewWindowFlags(formWidget));
+            // Make preview close when Widget closes (Dialog/accept, etc)
+            formWidget->setAttribute(Qt::WA_DeleteOnClose, true);
+            connect(formWidget, SIGNAL(destroyed()), zw, SLOT(close()));
+            zw->setZoom(initialZoom);
+            zw->setProperty(WidgetFactory::disableStyleCustomPaintingPropertyC, QVariant(true));
+            return zw;
+        }
+        formWidget->setParent(fw->window(), previewWindowFlags(formWidget));
+        formWidget->setProperty(WidgetFactory::disableStyleCustomPaintingPropertyC, QVariant(true));
+        return formWidget;
+    }
+    // Embed into skin. find config in cache
+    PreviewManagerPrivate::DeviceSkinConfigCache::iterator it = d->m_deviceSkinConfigCache.find(deviceSkin);
+    if (it == d->m_deviceSkinConfigCache.end()) {
+        DeviceSkinParameters parameters;
+        if (!parameters.read(deviceSkin, DeviceSkinParameters::ReadAll, errorMessage)) {
+            formWidget->deleteLater();
+            return 0;
+          }
+        it = d->m_deviceSkinConfigCache.insert(deviceSkin, parameters);
+    }
+
+    QWidget *skinContainer = createDeviceSkinContainer(fw);
+    PreviewDeviceSkin *skin = 0;
+    if (zoomable) {
+        ZoomablePreviewDeviceSkin *zds = new ZoomablePreviewDeviceSkin(it.value(), skinContainer);
+        zds->setZoomPercent(initialZoom);
+        connect(zds, SIGNAL(zoomPercentChanged(int)), this, SLOT(slotZoomChanged(int)));
+        skin = zds;
+    }  else {
+        skin = new PreviewDeviceSkin(it.value(), skinContainer);
+    }
+    skin->setPreview(formWidget);
+    // Make preview close when Widget closes (Dialog/accept, etc)
+    formWidget->setAttribute(Qt::WA_DeleteOnClose, true);
+    connect(formWidget, SIGNAL(destroyed()), skinContainer, SLOT(close()));
+    skinContainer->setWindowTitle(title);
+    skinContainer->setProperty(WidgetFactory::disableStyleCustomPaintingPropertyC, QVariant(true));
+    return skinContainer;
+}
+
+QWidget *PreviewManager::showPreview(const QDesignerFormWindowInterface *fw,
+                                     const PreviewConfiguration &pc,
+                                     int deviceProfileIndex,
+                                     QString *errorMessage)
+{
+    enum { Spacing = 10 };
+    if (QWidget *existingPreviewWidget = raise(fw, pc))
+        return existingPreviewWidget;
+
+    const QDesignerSharedSettings settings(fw->core());
+    const int initialZoom = settings.zoomEnabled() ? settings.zoom() : -1;
+
+    QWidget *widget = createPreview(fw, pc, deviceProfileIndex, errorMessage, initialZoom);
+    if (!widget)
+        return 0;
+    // Install filter for Escape key
+    widget->setAttribute(Qt::WA_DeleteOnClose, true);
+    widget->installEventFilter(this);
+
+    switch (d->m_mode) {
+    case ApplicationModalPreview:
+        // Cannot do this on the Mac as the dialog would have no close button
+        widget->setWindowModality(Qt::ApplicationModal);
+        break;
+    case SingleFormNonModalPreview:
+    case MultipleFormNonModalPreview:
+        widget->setWindowModality(Qt::NonModal);
+        connect(fw, SIGNAL(changed()), widget, SLOT(close()));
+        connect(fw, SIGNAL(destroyed()), widget, SLOT(close()));
+        if (d->m_mode == SingleFormNonModalPreview)
+            connect(fw->core()->formWindowManager(), SIGNAL(activeFormWindowChanged(QDesignerFormWindowInterface*)), widget, SLOT(close()));
+        break;
+    }
+    // Semi-smart algorithm to position previews:
+    // If its the first one, position relative to form.
+    // 2nd, attempt to tile right (for comparing styles) or cascade
+    const QSize size = widget->size();
+    const bool firstPreview = d->m_previews.empty();
+    if (firstPreview) {
+        widget->move(fw->mapToGlobal(QPoint(Spacing, Spacing)));
+    } else {
+        if (QWidget *lastPreview = d->m_previews.back().m_widget) {
+            QDesktopWidget *desktop = qApp->desktop();
+            const QRect lastPreviewGeometry = lastPreview->frameGeometry();
+            const QRect availGeometry = desktop->availableGeometry(desktop->screenNumber(lastPreview));
+            const QPoint newPos = lastPreviewGeometry.topRight() + QPoint(Spacing, 0);
+            if (newPos.x() +  size.width() < availGeometry.right())
+                widget->move(newPos);
+            else
+                widget->move(lastPreviewGeometry.topLeft() + QPoint(Spacing, Spacing));
+        }
+
+    }
+    d->m_previews.push_back(PreviewData(widget, fw, pc));
+    widget->show();
+    if (firstPreview)
+        emit firstPreviewOpened();
+    return widget;
+}
+
+QWidget *PreviewManager::raise(const QDesignerFormWindowInterface *fw, const PreviewConfiguration &pc)
+{
+    typedef PreviewManagerPrivate::PreviewDataList PreviewDataList;
+    if (d->m_previews.empty())
+        return false;
+
+    // find matching window
+    const PreviewDataList::const_iterator cend =  d->m_previews.constEnd();
+    for (PreviewDataList::const_iterator it = d->m_previews.constBegin(); it !=  cend ;++it) {
+        QWidget * w = it->m_widget;
+        if (w && it->m_formWindow == fw && it->m_configuration == pc) {
+            w->raise();
+            w->activateWindow();
+            return w;
+        }
+    }
+    return 0;
+}
+
+void PreviewManager::closeAllPreviews()
+{
+    typedef PreviewManagerPrivate::PreviewDataList PreviewDataList;
+    if (!d->m_previews.empty()) {
+        d->m_updateBlocked = true;
+        d->m_activePreview = 0;
+        const PreviewDataList::iterator cend =  d->m_previews.end();
+        for (PreviewDataList::iterator it = d->m_previews.begin(); it !=  cend ;++it) {
+            if (it->m_widget)
+                it->m_widget->close();
+        }
+        d->m_previews.clear();
+        d->m_updateBlocked = false;
+        emit lastPreviewClosed();
+    }
+}
+
+void PreviewManager::updatePreviewClosed(QWidget *w)
+{
+    typedef PreviewManagerPrivate::PreviewDataList PreviewDataList;
+    if (d->m_updateBlocked)
+        return;
+    // Purge out all 0 or widgets to be deleted
+    for (PreviewDataList::iterator it = d->m_previews.begin(); it != d->m_previews.end() ; ) {
+        QWidget *iw = it->m_widget; // Might be 0 when catching QEvent::Destroyed
+        if (iw == 0 || iw == w) {
+            it = d->m_previews.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    if (d->m_previews.empty())
+        emit lastPreviewClosed();
+}
+
+bool PreviewManager::eventFilter(QObject *watched, QEvent *event)
+{
+    // Courtesy of designer
+    do {
+        if (!watched->isWidgetType())
+            break;
+        QWidget *previewWindow = qobject_cast<QWidget *>(watched);
+        if (!previewWindow || !previewWindow->isWindow())
+            break;
+
+        switch (event->type()) {
+        case QEvent::KeyPress:
+        case QEvent::ShortcutOverride:        {
+            const  QKeyEvent *keyEvent = static_cast<const QKeyEvent *>(event);
+            const int key = keyEvent->key();
+            if ((key == Qt::Key_Escape
+#ifdef Q_WS_MAC
+                 || (keyEvent->modifiers() == Qt::ControlModifier && key == Qt::Key_Period)
+#endif
+                 )) {
+                previewWindow->close();
+                return true;
+            }
+        }
+            break;
+        case QEvent::WindowActivate:
+            d->m_activePreview = previewWindow;
+            break;
+        case  QEvent::Destroy: // We don't get QEvent::Close if someone accepts a QDialog.
+            updatePreviewClosed(previewWindow);
+            break;
+        case  QEvent::Close:
+            updatePreviewClosed(previewWindow);
+            previewWindow->removeEventFilter (this);
+            break;
+        default:
+            break;
+        }
+    } while(false);
+    return QObject::eventFilter(watched, event);
+}
+
+int PreviewManager::previewCount() const
+{
+    return  d->m_previews.size();
+}
+
+QPixmap PreviewManager::createPreviewPixmap(const QDesignerFormWindowInterface *fw, const QString &style, int deviceProfileIndex, QString *errorMessage)
+{
+    return createPreviewPixmap(fw, configurationFromSettings(fw->core(), style), deviceProfileIndex, errorMessage);
+}
+
+QPixmap PreviewManager::createPreviewPixmap(const QDesignerFormWindowInterface *fw, const QString &style, QString *errorMessage)
+{
+    return createPreviewPixmap(fw, style, -1, errorMessage);
+}
+
+QPixmap PreviewManager::createPreviewPixmap(const QDesignerFormWindowInterface *fw,
+                                            const PreviewConfiguration &pc,
+                                            int deviceProfileIndex,
+                                            QString *errorMessage)
+{
+    QWidget *widget = createPreview(fw, pc, deviceProfileIndex, errorMessage);
+    if (!widget)
+        return QPixmap();
+    const QPixmap rc = QPixmap::grabWidget(widget);
+    widget->deleteLater();
+    return rc;
+}
+
+void PreviewManager::slotZoomChanged(int z)
+{
+    if (d->m_core) { // Save the last zoom chosen by the user.
+        QDesignerSharedSettings settings(d->m_core);
+        settings.setZoom(z);
+    }
+}
+}
+
+QT_END_NAMESPACE
+
+#include "previewmanager.moc"

--- a/Patches/Qt/previewmanager.cpp
+++ b/Patches/Qt/previewmanager.cpp
@@ -817,7 +817,7 @@ QWidget *PreviewManager::raise(const QDesignerFormWindowInterface *fw, const Pre
 {
     typedef PreviewManagerPrivate::PreviewDataList PreviewDataList;
     if (d->m_previews.empty())
-        return false;
+        return 0;
 
     // find matching window
     const PreviewDataList::const_iterator cend =  d->m_previews.constEnd();


### PR DESCRIPTION
Qt won't build with gcc 6. This patch is a bit heavy handed since it disables the scripts module. I don't believe we use it anywhere and I don't think this patch is a permanent need since we'll likely switch over to Qt 5 at some point.