### PR TITLE
Added option to use protobuf 3.4.1

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -361,10 +361,21 @@ if(NOT WIN32)
 endif()
 
 # Protobuf
+
+set(Protobuf_SELECT_VERSION "2.5.0" CACHE STRING "Select the  version of ProtoBuf to build.")
+set_property(CACHE Protobuf_SELECT_VERSION PROPERTY STRINGS "2.5.0" "3.4.1")
+
 if(NOT WIN32)
-  set(Protobuf_version "2.5.0" )
-  set(Protobuf_url "https://github.com/google/protobuf/releases/download/v${Protobuf_version}/protobuf-${Protobuf_version}.tar.bz2" )
-  set(Protobuf_md5 "a72001a9067a4c2c4e0e836d0f92ece4" )
+  set(Protobuf_version ${Protobuf_SELECT_VERSION})
+  if (Protobuf_version VERSION_EQUAL 2.5.0)
+    set(Protobuf_url "https://github.com/google/protobuf/releases/download/v${Protobuf_version}/protobuf-${Protobuf_version}.tar.bz2" )
+    set(Protobuf_md5 "a72001a9067a4c2c4e0e836d0f92ece4" )
+  elseif (Protobuf_version VERSION_EQUAL 3.4.1)
+    set(Protobuf_url "https://github.com/google/protobuf/releases/download/v${Protobuf_version}/protobuf-cpp-${Protobuf_version}.tar.gz" )
+    set(Protobuf_md5 "74446d310ce79cf20bab3ffd0e8f8f8f" )
+  else()
+    message(ERROR "Protobuf Version ${Protobuf_SELECT_VERSION} Not Supported")
+  endif()
   list(APPEND fletch_external_sources Protobuf )
 endif()
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -363,9 +363,9 @@ endif()
 # Protobuf
 
 set(Protobuf_SELECT_VERSION "2.5.0" CACHE STRING "Select the  version of ProtoBuf to build.")
-set_property(CACHE Protobuf_SELECT_VERSION PROPERTY STRINGS "2.5.0" "3.4.1")
 
 if(NOT WIN32)
+  set_property(CACHE Protobuf_SELECT_VERSION PROPERTY STRINGS "2.5.0" "3.4.1")
   set(Protobuf_version ${Protobuf_SELECT_VERSION})
   if (Protobuf_version VERSION_EQUAL 2.5.0)
     set(Protobuf_url "https://github.com/google/protobuf/releases/download/v${Protobuf_version}/protobuf-${Protobuf_version}.tar.bz2" )

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -44,6 +44,9 @@ Package Upgrades
 
  * Associated the patches of Ceres Solver with specific versions
 
+ * Added experimental support for Protobuf 3.4.1
+
+
 Fixes since v1.0.0
 ------------------
 


### PR DESCRIPTION
The current Protobuf in fletch is version 2.5.0. Howver, when Python 3 is enabled with Caffe, protobuf version 3 is required.

However using protobuf2 does not result in a build error. Instead an error is thrown when importing `pycaffe` a `TypeError` occurs (having to do with `str` and `unicode`). This is documented in https://github.com/BVLC/caffe/issues/5170. 

Note depending on whether this or #176 is merged first, the other should add the following code to `CMake/External_Caffe.cmake` to throw a configure-time error if python3 and protobuf 2.5 are enabled at the same time. 

```cmake
if(fletch_BUILD_WITH_PYTHON AND fletch_ENABLE_Protobuf)
  if (${Protobuf_version} LESS 3.0 AND fletch_PYTHON_MAJOR_VERSION MATCHES "^3.*")
    message(ERROR "Must use Protobuf >= 3.x with Python 3.x")
  endif()
endif()
```