### PR TITLE
logic to append all _SELECT_VERSION vars to the config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,13 @@ foreach(source ${fletch_external_sources})
       set_target_properties(${source}-install PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD True)
       set_target_properties(${source}-install PROPERTIES EXCLUDE_FROM_ALL True)
     endif()
+
+    # append the value of any existing variable suffixed with _SELECT_VERSION
+    set(select_version_key ${source}_SELECT_VERSION)
+    set(select_version_val ${${select_version_key}})
+    if(select_version_val)
+      file(APPEND ${fletch_CONFIG_INPUT} "set(${select_version_key} ${select_version_val})")
+    endif()
   endif()
 endforeach()
 


### PR DESCRIPTION
This ensures that the selected version information for enabled packages is propagated to the fletchConfig.cmake file. 

I'm not sure if its more desirable to do it implicitly like this, or explicitly in the External_*.cmake packages. However, the "_SELECT_VERSION" variable is often used to set the value of a normal "<pkg>_version" variable, which is used in those scripts. Perhaps the two should be consolidated? If not, then I think the implicit version is correct, because we are assuming that all user options regarding version will have the "_SELECT_VERSION" suffix. 