### PR TITLE
Use the file api from girder and include file name.

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -377,7 +377,7 @@ if(InternalCaffe)
   # This is the recommended option.
   if(WIN32)
     set(Caffe_version "527f97c0692f116ada7cb97eed8172ef7da05416")
-    set(Caffe_url "https://data.kitware.com/api/v1/item/598215638d777f16d01ea137/download/")
+    set(Caffe_url "https://data.kitware.com/api/v1/file/598215638d777f16d01ea138/download/caffe-win32-527f97c0.zip")
     set(Caffe_md5 "4ec71f28a797eac7fe3ddcb0fbfab60e")
   else()
     set(Caffe_version "7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b")


### PR DESCRIPTION
This patch fixes an issue on Windows, 'Could not extract tarball filename from url:'