### PR TITLE
Fix for Ceres and Caffe to share the fletch glog and gflags

### DIFF
--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -47,8 +47,6 @@ endfunction()
 
 # Check for dependencies.
 if(NOT WIN32) # Win32 build takes care of most dependencies automatically
-  addCaffeDendency(GFlags "")
-  addCaffeDendency(GLog "")
   addCaffeDendency(LevelDB "")
   addCaffeDendency(LMDB "")
   if(NOT APPLE)
@@ -58,6 +56,8 @@ if(NOT WIN32) # Win32 build takes care of most dependencies automatically
 endif()
 addCaffeDendency(HDF5 "") # Caffe for windows grabs its own HDF5, but we need a parallel builds so we don't break other code
 addCaffeDendency(Boost 1.46)
+addCaffeDendency(GFlags "")
+addCaffeDendency(GLog "")
 addCaffeDendency(OpenCV "")
 addCaffeDendency(ZLib "")
 

--- a/CMake/External_Ceres.cmake
+++ b/CMake/External_Ceres.cmake
@@ -3,6 +3,7 @@
 if (fletch_ENABLE_Eigen)
   message(STATUS "Ceres depending on internal Eigen")
   list(APPEND Ceres_DEPENDS Eigen)
+  list(APPEND Ceres_EXTRA_BUILD_FLAGS -DEIGEN_INCLUDE_DIR_HINTS:PATH=${EIGEN_ROOT})
 else()
   message(FATAL_ERROR "Eigen is required for Ceres Solver, please enable")
 endif()

--- a/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/FindGlog.cmake
+++ b/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/FindGlog.cmake
@@ -1,0 +1,32 @@
+# - Try to find Glog
+#
+# The following variables are optionally searched for defaults
+#  GLOG_ROOT_DIR:            Base directory where all GLOG components are found
+#
+# The following are set after configuration is done:
+#  GLOG_FOUND
+#  GLOG_INCLUDE_DIRS
+#  GLOG_LIBRARIES
+#  GLOG_LIBRARYRARY_DIRS
+
+include(FindPackageHandleStandardArgs)
+
+set(GLOG_ROOT_DIR "" CACHE PATH "Folder contains Google glog")
+
+find_path(GLOG_INCLUDE_DIR glog/logging.h
+    PATHS ${GLOG_ROOT_DIR})
+
+find_library(GLOG_LIBRARY glog
+    PATHS ${GLOG_ROOT_DIR}
+    PATH_SUFFIXES lib lib64)
+
+
+find_package_handle_standard_args(Glog DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
+
+if(GLOG_FOUND)
+  set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})
+  set(GLOG_LIBRARIES ${GLOG_LIBRARY})
+  message(STATUS "Found glog    (include: ${GLOG_INCLUDE_DIR}, library: ${GLOG_LIBRARY})")
+  mark_as_advanced(GLOG_ROOT_DIR GLOG_LIBRARY_RELEASE GLOG_LIBRARY_DEBUG
+                                 GLOG_LIBRARY GLOG_INCLUDE_DIR)
+endif()

--- a/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/Patch.cmake
+++ b/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/Patch.cmake
@@ -14,6 +14,13 @@ if(WIN32)
     DESTINATION
     ${Caffe_source}/cmake/modules/
     )
+    
+  file(COPY
+    ${Caffe_patch}/FindGLog.cmake
+    DESTINATION
+    ${Caffe_source}/cmake/modules/
+    )
+    
   file(COPY
     ${Caffe_patch}/CMakeLists.txt
     DESTINATION

--- a/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/WindowsDownloadPrebuiltDependencies.cmake
+++ b/Patches/Caffe/527f97c0692f116ada7cb97eed8172ef7da05416/WindowsDownloadPrebuiltDependencies.cmake
@@ -28,9 +28,9 @@ if(USE_PREBUILT_DEPENDENCIES)
     endif()
     if(${MSVC_VERSION} GREATER ${MAX_MSVC_VERSION}) # Use the latest version we have
         set(CAPPED_MSVC_VERSION ${MAX_MSVC_VERSION})
-	else()
+  else()
         set(CAPPED_MSVC_VERSION ${MSVC_VERSION})
-    endif()	
+    endif()  
     if(NOT DEFINED DEPENDENCIES_URL_${CAPPED_MSVC_VERSION}_${_pyver})
         message(FATAL_ERROR "Could not find url for MSVC version = ${CAPPED_MSVC_VERSION} and Python version = ${_pyver}.")
     endif()
@@ -73,94 +73,96 @@ if(USE_PREBUILT_DEPENDENCIES)
         )
     endif()
     if(EXISTS ${CAFFE_DEPENDENCIES_DIR}/libraries/caffe-builder-config.cmake) # Sanity check
