### PR TITLE
Revert CUDA enable flag name

### DIFF
--- a/CMake/External_Darknet.cmake
+++ b/CMake/External_Darknet.cmake
@@ -18,13 +18,13 @@ else()
   set(DARKNET_OPENCV_ARGS -DUSE_OPENCV:BOOL=OFF)
 endif()
 
-if(fletch_ENABLE_CUDA)
+if(fletch_BUILD_WITH_CUDA)
   option(fletch_ENABLE_Darknet_CUDA "Build Darknet with CUDA support" TRUE )
   mark_as_advanced(fletch_ENABLE_Darknet_CUDA)
 else()
   unset(fletch_ENABLE_Darknet_CUDA CACHE)
 endif()
-if(fletch_ENABLE_CUDNN)
+if(fletch_BUILD_WITH_CUDNN)
   option(fletch_ENABLE_Darknet_CUDNN "Build Darknet with CUDNN support" TRUE )
   mark_as_advanced(fletch_ENABLE_Darknet_CUDNN)
 else()
@@ -62,7 +62,7 @@ ExternalProject_Add(Darknet
   CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
     -DCMAKE_CXX_COMPILER:PATH=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}    
+    -DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}
     -DBUILD_SHARED_LIBS:BOOL=${DARKNET_BUILD_SHARED}
     -DINSTALL_HEADER_FILES:BOOL=ON
     ${DARKNET_OPENCV_ARGS}

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -9,7 +9,7 @@ mark_as_advanced(fletch_ENABLE_OpenCV_highgui)
 list(APPEND OpenCV_EXTRA_BUILD_FLAGS -DBUILD_opencv_highgui=${fletch_ENABLE_OpenCV_highgui})
 
 # Allow OpenCV's GPU option to be explicitly turned off while keeping CUDA for everything else
-if(fletch_ENABLE_CUDA)
+if(fletch_BUILD_WITH_CUDA)
   option(fletch_ENABLE_OpenCV_CUDA "Build OpenCV with CUDA support" TRUE )
   mark_as_advanced(fletch_ENABLE_OpenCV_CUDA)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,21 +51,21 @@ add_custom_target(Download)
 add_custom_target(fletch-build-install)
 
 # Options to control GPU support
-option(fletch_ENABLE_CUDA "Build with CUDA support" FALSE)
+option(fletch_BUILD_WITH_CUDA "Build with CUDA support" FALSE)
 
-if (fletch_ENABLE_CUDA)
+if (fletch_BUILD_WITH_CUDA)
   find_package( CUDA QUIET REQUIRED )
 
-  option(fletch_ENABLE_CUDNN "Build with CUDNN support" FALSE)
-  if (fletch_ENABLE_CUDNN)
+  option(fletch_BUILD_WITH_CUDNN "Build with CUDNN support" FALSE)
+  if (fletch_BUILD_WITH_CUDNN)
     set( CUDNN_ROOT_DIR "" CACHE PATH "CUDNN root folder" )
     mark_as_advanced( CUDNN_ROOT_DIR )
-    
+
     find_package( CUDNN QUIET REQUIRED)
   endif()
-elseif(fletch_ENABLE_CUDNN)
-  unset(fletch_ENABLE_CUDNN CACHE)
-  message(WARNING "Disabling fletch_ENABLE_CUDNN, You must have fletch_ENABLE_CUDA enabled for this to be enabled")
+elseif(fletch_BUILD_WITH_CUDNN)
+  unset(fletch_BUILD_WITH_CUDNN CACHE)
+  message(WARNING "Disabling fletch_BUILD_WITH_CUDNN, You must have fletch_BUILD_WITH_CUDA enabled for this to be enabled")
 endif()
 
 


### PR DESCRIPTION
fletch_BUILD_WITH_CUDA was changed to fletch_ENABLE_CUDA, but it wasn't changed for all projects (e.g. CAFFE) so there's a bug in master since some things were using 1 flag but not the other.

I prefer BUILD_WITH_CUDA as opposed to ENABLE_CUDA because unlike all of the other packages, CUDA is not being built by fletch, just linked against, and the ENABLE_* would make it seems like it was building it like everything else.