### PR TITLE
Added release notes that were missed on previous branches

### DIFF
--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -12,6 +12,10 @@ New Packages
 
  * Added Darknet 
 
+ * Added PyBind11 version 2.2.0
+
+ * Added GTest version 1.8.0
+
 Package Upgrades
 
  * Updated Caffe to pull from a Kitware clone of the project and applied


### PR DESCRIPTION
It seems we didn't update the release notes when we added PyBind11 or GTest, so this PR makes that update.