-		file(COPY ${CAFFE_DEPENDENCIES_DIR}/libraries/ DESTINATION ${CMAKE_INSTALL_PREFIX} # We need to move the prereqs to the proper directory, except dependencies handled by fletch
-		        PATTERN "*opencv*" EXCLUDE
-				PATTERN "*boost*" EXCLUDE
-				PATTERN "*hdf5*" EXCLUDE
-				PATTERN "H5*" EXCLUDE
-		)
-		if(EXISTS ${CAFFE_DEPENDENCIES_DIR}/libraries/lib/libopenblas.dll.a AND NOT EXISTS ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.lib)
+    file(COPY ${CAFFE_DEPENDENCIES_DIR}/libraries/ DESTINATION ${CMAKE_INSTALL_PREFIX} # We need to move the prereqs to the proper directory, except dependencies handled by fletch
+            PATTERN "*opencv*" EXCLUDE
+        PATTERN "*boost*" EXCLUDE
+        PATTERN "*hdf5*" EXCLUDE
+        PATTERN "H5*" EXCLUDE
+        PATTERN "glog*" EXCLUDE
+        PATTERN "gflags*" EXCLUDE
+    )
+    if(EXISTS ${CAFFE_DEPENDENCIES_DIR}/libraries/lib/libopenblas.dll.a AND NOT EXISTS ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.lib)
           file(RENAME ${CAFFE_DEPENDENCIES_DIR}/libraries/lib/libopenblas.dll.a ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.lib) # Same file type, but needs to be .lib for cmake
         endif()
-		file (REMOVE_RECURSE ${CAFFE_DEPENDENCIES_DIR}/libraries/) # Clean up
+    file (REMOVE_RECURSE ${CAFFE_DEPENDENCIES_DIR}/libraries/) # Clean up
 
-		# BOOST config
-		set(BOOST_ROOT ${CMAKE_INSTALL_PREFIX} CACHE PATH "")
-		set(BOOST_INCLUDEDIR ${BOOST_ROOT}/include CACHE PATH "")
-		set(BOOST_LIBRARYDIR ${BOOST_ROOT}/lib CACHE PATH "")
-		set(Boost_LIBRARY_DIR_RELEASE ${BOOST_ROOT}/lib CACHE PATH "")
-		set(Boost_LIBRARY_DIR_DEBUG ${BOOST_ROOT}/lib CACHE PATH "")
-		set(Boost_USE_MULTITHREADED ON CACHE BOOL "")
-		set(Boost_USE_STATIC_LIBS ON CACHE BOOL "")
-		set(Boost_USE_STATIC_RUNTIME OFF CACHE BOOL "")
-
-
-		# GFLAGS config
-		set(GFLAGS_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(gflags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
-		set(GFlags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
-		set(Gflags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
-		get_filename_component(GFLAGS_ROOT_DIR ${GFlags_DIR} DIRECTORY)
-		
+    # BOOST config
+    set(BOOST_ROOT ${CMAKE_INSTALL_PREFIX} CACHE PATH "")
+    set(BOOST_INCLUDEDIR ${BOOST_ROOT}/include CACHE PATH "")
+    set(BOOST_LIBRARYDIR ${BOOST_ROOT}/lib CACHE PATH "")
+    set(Boost_LIBRARY_DIR_RELEASE ${BOOST_ROOT}/lib CACHE PATH "")
+    set(Boost_LIBRARY_DIR_DEBUG ${BOOST_ROOT}/lib CACHE PATH "")
+    set(Boost_USE_MULTITHREADED ON CACHE BOOL "")
+    set(Boost_USE_STATIC_LIBS ON CACHE BOOL "")
+    set(Boost_USE_STATIC_RUNTIME OFF CACHE BOOL "")
 
 
-		# GLOG config
-		set(GLOG_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/glog CACHE PATH "")
-		set(glog_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/glog CACHE PATH "")
-		set(Glog_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    # GFLAGS config
+    set(GFLAGS_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(gflags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    set(GFlags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    set(Gflags_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    get_filename_component(GFLAGS_ROOT_DIR ${GFlags_DIR} DIRECTORY)
+    
 
 
-		# HDF5 config
-		set(HDF5_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(hdf5_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(HDF5_ROOT_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    # GLOG config
+    set(GLOG_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/glog CACHE PATH "")
+    set(glog_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/glog CACHE PATH "")
+    set(Glog_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+
+
+    # HDF5 config
+    set(HDF5_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(hdf5_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(HDF5_ROOT_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
         find_package(HDF5 COMPONENTS C HL REQUIRED)
 
 
-		# LEVELDB config
-		set(LEVELDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(leveldb_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
-		set(LevelDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    # LEVELDB config
+    set(LEVELDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(leveldb_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    set(LevelDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
 
 
-		# LMDB config
-		set(LMDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(lmdb_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
+    # LMDB config
+    set(LMDB_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(lmdb_DIR ${CMAKE_INSTALL_PREFIX}/cmake  CACHE PATH "")
 
 
-		# OPENBLAS config
-		set(OPENBLAS_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
-		set(openblas_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
-		set(OpenBLAS_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
-		set(OPENBLAS_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
-		set(openblas_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
-		set(OpenBLAS_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
+    # OPENBLAS config
+    set(OPENBLAS_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
+    set(openblas_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
+    set(OpenBLAS_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
+    set(OPENBLAS_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
+    set(openblas_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
+    set(OpenBLAS_LIB ${CMAKE_INSTALL_PREFIX}/lib/libopenblas.dll.a CACHE FILEPATH "")
 
 
-		# OPENCV config
-		set(OPENCV_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
-		set(opencv_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
-		set(OpenCV_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
-		set(OpenCV_STATIC OFF CACHE BOOL "")
+    # OPENCV config
+    set(OPENCV_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
+    set(opencv_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
+    set(OpenCV_DIR ${CMAKE_INSTALL_PREFIX}  CACHE PATH "")
+    set(OpenCV_STATIC OFF CACHE BOOL "")
 
 
-		# PROTOBUF config
-		set(PROTOBUF_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(protobuf_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(Protobuf_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
-		set(protobuf_MODULE_COMPATIBLE ON CACHE BOOL "")
+    # PROTOBUF config
+    set(PROTOBUF_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(protobuf_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(Protobuf_DIR ${CMAKE_INSTALL_PREFIX}/cmake CACHE PATH "")
+    set(protobuf_MODULE_COMPATIBLE ON CACHE BOOL "")
 
 
-		# SNAPPY config
-		set(SNAPPY_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
-		set(snappy_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
-		set(Snappy_DIR ${CAFFE_DEPENDENCIES_DIR}/libraries/cmake)
+    # SNAPPY config
+    set(SNAPPY_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
+    set(snappy_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
+    set(Snappy_DIR ${CAFFE_DEPENDENCIES_DIR}/libraries/cmake)
 
 
-		# ZLIB config
-		set(ZLIB_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
-		set(ZLIB_LIBRARY_DEBUG  ${CMAKE_INSTALL_PREFIX}/lib/zlib.lib CACHE FILEPATH "")
-		set(ZLIB_LIBRARY_RELEASE  ${CMAKE_INSTALL_PREFIX}/lib/zlib.lib CACHE FILEPATH "")
+    # ZLIB config
+    set(ZLIB_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "")
+    set(ZLIB_LIBRARY_DEBUG  ${CMAKE_INSTALL_PREFIX}/lib/zlib.lib CACHE FILEPATH "")
+    set(ZLIB_LIBRARY_RELEASE  ${CMAKE_INSTALL_PREFIX}/lib/zlib.lib CACHE FILEPATH "")
 
         # Generate leveldb files so we can get rid of some hard coding
         find_package(Boost 1.46 REQUIRED date_time filesystem system)


### PR DESCRIPTION
Also a small fix to give Ceres a hint to find eigen

Note I converted tabs to spaces in the WindowsDownloadPrebuiltDependencies.cmake
The actual needed change was ~line 80
PATTERN "glog*" EXCLUDE
PATTERN "gflag*" EXCLUDE

I had to patch FindGlog because the find_package(glog) would find the glog-config.cmake but for whatever reason, it would NOT find the glog library. So I did this patch.
The find_package(gflags) in FindGflags.cmake uses gflags-config.cmake and finds the gflags lib, 
but glog.lib isnot found when find_package(glog) uses the glog-config.cmake