### PR TITLE
Caffe segnet

### DIFF
--- a/CMake/External_Caffe_Segnet.cmake
+++ b/CMake/External_Caffe_Segnet.cmake
@@ -1,0 +1,350 @@
+set(allOk True)
+set(errorMessage)
+
+option(AUTO_ENABLE_CAFFE_SEGNET_DEPENDENCY "Automatically turn on all caffe segnet dependencies if caffe segnet is enabled" OFF)
+if(fletch_ENABLE_Caffe_Segnet AND AUTO_ENABLE_CAFFE_SEGNET_DEPENDENCY)
+  #Snappy is needed by LevelDB and ZLib is needed by HDF5
+  if(WIN32)
+    set(dependency Boost ZLib OpenCV HDF5)
+  else()
+    set(dependency Boost GFlags GLog ZLib HDF5 Snappy LevelDB LMDB OpenCV Protobuf)
+  endif()
+
+  if(NOT APPLE AND NOT WIN32)
+    list(APPEND dependency OpenBLAS)
+  endif()
+
+  set(OneWasOff FALSE)
+
+  foreach (_var IN LISTS dependency)
+    get_property(currentHelpString CACHE "fletch_ENABLE_${_var}" PROPERTY HELPSTRING)
+    set(fletch_ENABLE_${_var} ON CACHE BOOL ${currentHelpString} FORCE)
+    if(NOT TARGET ${_var})
+      include(External_${_var})
+    endif()
+  endforeach()
+endif()
+
+function(addCaffeSegnetDendency depend version)
+  if(NOT fletch_ENABLE_${depend} )
+    find_package(${depend} ${version} QUIET)
+    string(TOUPPER "${depend}" dependency_name_upper)
+    if(NOT ${depend}_FOUND AND NOT ${dependency_name_upper}_FOUND)
+      message("${depend} is needed")
+      set(allOk False PARENT_SCOPE)
+      return()
+    endif()
+    message("Warning: Using system library for ${depend}")
+  else() #need to make sure library is built before caffe segnet
+    set(Caffe_Segnet_DEPENDS ${Caffe_Segnet_DEPENDS} ${depend} PARENT_SCOPE)
+  endif()
+  add_package_dependency(
+    PACKAGE Caffe_Segnet
+    PACKAGE_DEPENDENCY ${depend}
+    PACKAGE_DEPENDENCY_ALIAS ${depend}
+    )
+endfunction()
+
+# Check for dependencies.
+if(NOT WIN32) # Win32 build takes care of most dependencies automatically
+  addCaffeSegnetDendency(GFlags "")
+  addCaffeSegnetDendency(GLog "")
+  addCaffeSegnetDendency(LevelDB "")
+  addCaffeSegnetDendency(LMDB "")
+  if(NOT APPLE)
+    addCaffeSegnetDendency(OpenBLAS "")
+  endif()
+  addCaffeSegnetDendency(Protobuf "")
+endif()
+addCaffeSegnetDendency(HDF5 "") # CaffeSegnet for windows grabs its own HDF5, but we need a parallel builds so we don't break other code
+addCaffeSegnetDendency(Boost 1.46)
+addCaffeSegnetDendency(OpenCV "")
+addCaffeSegnetDendency(ZLib "")
+
+if(NOT allOk)
+  message(FATAL_ERROR "Missing dependency(ies).")
+endif()
+
+# Set paths which CaffeSegnet requires for protobuf and opencv
+
+set( CAFFE_SEGNET_PROTOBUF_ARGS )
+
+if(fletch_ENABLE_Protobuf)
+  get_system_library_name( protobuf protobuf_libname )
+  get_system_library_name( protobuf-lite protobuf-lite_libname )
+  get_system_library_name( protoc protoc_libname )
+
+  set( CAFFE_SEGNET_PROTOBUF_ARGS
+    -DPROTOBUF_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DPROTOBUF_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protobuf_libname}
+    -DPROTOBUF_LIBRARY_DEBUG:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protobuf_libname}
+    -DPROTOBUF_LITE_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protobuf-lite_libname}
+    -DPROTOBUF_LITE_LIBRARY_DEBUG:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protobuf-lite_libname}
+    -DPROTOBUF_PROTOC_EXECUTABLE:PATH=${fletch_BUILD_INSTALL_PREFIX}/bin/protoc
+    -DPROTOBUF_PROTOC_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protoc_libname}
+    -DPROTOBUF_PROTOC_LIBRARY_DEBUG:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${protoc_libname}
+    )
+else()
+  set( CAFFE_SEGNET_PROTOBUF_ARGS
+    -DPROTOBUF_INCLUDE_DIR:PATH=${PROTOBUF_INCLUDE_DIR}
+    -DPROTOBUF_LIBRARY:PATH=${PROTOBUF_LIBRARY}
+    -DPROTOBUF_LIBRARY_DEBUG:PATH=${PROTOBUF_LIBRARY_DEBUG}
+    -DPROTOBUF_LITE_LIBRARY:PATH=${PROTOBUF_LITE_LIBRARY}
+    -DPROTOBUF_LITE_LIBRARY_DEBUG:PATH=${PROTOBUF_LITE_LIBRARY_DEBUG}
+    -DPROTOBUF_PROTOC_EXECUTABLE:PATH=${PROTOBUF_PROTOC_EXECUTABLE}
+    -DPROTOBUF_PROTOC_LIBRARY:PATH=${PROTOBUF_PROTOC_LIBRARY}
+    -DPROTOBUF_PROTOC_LIBRARY_DEBUG:PATH=${PROTOBUF_PROTOC_LIBRARY_DEBUG}
+  )
+endif()
+
+if(fletch_ENABLE_OpenCV)
+  set( CAFFE_SEGNET_OPENCV_ARGS
+    -DOpenCV_DIR:PATH=${fletch_BUILD_PREFIX}/src/OpenCV-build
+    -DOpenCV_LIB_PATH:PATH=${OpenCV_ROOT}/lib
+    )
+else()
+  set( CAFFE_SEGNET_OPENCV_ARGS
+    -DOpenCV_DIR:PATH=${OpenCV_DIR}
+  )
+endif()
+
+if(fletch_ENABLE_LMDB)
+  get_system_library_name( lmdb lmdb_libname )
+
+  set( CAFFE_SEGNET_LMDB_ARGS
+    -DLMDB_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DLMDB_LIBRARIES:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${lmdb_libname}
+    )
+else()
+  set( CAFFE_SEGNET_LMDB_ARGS
+    -DLMDB_INCLUDE_DIR:PATH=${LMDB_INCLUDE_DIR}
+    -DLMDB_LIBRARIES:PATH=${LMDB_LIBRARY}
+    )
+endif()
+
+if(fletch_ENABLE_LevelDB)
+  get_system_library_name( leveldb leveldb_libname )
+  # NOTE: CaffeSegnet currently has LevelDB_INCLUDE instead of the normal LevelDB_INCLUDE_DIR
+  set( CAFFE_SEGNET_LevelDB_ARGS
+    -DLevelDB_INCLUDE:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DLevelDB_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${leveldb_libname}
+    )
+else()
+  set( CAFFE_SEGNET_LevelDB_ARGS
+    -DLevelDB_INCLUDE:PATH=${LevelDB_INCLUDE_DIR}
+    -DLevelDB_LIBRARY:PATH=${LevelDB_LIBRARY}
+    )
+endif()
+
+if(fletch_ENABLE_GLog)
+  get_system_library_name( glog glog_libname )
+
+  set( CAFFE_SEGNET_GLog_ARGS
+    -DGLOG_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DGLOG_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${glog_libname}
+    )
+else()
+  set( CAFFE_SEGNET_GLog_ARGS
+    -DGLOG_INCLUDE_DIR:PATH=${GLog_INCLUDE_DIR}
+    -DGLOG_LIBRARY:FILEPATH=${GLog_LIBRARY}
+    )
+endif()
+
+if(fletch_ENABLE_GFlags)
+  get_system_library_name( gflags gflags_libname )
+
+  set( CAFFE_SEGNET_GFlags_ARGS
+    -DGFLAGS_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DGFLAGS_LIBRARY:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${gflags_libname}
+    )
+else()
+  set( CAFFE_SEGNET_GFlags_ARGS -DGFLAGS_ROOT_DIR:PATH=${GFlags_DIR})
+endif()
+
+if(fletch_ENABLE_HDF5)
+
+  if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+
+    get_system_library_name( hdf5_debug hdf5_libname )
+    get_system_library_name( hdf5_hl_debug hdf5_hl_libname )
+    get_system_library_name( hdf5_cpp_debug hdf5_cpp_libname )
+    get_system_library_name( hdf5_hl_cpp_debug hdf5_hl_cpp_libname )
+
+
+  else()
+
+    get_system_library_name( hdf5 hdf5_libname )
+    get_system_library_name( hdf5_hl hdf5_hl_libname )
+    get_system_library_name( hdf5_cpp hdf5_cpp_libname )
+    get_system_library_name( hdf5_hl_cpp hdf5_hl_cpp_libname )
+
+  endif()
+  set( CAFFE_SEGNET_HDF5_ARGS
+    -DHDF5_INCLUDE_DIRS:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DHDF5_HL_INCLUDE_DIR:PATH=${fletch_BUILD_INSTALL_PREFIX}/include
+    -DHDF5_LIBRARIES:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_libname}
+    -DHDF5_hdf5_LIBRARY_DEBUG:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_libname}
+    -DHDF5_hdf5_LIBRARY_RELEASE:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_libname}
+    -DHDF5_hdf5_hl_LIBRARY_DEBUG:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_libname}
+    -DHDF5_hdf5_hl_LIBRARY_RELEASE:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_libname}
+    -DHDF5_HL_LIBRARIES:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_libname}
+
+    -DHDF5_CXX_LIBRARY_hdf5:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_libname}
+    -DHDF5_CXX_LIBRARY_hdf5_cpp:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_cpp_libname}
+    -DHDF5_CXX_LIBRARY_hdf5_hl:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_libname}
+    -DHDF5_CXX_LIBRARY_hdf5_hl_cpp:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_cpp_libname}
+
+    -DHDF5_C_LIBRARY_hdf5_hl:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_libname}
+    -DHDF5_C_LIBRARY_hdf5:PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/${hdf5_hl_libname}
+
+    )
+else()
+  set( CAFFE_SEGNET_HDF5_ARGS
+    -DHDF5_INCLUDE_DIRS:PATH=${HDF5_INCLUDE_DIRS}
+    -DHDF5_HL_INCLUDE_DIR:PATH=${HDF5_HL_INCLUDE_DIR}
+    -DHDF5_LIBRARIES:PATH=${HDF5_LIBRARIES}
+    -DHDF5_hdf5_LIBRARY_DEBUG:PATH=${HDF5_hdf5_LIBRARY_DEBUG}
+    -DHDF5_hdf5_LIBRARY_RELEASE:PATH=${HDF5_hdf5_LIBRARY_RELEASE}
+    -DHDF5_hdf5_hl_LIBRARY_DEBUG:PATH=${HDF5_hdf5_hl_LIBRARY_DEBUG}
+    -DHDF5_hdf5_hl_LIBRARY_RELEASE:PATH=${HDF5_hdf5_hl_LIBRARY_RELEASE}
+    -DHDF5_HL_LIBRARIES:PATH=${HDF5_HL_LIBRARIES}
+  )
+endif()
+
+if(fletch_BUILD_WITH_PYTHON AND fletch_ENABLE_Boost)
+  if(Boost_Do_BCP_Name_Mangling)
+    message(FATAL_ERROR "Cannot have Boost mangling enabled and use pycaffe.")
+  endif()
+  find_package(NumPy 1.7 REQUIRED)
+  set(PYTHON_ARGS
+      -DBUILD_python:BOOL=ON
+      -DBUILD_python_layer:BOOL=ON
+      -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+      -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
+      -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR}
+      -DNUMPY_INCLUDE_DIR=${NUMPY_INCLUDE_DIR}
+      -DNUMPY_VERSION=${NUMPY_VERSION}
+      )
+else()
+  set(PYTHON_ARGS -DBUILD_python:BOOL=OFF -DBUILD_python_layer:BOOL=OFF)
+endif()
+
+if(fletch_ENABLE_OpenBLAS)
+  get_system_library_name(openblas openblas_libname)
+  set(CAFFE_SEGNET_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_ROOT}/include"
+    "-DOpenBLAS_LIB=${OpenBLAS_ROOT}/lib/${openblas_libname}")
+else()
+  set(CAFFE_SEGNET_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_INCLUDE_DIR}"
+    "-DOpenBLAS_LIB=${OpenBLAS_LIBRARY}")
+endif()
+
+if(fletch_BUILD_WITH_CUDA)
+  format_passdowns("CUDA" CUDA_BUILD_FLAGS)
+  set( CAFFE_SEGNET_GPU_ARGS
+    ${CUDA_BUILD_FLAGS}
+    -DCPU_ONLY:BOOL=OFF
+    )
+  if(fletch_BUILD_WITH_CUDNN)
+    format_passdowns("CUDNN" CUDNN_BUILD_FLAGS)
+    set( CAFFE_SEGNET_GPU_ARGS
+      ${CAFFE_SEGNET_GPU_ARGS}
+      ${CUDNN_BUILD_FLAGS}
+      -DUSE_CUDNN:BOOL=ON
+    )
+  else()
+    set( CAFFE_SEGNET_GPU_ARGS
+      ${CAFFE_SEGNET_GPU_ARGS}
+      -DUSE_CUDNN:BOOL=OFF
+    )
+  endif()
+else()
+  set( CAFFE_SEGNET_GPU_ARGS
+    -DCPU_ONLY:BOOL=ON
+    -DUSE_CUDNN:BOOL=OFF
+    )
+endif()
+
+
+set (Caffe_Segnet_PATCH_DIR "${fletch_SOURCE_DIR}/Patches/Caffe_Segnet/${Caffe_Segnet_version}")
+if (EXISTS ${Caffe_Segnet_PATCH_DIR})
+  set(
+    Caffe_Segnet_PATCH_COMMAND ${CMAKE_COMMAND}
+    -DCaffe_Segnet_patch=${Caffe_Segnet_PATCH_DIR}
+    -DCaffe_Segnet_source=${fletch_BUILD_PREFIX}/src/Caffe_Segnet
+    -P ${Caffe_Segnet_PATCH_DIR}/Patch.cmake
+    )
+else()
+  set(Caffe_Segnet_PATCH_COMMAND "")
+endif()
+
+
+# Main build and install command
+if(WIN32)
+ExternalProject_Add(Caffe_Segnet
+  DEPENDS ${Caffe_Segnet_DEPENDS}
+  URL ${Caffe_Segnet_url}
+  URL_MD5 ${Caffe_Segnet_md5}
+  PREFIX ${fletch_BUILD_PREFIX}
+  DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
+  INSTALL_DIR ${fletch_BUILD_INSTALL_PREFIX}
+
+  PATCH_COMMAND ${Caffe_Segnet_PATCH_COMMAND}
+
+  CMAKE_COMMAND
+  CMAKE_GENERATOR ${gen}
+  CMAKE_ARGS
+    ${COMMON_CMAKE_ARGS}
+    -DCMAKE_CXX_COMPILER:PATH=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}
+    -DBOOST_ROOT:PATH=${BOOST_ROOT}
+    -DBoost_USE_STATIC_LIBS:BOOL=OFF
+    -DBLAS:STRING=Open
+    -DBUILD_SHARED_LIBS:BOOL=ON
+    -DCAFFE_FORK_SUFFIX:STRING=Segnet
+    ${CAFFE_SEGNET_OPENCV_ARGS}
+    ${PYTHON_ARGS}
+    ${CAFFE_SEGNET_GPU_ARGS}
+)
+else()
+ExternalProject_Add(Caffe_Segnet
+  DEPENDS ${Caffe_Segnet_DEPENDS}
+  URL ${Caffe_Segnet_url}
+  URL_MD5 ${Caffe_Segnet_md5}
+  PREFIX ${fletch_BUILD_PREFIX}
+  DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
+  INSTALL_DIR ${fletch_BUILD_INSTALL_PREFIX}
+
+  PATCH_COMMAND ${Caffe_Segnet_PATCH_COMMAND}
+
+  CMAKE_COMMAND
+  CMAKE_GENERATOR ${gen}
+  CMAKE_ARGS
+    ${COMMON_CMAKE_ARGS}
+    -DCMAKE_CXX_COMPILER:PATH=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}
+    -DBOOST_ROOT:PATH=${BOOST_ROOT}
+    -DBLAS:STRING=Open
+    -DCAFFE_FORK_SUFFIX:STRING=Segnet
+    ${PYTHON_ARGS}
+    ${CAFFE_SEGNET_PROTOBUF_ARGS}
+    ${CAFFE_SEGNET_OPENCV_ARGS}
+    ${CAFFE_SEGNET_LMDB_ARGS}
+    ${CAFFE_SEGNET_LevelDB_ARGS}
+    ${CAFFE_SEGNET_GLog_ARGS}
+    ${CAFFE_SEGNET_GFlags_ARGS}
+    ${CAFFE_SEGNET_HDF5_ARGS}
+    ${CAFFE_SEGNET_OPENBLAS_ARGS}
+    ${CAFFE_SEGNET_GPU_ARGS}
+  )
+endif()
+
+fletch_external_project_force_install(PACKAGE Caffe_Segnet)
+
+set(Caffe_Segnet_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+
+file(APPEND ${fletch_CONFIG_INPUT} "
+########################################
+# Caffe Segnet
+########################################
+set(Caffe_Segnet_ROOT    \${fletch_ROOT})
+")

--- a/CMake/External_Caffe_Segnet.cmake
+++ b/CMake/External_Caffe_Segnet.cmake
@@ -53,8 +53,6 @@ endfunction()
 
 # Check for dependencies.
 if(NOT WIN32) # Win32 build takes care of most dependencies automatically
-  addCaffeSegnetDendency(GFlags "")
-  addCaffeSegnetDendency(GLog "")
   addCaffeSegnetDendency(LevelDB "")
   addCaffeSegnetDendency(LMDB "")
   if(NOT APPLE)
@@ -64,6 +62,8 @@ if(NOT WIN32) # Win32 build takes care of most dependencies automatically
 endif()
 addCaffeSegnetDendency(HDF5 "") # CaffeSegnet for windows grabs its own HDF5, but we need a parallel builds so we don't break other code
 addCaffeSegnetDendency(Boost 1.46)
+addCaffeSegnetDendency(GFlags "")
+addCaffeSegnetDendency(GLog "")
 addCaffeSegnetDendency(OpenCV "")
 addCaffeSegnetDendency(ZLib "")
 

--- a/CMake/External_Caffe_Segnet.cmake
+++ b/CMake/External_Caffe_Segnet.cmake
@@ -1,3 +1,9 @@
+if (WIN32)
+  message( FATAL_ERROR "Caffe-Segnet is not yet supported on windows" )
+  return()
+endif()
+
+
 set(allOk True)
 set(errorMessage)
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -474,6 +474,19 @@ else()
 endif()
 list(APPEND fletch_external_sources Caffe)
 
+# Caffe-Segnet
+# This segnet code is based on caffe, and calls itself caffe, but much different than caffe
+if(WIN32)
+  #set(Caffe_Segnet_version "527f97c0692f116ada7cb97eed8172ef7da05416")
+  #set(Caffe_Segnet_url "https://data.kitware.com/api/v1/file/59cbedae8d777f7d33e9d9df/download/darknet-1e3a9ceb.zip")
+  #set(Caffe_Segnet_md5 "89fef1913972ec855c7b31a598c9c52f")
+else()
+  set(Caffe_Segnet_version "abcf30dca449245e101bf4ced519f716177f0885")
+  set(Caffe_Segnet_url "https://data.kitware.com/api/v1/file/59de95548d777f31ac641dbb/download/caffe-segnet-abcf30d.zip")
+  set(Caffe_Segnet_md5 "73780d2a1e9761711d4f7b806dd497ef")
+endif()
+list(APPEND fletch_external_sources Caffe_Segnet)
+
 # Darknet
 # The Darket package used is a fork maintained by kitware that uses CMake and supports building/running on windows
 set(Darknet_url "https://data.kitware.com/api/v1/file/59cbedae8d777f7d33e9d9df/download/darknet-1e3a9ceb.zip")

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -484,8 +484,10 @@ else()
   set(Caffe_Segnet_version "abcf30dca449245e101bf4ced519f716177f0885")
   set(Caffe_Segnet_url "https://data.kitware.com/api/v1/file/59de95548d777f31ac641dbb/download/caffe-segnet-abcf30d.zip")
   set(Caffe_Segnet_md5 "73780d2a1e9761711d4f7b806dd497ef")
+  
+  #Move this out when windows is supported
+  list(APPEND fletch_external_sources Caffe_Segnet)
 endif()
-list(APPEND fletch_external_sources Caffe_Segnet)
 
 # Darknet
 # The Darket package used is a fork maintained by kitware that uses CMake and supports building/running on windows

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -10,6 +10,8 @@ Updates since v1.0.0
 
 New Packages
 
+ * Added Caffe Segnet
+ 
  * Added Darknet
 
  * Added PostgreSQL

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 2.8.7)
+if(POLICY CMP0046)
+  cmake_policy(SET CMP0046 NEW)
+endif()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
+# ---[ Caffe project
+project(Caffe C CXX)
+
+# ---[ Caffe version
+set(CAFFE_TARGET_VERSION "1.0.0-rc3" CACHE STRING "Caffe logical version")
+set(CAFFE_TARGET_SOVERSION "1.0.0-rc3" CACHE STRING "Caffe soname version")
+add_definitions(-DCAFFE_VERSION=${CAFFE_TARGET_VERSION})
+
+# ---[ Using cmake scripts and modules
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+
+include(ExternalProject)
+
+include(cmake/Utils.cmake)
+include(cmake/Targets.cmake)
+include(cmake/Misc.cmake)
+include(cmake/Summary.cmake)
+include(cmake/ConfigGen.cmake)
+
+# ---[ Options
+caffe_option(CPU_ONLY  "Build Caffe without CUDA support" OFF) # TODO: rename to USE_CUDA
+caffe_option(USE_CUDNN "Build Caffe with cuDNN library support" ON IF NOT CPU_ONLY)
+caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+caffe_option(BUILD_python "Build Python wrapper" ON)
+set(python_version "2" CACHE STRING "Specify which Python version to use")
+caffe_option(BUILD_matlab "Build Matlab wrapper" OFF IF UNIX OR APPLE)
+caffe_option(BUILD_docs   "Build documentation" ON IF UNIX OR APPLE)
+caffe_option(BUILD_python_layer "Build the Caffe Python layer" ON)
+caffe_option(USE_OPENCV "Build with OpenCV support" ON)
+caffe_option(USE_LEVELDB "Build with levelDB" ON)
+caffe_option(USE_LMDB "Build with lmdb" ON)
+caffe_option(ALLOW_LMDB_NOLOCK "Allow MDB_NOLOCK when reading LMDB files (only if necessary)" OFF)
+
+# ---[ Dependencies
+include(cmake/Dependencies.cmake)
+
+# ---[ Flags
+if(UNIX OR APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
+endif()
+
+caffe_set_caffe_link()
+
+if(USE_libstdcpp)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+  message("-- Warning: forcing libstdc++ (controlled by USE_libstdcpp option in cmake)")
+endif()
+
+add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
+
+# ---[ Warnings
+caffe_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare -Wno-uninitialized)
+
+# ---[ Config generation
+configure_file(cmake/Templates/caffe_config.h.in "${PROJECT_BINARY_DIR}/caffe_config.h")
+
+# ---[ Includes
+set(Caffe_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+include_directories(${Caffe_INCLUDE_DIR} ${PROJECT_BINARY_DIR})
+include_directories(BEFORE src) # This is needed for gtest.
+
+# ---[ Subdirectories
+add_subdirectory(src/gtest)
+add_subdirectory(src/caffe)
+add_subdirectory(tools)
+add_subdirectory(examples)
+add_subdirectory(python)
+add_subdirectory(matlab)
+add_subdirectory(docs)
+
+# ---[ Linter target
+add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+# ---[ pytest target
+if(BUILD_python)
+  add_custom_target(pytest COMMAND python${python_version} -m unittest discover -s caffe/test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/python )
+  add_dependencies(pytest pycaffe)
+endif()
+
+# ---[ Configuration summary
+caffe_print_configuration_summary()
+
+# ---[ Export configs generation
+caffe_generate_export_configs()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/Patch.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/Patch.cmake
@@ -1,0 +1,11 @@
+# This patch is targeted at non-windows systems
+if(WIN32)
+  message(FATAL_ERROR "This caffe patch is only for non-windows")
+else()
+  file(COPY ${Caffe_patch}/cmake/Dependencies.cmake
+       DESTINATION ${Caffe_source}/cmake/ )
+
+  # Fixes issue where __inbinary and __insource lists were empty.
+  file(COPY ${Caffe_patch}/cmake/ConfigGen.cmake
+       DESTINATION ${Caffe_source}/cmake/ )
+endif()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/cmake/ConfigGen.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/cmake/ConfigGen.cmake
@@ -1,0 +1,123 @@
+
+################################################################################################
+# Helper function to fetch caffe includes which will be passed to dependent projects
+# Usage:
+#   caffe_get_current_includes(<includes_list_variable>)
+function(caffe_get_current_includes includes_variable)
+  get_property(current_includes DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+  caffe_convert_absolute_paths(current_includes)
+
+  # remove at most one ${PROJECT_BINARY_DIR} include added for caffe_config.h
+  list(FIND current_includes ${PROJECT_BINARY_DIR} __index)
+  list(REMOVE_AT current_includes ${__index})
+
+  # removing numpy includes (since not required for client libs)
+  set(__toremove "")
+  foreach(__i ${current_includes})
+    if(${__i} MATCHES "python")
+      list(APPEND __toremove ${__i})
+    endif()
+  endforeach()
+  if(__toremove)
+    list(REMOVE_ITEM current_includes ${__toremove})
+  endif()
+
+  caffe_list_unique(current_includes)
+  set(${includes_variable} ${current_includes} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+# Helper function to get all list items that begin with given prefix
+# Usage:
+#   caffe_get_items_with_prefix(<prefix> <list_variable> <output_variable>)
+function(caffe_get_items_with_prefix prefix list_variable output_variable)
+  set(__result "")
+  foreach(__e ${${list_variable}})
+    if(__e MATCHES "^${prefix}.*")
+      list(APPEND __result ${__e})
+    endif()
+  endforeach()
+  set(${output_variable} ${__result} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+# Function for generation Caffe build- and install- tree export config files
+# Usage:
+#  caffe_generate_export_configs()
+function(caffe_generate_export_configs)
+  set(install_cmake_suffix "share/Caffe")
+
+  # ---[ Configure build-tree CaffeConfig.cmake file ]---
+  caffe_get_current_includes(Caffe_INCLUDE_DIRS)
+
+  set(Caffe_DEFINITIONS "")
+  if(NOT HAVE_CUDA)
+    set(HAVE_CUDA FALSE)
+    list(APPEND Caffe_DEFINITIONS -DCPU_ONLY)
+  endif()
+
+  if(USE_OPENCV)
+    list(APPEND Caffe_DEFINITIONS -DUSE_OPENCV)
+  endif()
+
+  if(USE_LMDB)
+    list(APPEND Caffe_DEFINITIONS -DUSE_LMDB)
+    if (ALLOW_LMDB_NOLOCK)
+        list(APPEND Caffe_DEFINITIONS -DALLOW_LMDB_NOLOCK)
+    endif()
+  endif()
+
+  if(USE_LEVELDB)
+    list(APPEND Caffe_DEFINITIONS -DUSE_LEVELDB)
+  endif()
+
+  if(NOT HAVE_CUDNN)
+    set(HAVE_CUDNN FALSE)
+  else()
+    list(APPEND DEFINITIONS -DUSE_CUDNN)
+  endif()
+
+  if(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
+    list(APPEND Caffe_DEFINITIONS -DUSE_MKL)
+  endif()
+
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/CaffeConfig.cmake" @ONLY)
+
+  # Add targets to the build-tree export set/
+  export(TARGETS caffe proto FILE "${PROJECT_BINARY_DIR}/CaffeTargets.cmake")
+  export(PACKAGE Caffe)
+
+  # ---[ Configure install-tree CaffeConfig.cmake file ]---
+
+  # remove source and build dir includes
+  caffe_get_items_with_prefix(${PROJECT_SOURCE_DIR} Caffe_INCLUDE_DIRS __insource)
+  caffe_get_items_with_prefix(${PROJECT_BINARY_DIR} Caffe_INCLUDE_DIRS __inbinary)
+
+  # --- <BEGIN_PATCH> ---
+  list(LENGTH "${__insource} ${__inbinary}" __numremove)
+  if (__numremove GREATER 0)
+      list(REMOVE_ITEM Caffe_INCLUDE_DIRS ${__insource} ${__inbinary})
+  endif()
+  # --- <END_PATCH> ---
+
+  # add `install` include folder
+  set(lines
+     "get_filename_component(__caffe_include \"\${Caffe_CMAKE_DIR}/../../include\" ABSOLUTE)\n"
+     "list(APPEND Caffe_INCLUDE_DIRS \${__caffe_include})\n"
+     "unset(__caffe_include)\n")
+  string(REPLACE ";" "" Caffe_INSTALL_INCLUDE_DIR_APPEND_COMMAND ${lines})
+
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/cmake/CaffeConfig.cmake" @ONLY)
+
+  # Install the CaffeConfig.cmake and export set to use with install-tree
+  install(FILES "${PROJECT_BINARY_DIR}/cmake/CaffeConfig.cmake" DESTINATION ${install_cmake_suffix})
+  install(EXPORT CaffeTargets DESTINATION ${install_cmake_suffix})
+
+  # ---[ Configure and install version file ]---
+
+  # TODO: Lines below are commented because Caffe does't declare its version in headers.
+  # When the declarations are added, modify `caffe_extract_caffe_version()` macro and uncomment
+
+  # configure_file(cmake/Templates/CaffeConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/CaffeConfigVersion.cmake" @ONLY)
+  # install(FILES "${PROJECT_BINARY_DIR}/CaffeConfigVersion.cmake" DESTINATION ${install_cmake_suffix})
+endfunction()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/cmake/Dependencies.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/cmake/Dependencies.cmake
@@ -1,0 +1,172 @@
+# This list is required for static linking and exported to CaffeConfig.cmake
+set(Caffe_LINKER_LIBS "")
+
+# ---[ Boost
+find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
+include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
+
+# ---[ Threads
+find_package(Threads REQUIRED)
+list(APPEND Caffe_LINKER_LIBS ${CMAKE_THREAD_LIBS_INIT})
+
+# ---[ Google-glog
+include("cmake/External/glog.cmake")
+include_directories(SYSTEM ${GLOG_INCLUDE_DIRS})
+list(APPEND Caffe_LINKER_LIBS ${GLOG_LIBRARIES})
+
+# ---[ Google-gflags
+include("cmake/External/gflags.cmake")
+include_directories(SYSTEM ${GFLAGS_INCLUDE_DIRS})
+list(APPEND Caffe_LINKER_LIBS ${GFLAGS_LIBRARIES})
+
+# ---[ Google-protobuf
+include(cmake/ProtoBuf.cmake)
+
+# ---[ HDF5
+find_package(HDF5 COMPONENTS HL REQUIRED)
+include_directories(SYSTEM ${HDF5_INCLUDE_DIRS} ${HDF5_HL_INCLUDE_DIR})
+list(APPEND Caffe_LINKER_LIBS ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
+
+# ---[ LMDB
+if(USE_LMDB)
+  find_package(LMDB REQUIRED)
+  include_directories(SYSTEM ${LMDB_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${LMDB_LIBRARIES})
+  add_definitions(-DUSE_LMDB)
+  if(ALLOW_LMDB_NOLOCK)
+    add_definitions(-DALLOW_LMDB_NOLOCK)
+  endif()
+endif()
+
+# ---[ LevelDB
+if(USE_LEVELDB)
+  find_package(LevelDB REQUIRED)
+  include_directories(SYSTEM ${LevelDB_INCLUDE})
+  list(APPEND Caffe_LINKER_LIBS ${LevelDB_LIBRARIES})
+  add_definitions(-DUSE_LEVELDB)
+endif()
+
+# ---[ Snappy
+if(USE_LEVELDB)
+  find_package(Snappy REQUIRED)
+  include_directories(SYSTEM ${Snappy_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${Snappy_LIBRARIES})
+endif()
+
+# ---[ CUDA
+include(cmake/Cuda.cmake)
+if(NOT HAVE_CUDA)
+  if(CPU_ONLY)
+    message(STATUS "-- CUDA is disabled. Building without it...")
+  else()
+    message(WARNING "-- CUDA is not detected by cmake. Building without it...")
+  endif()
+
+  # TODO: remove this not cross platform define in future. Use caffe_config.h instead.
+  add_definitions(-DCPU_ONLY)
+endif()
+
+# ---[ OpenCV
+if(USE_OPENCV)
+  find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
+  if(NOT OpenCV_FOUND) # if not OpenCV 3.x, then imgcodecs are not found
+    find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc)
+  endif()
+  include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
+  list(APPEND Caffe_LINKER_LIBS ${OpenCV_LIBS})
+  message(STATUS "OpenCV found (${OpenCV_CONFIG_PATH})")
+  add_definitions(-DUSE_OPENCV)
+endif()
+
+# ---[ BLAS
+if(NOT APPLE)
+  set(BLAS "Atlas" CACHE STRING "Selected BLAS library")
+  set_property(CACHE BLAS PROPERTY STRINGS "Atlas;Open;MKL")
+
+  if(BLAS STREQUAL "Atlas" OR BLAS STREQUAL "atlas")
+    find_package(Atlas REQUIRED)
+    include_directories(SYSTEM ${Atlas_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${Atlas_LIBRARIES})
+  elseif(BLAS STREQUAL "Open" OR BLAS STREQUAL "open")
+    find_package(OpenBLAS REQUIRED)
+    include_directories(SYSTEM ${OpenBLAS_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${OpenBLAS_LIB})
+  elseif(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
+    find_package(MKL REQUIRED)
+    include_directories(SYSTEM ${MKL_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${MKL_LIBRARIES})
+    add_definitions(-DUSE_MKL)
+  endif()
+elseif(APPLE)
+  find_package(vecLib REQUIRED)
+  include_directories(SYSTEM ${vecLib_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${vecLib_LINKER_LIBS})
+endif()
+
+# ---[ Python
+if(BUILD_python)
+  if(NOT "${python_version}" VERSION_LESS "3.0.0")
+    # use python3
+    find_package(PythonInterp 3.0)
+    find_package(PythonLibs 3.0)
+    find_package(NumPy 1.7.1)
+    # Find the matching boost python implementation
+    set(version ${PYTHONLIBS_VERSION_STRING})
+
+    STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+    find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+    set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+    while(NOT "${version}" STREQUAL "" AND NOT Boost_PYTHON_FOUND)
+      STRING( REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version ${version} )
+
+      STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+      find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+      set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+      STRING( REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version ${version} )
+      if("${has_more_version}" STREQUAL "")
+        break()
+      endif()
+    endwhile()
+    if(NOT Boost_PYTHON_FOUND)
+      find_package(Boost 1.46 COMPONENTS python)
+    endif()
+  else()
+    # disable Python 3 search
+    find_package(PythonInterp 2.7)
+    find_package(PythonLibs 2.7)
+    find_package(NumPy 1.7.1)
+    find_package(Boost 1.46 COMPONENTS python)
+  endif()
+  if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND Boost_PYTHON_FOUND)
+    set(HAVE_PYTHON TRUE)
+    if(BUILD_python_layer)
+      add_definitions(-DWITH_PYTHON_LAYER)
+      include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+      list(APPEND Caffe_LINKER_LIBS ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+    endif()
+  endif()
+endif()
+
+# ---[ Matlab
+if(BUILD_matlab)
+  find_package(MatlabMex)
+  if(MATLABMEX_FOUND)
+    set(HAVE_MATLAB TRUE)
+  endif()
+
+  # sudo apt-get install liboctave-dev
+  find_program(Octave_compiler NAMES mkoctfile DOC "Octave C++ compiler")
+
+  if(HAVE_MATLAB AND Octave_compiler)
+    set(Matlab_build_mex_using "Matlab" CACHE STRING "Select Matlab or Octave if both detected")
+    set_property(CACHE Matlab_build_mex_using PROPERTY STRINGS "Matlab;Octave")
+  endif()
+endif()
+
+# ---[ Doxygen
+if(BUILD_docs)
+  find_package(Doxygen)
+endif()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/docs/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/docs/CMakeLists.txt
@@ -1,0 +1,106 @@
+# Building docs script
+# Requirements:
+#   sudo apt-get install doxygen texlive ruby-dev
+#   sudo gem install jekyll execjs therubyracer
+
+if(NOT BUILD_docs OR NOT DOXYGEN_FOUND)
+  return()
+endif()
+
+#################################################################################################
+# Gather docs from <root>/examples/**/readme.md
+function(gather_readmes_as_prebuild_cmd target gathered_dir root)
+  set(full_gathered_dir ${root}/${gathered_dir})
+
+  file(GLOB_RECURSE readmes ${root}/examples/readme.md ${root}/examples/README.md)
+  foreach(file ${readmes})
+    # Only use file if it is to be included in docs.
+    file(STRINGS ${file} file_lines REGEX "include_in_docs: true")
+
+    if(file_lines)
+      # Since everything is called readme.md, rename it by its dirname.
+      file(RELATIVE_PATH file ${root} ${file})
+      get_filename_component(folder ${file} PATH)
+      set(new_filename ${full_gathered_dir}/${folder}.md)
+
+      # folder value might be like <subfolder>/readme.md. That's why make directory.
+      get_filename_component(new_folder ${new_filename} PATH)
+      add_custom_command(TARGET ${target} PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${new_folder}
+        COMMAND ln -sf ${root}/${file} ${new_filename}
+        COMMENT "Creating symlink ${new_filename} -> ${root}/${file}"
+        WORKING_DIRECTORY ${root} VERBATIM)
+    endif()
+  endforeach()
+endfunction()
+
+################################################################################################
+# Gather docs from examples/*.ipynb and add YAML front-matter.
+function(gather_notebooks_as_prebuild_cmd target gathered_dir root)
+  set(full_gathered_dir ${root}/${gathered_dir})
+
+  if(NOT PYTHON_EXECUTABLE)
+    message(STATUS "Python interpeter is not found. Can't include *.ipynb files in docs. Skipping...")
+    return()
+  endif()
+
+  file(GLOB_RECURSE notebooks ${root}/examples/*.ipynb)
+  foreach(file ${notebooks})
+    file(RELATIVE_PATH file ${root} ${file})
+    set(new_filename ${full_gathered_dir}/${file})
+
+    get_filename_component(new_folder ${new_filename} PATH)
+    add_custom_command(TARGET ${target} PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${new_folder}
+      COMMAND ${PYTHON_EXECUTABLE} scripts/copy_notebook.py ${file} ${new_filename}
+      COMMENT "Copying notebook ${file} to ${new_filename}"
+      WORKING_DIRECTORY ${root} VERBATIM)
+  endforeach()
+
+  set(${outputs_var} ${outputs} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+########################## [ Non macro part ] ##################################################
+
+# Gathering is done at each 'make doc'
+file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/docs/gathered)
+
+# Doxygen config file path
+set(DOXYGEN_config_file ${PROJECT_SOURCE_DIR}/.Doxyfile CACHE FILEPATH "Doxygen config file")
+
+# Adding docs target
+add_custom_target(docs COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_config_file}
+                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                       COMMENT "Launching doxygen..." VERBATIM)
+
+# Gathering examples into docs subfolder
+gather_notebooks_as_prebuild_cmd(docs docs/gathered ${PROJECT_SOURCE_DIR})
+gather_readmes_as_prebuild_cmd(docs docs/gathered  ${PROJECT_SOURCE_DIR})
+
+# Auto detect output directory
+file(STRINGS ${DOXYGEN_config_file} config_line REGEX "OUTPUT_DIRECTORY[ \t]+=[^=].*")
+if(config_line)
+  string(REGEX MATCH "OUTPUT_DIRECTORY[ \t]+=([^=].*)" __ver_check "${config_line}")
+  string(STRIP ${CMAKE_MATCH_1} output_dir)
+  message(STATUS "Detected Doxygen OUTPUT_DIRECTORY: ${output_dir}")
+else()
+  set(output_dir ./doxygen/)
+  message(STATUS "Can't find OUTPUT_DIRECTORY in doxygen config file. Try to use default: ${output_dir}")
+endif()
+
+if(NOT IS_ABSOLUTE ${output_dir})
+  set(output_dir ${PROJECT_SOURCE_DIR}/${output_dir})
+  get_filename_component(output_dir ${output_dir} ABSOLUTE)
+endif()
+
+# creates symlink in docs subfolder to code documentation built by doxygen
+add_custom_command(TARGET docs POST_BUILD VERBATIM
+                   COMMAND ln -sfn "${output_dir}/html" doxygen
+                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+                   COMMENT "Creating symlink ${PROJECT_SOURCE_DIR}/docs/doxygen -> ${output_dir}/html")
+
+# for quick launch of jekyll
+add_custom_target(jekyll COMMAND jekyll serve -w -s . -d _site --port=4000
+                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+                         COMMENT "Launching jekyll..." VERBATIM)

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/examples/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/examples/CMakeLists.txt
@@ -1,0 +1,31 @@
+file(GLOB_RECURSE examples_srcs "${PROJECT_SOURCE_DIR}/examples/*.cpp")
+
+foreach(source_file ${examples_srcs})
+  # get file name
+  get_filename_component(name ${source_file} NAME_WE)
+    
+  # get folder name
+  get_filename_component(path ${source_file} PATH)
+  get_filename_component(folder ${path} NAME_WE)
+    
+  add_executable(${name} ${source_file})
+  target_link_libraries(${name} ${Caffe_LINK})
+  caffe_default_properties(${name})
+
+  # set back RUNTIME_OUTPUT_DIRECTORY
+  set_target_properties(${name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/examples/${folder}")
+
+  caffe_set_solution_folder(${name} examples)
+
+  # install
+  install(TARGETS ${name} DESTINATION bin)
+
+  if(UNIX OR APPLE)
+    # Funny command to make tutorials work
+    # TODO: remove in future as soon as naming is standartaized everywhere
+    set(__outname ${PROJECT_BINARY_DIR}/examples/${folder}/${name}${Caffe_POSTFIX})
+    add_custom_command(TARGET ${name} POST_BUILD
+                       COMMAND ln -sf "${__outname}" "${__outname}.bin")
+  endif()
+endforeach()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/matlab/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/matlab/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Builds Matlab (or Octave) interface. In case of Matlab caffe must be
+# compield as shared library. Octave can link static or shared caffe library
+# To install octave run: sudo apt-get install liboctave-dev
+
+if(NOT BUILD_matlab)
+  return()
+endif()
+
+if(HAVE_MATLAB AND Octave_compiler)
+  set(build_using ${Matlab_build_mex_using})
+elseif(HAVE_MATLAB AND NOT Octave_compiler)
+  set(build_using "Matlab")
+elseif(NOT HAVE_MATLAB AND Octave_compiler)
+  set(build_using "Octave")
+else()
+  return()
+endif()
+
+if(NOT BUILD_SHARED_LIBS AND build_using MATCHES Matlab)
+  message(FATAL_ERROR "Matlab MEX interface (with default mex options file) can only be built if caffe is compiled as shared library. Please enable 'BUILD_SHARED_LIBS' in CMake. Aternativelly you can switch to Octave compiler.")
+endif()
+
+# helper function to set proper mex file extension
+function(caffe_fetch_and_set_proper_mexext mexfile_variable)
+  execute_process(COMMAND ${Matlab_mexext} OUTPUT_STRIP_TRAILING_WHITESPACE RESULT_VARIABLE res OUTPUT_VARIABLE ext)
+  if(res MATCHES 0)
+    get_filename_component(folder  ${${mexfile_variable}} PATH)
+    get_filename_component(name_we ${${mexfile_variable}} NAME_WE)
+    set(${mexfile_variable} ${folder}/${name_we}.${ext} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# global settings
+file(GLOB Matlab_srcs +caffe/private/caffe_.cpp)
+set(Matlab_caffe_mex ${PROJECT_SOURCE_DIR}/matlab/+caffe/private/caffe_.mex)
+
+caffe_get_current_cflags(cflags)
+caffe_parse_linker_libs(Caffe_LINKER_LIBS folders libflags macos_frameworks)
+set(folders $<TARGET_LINKER_FILE_DIR:caffe> ${folders})
+
+# prepare linker flag lists
+string(REPLACE ";" ";-L" link_folders "-L${folders}")
+string(REPLACE ";" ":"  rpath_folders   "${folders}")
+
+if(build_using MATCHES "Matlab")
+  set(libflags -lcaffe${Caffe_POSTFIX} ${libflags}) # Matlab R2014a complans for -Wl,--whole-archive
+
+  caffe_fetch_and_set_proper_mexext(Matlab_caffe_mex)
+  add_custom_command(OUTPUT ${Matlab_caffe_mex} COMMAND ${Matlab_mex}
+      ARGS -output ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${libflags}
+      DEPENDS caffe COMMENT "Building Matlab interface: ${Matlab_caffe_mex}" VERBATIM)
+  add_custom_target(matlab ALL DEPENDS ${Matlab_caffe_mex} SOURCES ${Matlab_srcs})
+
+elseif(build_using MATCHES "Octave")
+
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(libflags -Wl,-force_load,$<TARGET_LINKER_FILE:caffe> ${libflags})
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(libflags -Wl,--whole-archive -lcaffe${Caffe_POSTFIX} -Wl,--no-whole-archive ${libflags})
+  endif()
+
+  add_custom_command(OUTPUT ${Matlab_caffe_mex} COMMAND ${Octave_compiler}
+      ARGS --mex -o ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${libflags} -Wl,-rpath,${rpath_folders}
+      DEPENDS caffe COMMENT "Building Octave interface: ${Matlab_caffe_mex}" VERBATIM)
+
+  add_custom_target(octave ALL DEPENDS ${Matlab_caffe_mex} SOURCES ${Matlab_srcs})
+endif()
+
+# ---[ Install
+file(GLOB mfiles caffe/*.m)
+install(FILES ${mfiles} ${Matlab_caffe_mex} DESTINATION matlab)
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/python/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/python/CMakeLists.txt
@@ -1,0 +1,40 @@
+if(NOT HAVE_PYTHON)
+  message(STATUS "Python interface is disabled or not all required dependencies found. Building without it...")
+  return()
+endif()
+
+include_directories(${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+file(GLOB_RECURSE python_srcs ${PROJECT_SOURCE_DIR}/python/*.cpp)
+
+add_library(pycaffe SHARED ${python_srcs})
+target_link_libraries(pycaffe ${Caffe_LINK} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+set_target_properties(pycaffe PROPERTIES PREFIX "" OUTPUT_NAME "_caffe")
+caffe_default_properties(pycaffe)
+
+if(UNIX OR APPLE)
+    set(__linkname "${PROJECT_SOURCE_DIR}/python/caffe/_caffe.so")
+    add_custom_command(TARGET pycaffe POST_BUILD
+                       COMMAND ln -sf $<TARGET_LINKER_FILE:pycaffe> "${__linkname}"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/python/caffe/proto
+                       COMMAND touch ${PROJECT_SOURCE_DIR}/python/caffe/proto/__init__.py
+                       COMMAND cp ${proto_gen_folder}/*.py ${PROJECT_SOURCE_DIR}/python/caffe/proto/
+                       COMMENT "Creating symlink ${__linkname} -> ${PROJECT_BINARY_DIR}/lib/_caffe${Caffe_POSTFIX}.so")
+endif()
+
+# ---[ Install
+# scripts
+file(GLOB python_files *.py requirements.txt)
+install(FILES ${python_files} DESTINATION python)
+
+# module
+install(DIRECTORY caffe
+    DESTINATION python
+    FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "ilsvrc_2012_mean.npy"
+    PATTERN "test" EXCLUDE
+    )
+
+# _caffe.so
+install(TARGETS pycaffe  DESTINATION python/caffe)
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/src/caffe/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/src/caffe/CMakeLists.txt
@@ -1,0 +1,40 @@
+# generate protobuf sources
+file(GLOB proto_files proto/*.proto)
+caffe_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto_python ${proto_files})
+
+# include python files either to force generation
+add_library(proto STATIC ${proto_hdrs} ${proto_srcs} ${proto_python})
+set(Caffe_LINKER_LIBS proto ${Caffe_LINKER_LIBS}) # note, crucial to prepend!
+caffe_default_properties(proto)
+
+# --[ Caffe library
+
+# creates 'test_srcs', 'srcs', 'test_cuda', 'cuda' lists
+caffe_pickup_caffe_sources(${PROJECT_SOURCE_DIR})
+
+if(HAVE_CUDA)
+  caffe_cuda_compile(cuda_objs ${cuda})
+  list(APPEND srcs ${cuda_objs} ${cuda})
+endif()
+
+add_library(caffe ${srcs})
+target_link_libraries(caffe proto ${Caffe_LINKER_LIBS})
+caffe_default_properties(caffe)
+set_target_properties(caffe PROPERTIES
+    VERSION   ${CAFFE_TARGET_VERSION}
+    SOVERSION ${CAFFE_TARGET_SOVERSION}
+    )
+
+# ---[ Tests
+ add_subdirectory(test)
+
+# ---[ Install
+install(DIRECTORY ${Caffe_INCLUDE_DIR}/caffe DESTINATION include)
+install(FILES ${proto_hdrs} DESTINATION include/caffe/proto)
+install(TARGETS caffe proto EXPORT CaffeTargets DESTINATION lib)
+
+file(WRITE ${PROJECT_BINARY_DIR}/__init__.py)
+list(APPEND proto_python ${PROJECT_BINARY_DIR}/__init__.py)
+install(PROGRAMS ${proto_python} DESTINATION python/caffe/proto)
+
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/src/gtest/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/src/gtest/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(gtest STATIC EXCLUDE_FROM_ALL gtest.h gtest-all.cpp)
+caffe_default_properties(gtest)
+
+#add_library(gtest_main gtest_main.cc)
+#target_link_libraries(gtest_main gtest)

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/tools/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885 (copy)/tools/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Collect source files
+file(GLOB_RECURSE srcs ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Build each source file independently
+foreach(source ${srcs})
+  get_filename_component(name ${source} NAME_WE)
+
+  # caffe target already exits
+  if(name MATCHES "caffe")
+    set(name ${name}.bin)
+  endif()
+
+  # target
+  add_executable(${name} ${source})
+  target_link_libraries(${name} ${Caffe_LINK})
+  caffe_default_properties(${name})
+
+  # set back RUNTIME_OUTPUT_DIRECTORY
+  caffe_set_runtime_directory(${name} "${PROJECT_BINARY_DIR}/tools")
+  caffe_set_solution_folder(${name} tools)
+
+  # restore output name without suffix
+  if(name MATCHES "caffe.bin")
+    set_target_properties(${name} PROPERTIES OUTPUT_NAME caffe)
+  endif()
+
+  # Install
+  install(TARGETS ${name} DESTINATION bin)
+endforeach(source)

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 2.8.7)
+if(POLICY CMP0046)
+  cmake_policy(SET CMP0046 NEW)
+endif()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
+set (CAFFE_FORK_SUFFIX "" CACHE STRING "A name that will cmake postfix to all targets and install paths allowing multiple caffe forks to be build side by side")
+if(CAFFE_FORK_SUFFIX)
+  set(projName "Caffe_${CAFFE_FORK_SUFFIX}")
+  string(TOLOWER ${projName} tgtName)
+else()
+  set(projName "Caffe")
+  set(tgtName "caffe")
+endif()
+
+message(STATUS "Project Name : ${projName}")
+message(STATUS "Target Name : ${tgtName}")
+
+# ---[ Caffe project
+project(${projName} C CXX)
+
+# ---[ Caffe version
+set(CAFFE_TARGET_VERSION "1.0.0-rc3" CACHE STRING "${projName} logical version")
+set(CAFFE_TARGET_SOVERSION "1.0.0-rc3" CACHE STRING "${projName} soname version")
+add_definitions(-DCAFFE_VERSION=${CAFFE_TARGET_VERSION})
+
+# ---[ Using cmake scripts and modules
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+
+include(ExternalProject)
+
+include(cmake/Utils.cmake)
+include(cmake/Targets.cmake)
+include(cmake/Misc.cmake)
+include(cmake/Summary.cmake)
+include(cmake/ConfigGen.cmake)
+
+# ---[ Options
+caffe_option(USE_CUDA  "Build without CUDA support" OFF)
+caffe_option(USE_CUDNN "Build with cuDNN library support" ON IF NOT CPU_ONLY)
+caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+caffe_option(BUILD_python "Build Python wrapper" ON)
+set(python_version "2" CACHE STRING "Specify which Python version to use")
+caffe_option(BUILD_tests "Build tests" OFF IF UNIX OR APPLE)
+caffe_option(BUILD_examples "Build examples" OFF IF UNIX OR APPLE)
+caffe_option(BUILD_matlab "Build Matlab wrapper" OFF IF UNIX OR APPLE)
+caffe_option(BUILD_docs   "Build documentation" OFF IF UNIX OR APPLE)
+caffe_option(BUILD_python_layer "Build the Caffe Python layer" ON)
+caffe_option(USE_OPENCV "Build with OpenCV support" ON)
+caffe_option(USE_LEVELDB "Build with levelDB" ON)
+caffe_option(USE_LMDB "Build with lmdb" ON)
+caffe_option(ALLOW_LMDB_NOLOCK "Allow MDB_NOLOCK when reading LMDB files (only if necessary)" OFF)
+
+# ---[ Dependencies
+include(cmake/Dependencies.cmake)
+
+# ---[ Flags
+if(UNIX OR APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
+endif()
+
+caffe_set_caffe_link()
+
+if(USE_libstdcpp)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+  message("-- Warning: forcing libstdc++ (controlled by USE_libstdcpp option in cmake)")
+endif()
+
+add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
+
+# ---[ Warnings
+caffe_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare -Wno-uninitialized)
+
+# ---[ Config generation
+configure_file(cmake/Templates/caffe_config.h.in "${PROJECT_BINARY_DIR}/caffe_config.h")
+
+# ---[ Includes
+set(Caffe_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+include_directories(${Caffe_INCLUDE_DIR} ${PROJECT_BINARY_DIR})
+include_directories(BEFORE src) # This is needed for gtest.
+
+# ---[ Subdirectories
+add_subdirectory(src/gtest)
+add_subdirectory(src/caffe)
+add_subdirectory(tools)
+add_subdirectory(examples)
+add_subdirectory(python)
+add_subdirectory(matlab)
+add_subdirectory(docs)
+
+# ---[ Linter target
+add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+# ---[ pytest target
+if(BUILD_python)
+  add_custom_target(pytest COMMAND python${python_version} -m unittest discover -s caffe/test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/python )
+  add_dependencies(pytest py${tgtName})
+endif()
+
+# ---[ Configuration summary
+caffe_print_configuration_summary()
+
+# ---[ Export configs generation
+caffe_generate_export_configs()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
@@ -1,0 +1,42 @@
+# This patch is targeted at non-windows systems
+if(WIN32)
+  message(FATAL_ERROR "This caffe patch is only for non-windows")
+else()
+  file(COPY ${Caffe_Segnet_patch}/cmake/Dependencies.cmake
+       DESTINATION ${Caffe_Segnet_source}/cmake/ )
+
+# These files use the fork name in targets and installation locations
+
+  # Fixes issue where __inbinary and __insource lists were empty.
+  file(COPY ${Caffe_Segnet_patch}/cmake/ConfigGen.cmake
+       DESTINATION ${Caffe_Segnet_source}/cmake/ )
+
+  file(COPY ${Caffe_Segnet_patch}/cmake/Targets.cmake
+       DESTINATION ${Caffe_Segnet_source}/cmake/ )
+
+  file(COPY ${Caffe_Segnet_patch}/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/ )
+
+  file(COPY ${Caffe_Segnet_patch}/docs/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/docs/ )
+
+  file(COPY ${Caffe_Segnet_patch}/examples/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/examples/ )
+
+  file(COPY ${Caffe_Segnet_patch}/matlab/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/matlab/ )
+
+  file(COPY ${Caffe_Segnet_patch}/python/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/python/ )
+
+  file(COPY ${Caffe_Segnet_patch}/src/caffe/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/src/caffe/ )
+
+  file(COPY ${Caffe_Segnet_patch}/src/gtest/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/src/gtest/ )
+
+  file(COPY ${Caffe_Segnet_patch}/tools/CMakeLists.txt
+       DESTINATION ${Caffe_Segnet_source}/tools/ )
+
+  
+endif()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/ConfigGen.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/ConfigGen.cmake
@@ -1,0 +1,123 @@
+
+################################################################################################
+# Helper function to fetch caffe includes which will be passed to dependent projects
+# Usage:
+#   caffe_get_current_includes(<includes_list_variable>)
+function(caffe_get_current_includes includes_variable)
+  get_property(current_includes DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+  caffe_convert_absolute_paths(current_includes)
+
+  # remove at most one ${PROJECT_BINARY_DIR} include added for caffe_config.h
+  list(FIND current_includes ${PROJECT_BINARY_DIR} __index)
+  list(REMOVE_AT current_includes ${__index})
+
+  # removing numpy includes (since not required for client libs)
+  set(__toremove "")
+  foreach(__i ${current_includes})
+    if(${__i} MATCHES "python")
+      list(APPEND __toremove ${__i})
+    endif()
+  endforeach()
+  if(__toremove)
+    list(REMOVE_ITEM current_includes ${__toremove})
+  endif()
+
+  caffe_list_unique(current_includes)
+  set(${includes_variable} ${current_includes} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+# Helper function to get all list items that begin with given prefix
+# Usage:
+#   caffe_get_items_with_prefix(<prefix> <list_variable> <output_variable>)
+function(caffe_get_items_with_prefix prefix list_variable output_variable)
+  set(__result "")
+  foreach(__e ${${list_variable}})
+    if(__e MATCHES "^${prefix}.*")
+      list(APPEND __result ${__e})
+    endif()
+  endforeach()
+  set(${output_variable} ${__result} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+# Function for generation Caffe build- and install- tree export config files
+# Usage:
+#  caffe_generate_export_configs()
+function(caffe_generate_export_configs)
+  set(install_cmake_suffix "share/${projName}")
+
+  # ---[ Configure build-tree CaffeConfig.cmake file ]---
+  caffe_get_current_includes(Caffe_INCLUDE_DIRS)
+
+  set(Caffe_DEFINITIONS "")
+  if(NOT HAVE_CUDA)
+    set(HAVE_CUDA FALSE)
+    list(APPEND Caffe_DEFINITIONS -DCPU_ONLY)
+  endif()
+
+  if(USE_OPENCV)
+    list(APPEND Caffe_DEFINITIONS -DUSE_OPENCV)
+  endif()
+
+  if(USE_LMDB)
+    list(APPEND Caffe_DEFINITIONS -DUSE_LMDB)
+    if (ALLOW_LMDB_NOLOCK)
+        list(APPEND Caffe_DEFINITIONS -DALLOW_LMDB_NOLOCK)
+    endif()
+  endif()
+
+  if(USE_LEVELDB)
+    list(APPEND Caffe_DEFINITIONS -DUSE_LEVELDB)
+  endif()
+
+  if(NOT HAVE_CUDNN)
+    set(HAVE_CUDNN FALSE)
+  else()
+    list(APPEND DEFINITIONS -DUSE_CUDNN)
+  endif()
+
+  if(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
+    list(APPEND Caffe_DEFINITIONS -DUSE_MKL)
+  endif()
+
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/${projName}Config.cmake" @ONLY)
+
+  # Add targets to the build-tree export set/
+  export(TARGETS ${tgtName} proto FILE "${PROJECT_BINARY_DIR}/${projName}Targets.cmake")
+  export(PACKAGE ${projName})
+
+  # ---[ Configure install-tree CaffeConfig.cmake file ]---
+
+  # remove source and build dir includes
+  caffe_get_items_with_prefix(${PROJECT_SOURCE_DIR} Caffe_INCLUDE_DIRS __insource)
+  caffe_get_items_with_prefix(${PROJECT_BINARY_DIR} Caffe_INCLUDE_DIRS __inbinary)
+
+  # --- <BEGIN_PATCH> ---
+  list(LENGTH "${__insource} ${__inbinary}" __numremove)
+  if (__numremove GREATER 0)
+      list(REMOVE_ITEM Caffe_INCLUDE_DIRS ${__insource} ${__inbinary})
+  endif()
+  # --- <END_PATCH> ---
+
+  # add `install` include folder
+  set(lines
+     "get_filename_component(__caffe_include \"\${Caffe_CMAKE_DIR}/../../include\" ABSOLUTE)\n"
+     "list(APPEND Caffe_INCLUDE_DIRS \${__caffe_include})\n"
+     "unset(__caffe_include)\n")
+  string(REPLACE ";" "" Caffe_INSTALL_INCLUDE_DIR_APPEND_COMMAND ${lines})
+
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/cmake/${projName}Config.cmake" @ONLY)
+
+  # Install the CaffeConfig.cmake and export set to use with install-tree
+  install(FILES "${PROJECT_BINARY_DIR}/cmake/${projName}Config.cmake" DESTINATION ${install_cmake_suffix})
+  install(EXPORT ${projName}Targets DESTINATION ${install_cmake_suffix})
+
+  # ---[ Configure and install version file ]---
+
+  # TODO: Lines below are commented because Caffe does't declare its version in headers.
+  # When the declarations are added, modify `caffe_extract_caffe_version()` macro and uncomment
+
+  # configure_file(cmake/Templates/CaffeConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/${projName}ConfigVersion.cmake" @ONLY)
+  # install(FILES "${PROJECT_BINARY_DIR}/CaffeConfigVersion.cmake" DESTINATION ${install_cmake_suffix})
+endfunction()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Dependencies.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Dependencies.cmake
@@ -1,0 +1,172 @@
+# This list is required for static linking and exported to CaffeConfig.cmake
+set(Caffe_LINKER_LIBS "")
+
+# ---[ Boost
+find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
+include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
+
+# ---[ Threads
+find_package(Threads REQUIRED)
+list(APPEND Caffe_LINKER_LIBS ${CMAKE_THREAD_LIBS_INIT})
+
+# ---[ Google-glog
+include("cmake/External/glog.cmake")
+include_directories(SYSTEM ${GLOG_INCLUDE_DIRS})
+list(APPEND Caffe_LINKER_LIBS ${GLOG_LIBRARIES})
+
+# ---[ Google-gflags
+include("cmake/External/gflags.cmake")
+include_directories(SYSTEM ${GFLAGS_INCLUDE_DIRS})
+list(APPEND Caffe_LINKER_LIBS ${GFLAGS_LIBRARIES})
+
+# ---[ Google-protobuf
+include(cmake/ProtoBuf.cmake)
+
+# ---[ HDF5
+find_package(HDF5 COMPONENTS HL REQUIRED)
+include_directories(SYSTEM ${HDF5_INCLUDE_DIRS} ${HDF5_HL_INCLUDE_DIR})
+list(APPEND Caffe_LINKER_LIBS ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
+
+# ---[ LMDB
+if(USE_LMDB)
+  find_package(LMDB REQUIRED)
+  include_directories(SYSTEM ${LMDB_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${LMDB_LIBRARIES})
+  add_definitions(-DUSE_LMDB)
+  if(ALLOW_LMDB_NOLOCK)
+    add_definitions(-DALLOW_LMDB_NOLOCK)
+  endif()
+endif()
+
+# ---[ LevelDB
+if(USE_LEVELDB)
+  find_package(LevelDB REQUIRED)
+  include_directories(SYSTEM ${LevelDB_INCLUDE})
+  list(APPEND Caffe_LINKER_LIBS ${LevelDB_LIBRARIES})
+  add_definitions(-DUSE_LEVELDB)
+endif()
+
+# ---[ Snappy
+if(USE_LEVELDB)
+  find_package(Snappy REQUIRED)
+  include_directories(SYSTEM ${Snappy_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${Snappy_LIBRARIES})
+endif()
+
+# ---[ CUDA
+include(cmake/Cuda.cmake)
+if(NOT HAVE_CUDA)
+  if(CPU_ONLY)
+    message(STATUS "-- CUDA is disabled. Building without it...")
+  else()
+    message(WARNING "-- CUDA is not detected by cmake. Building without it...")
+  endif()
+
+  # TODO: remove this not cross platform define in future. Use caffe_config.h instead.
+  add_definitions(-DCPU_ONLY)
+endif()
+
+# ---[ OpenCV
+if(USE_OPENCV)
+  find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
+  if(NOT OpenCV_FOUND) # if not OpenCV 3.x, then imgcodecs are not found
+    find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc)
+  endif()
+  include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
+  list(APPEND Caffe_LINKER_LIBS ${OpenCV_LIBS})
+  message(STATUS "OpenCV found (${OpenCV_CONFIG_PATH})")
+  add_definitions(-DUSE_OPENCV)
+endif()
+
+# ---[ BLAS
+if(NOT APPLE)
+  set(BLAS "Atlas" CACHE STRING "Selected BLAS library")
+  set_property(CACHE BLAS PROPERTY STRINGS "Atlas;Open;MKL")
+
+  if(BLAS STREQUAL "Atlas" OR BLAS STREQUAL "atlas")
+    find_package(Atlas REQUIRED)
+    include_directories(SYSTEM ${Atlas_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${Atlas_LIBRARIES})
+  elseif(BLAS STREQUAL "Open" OR BLAS STREQUAL "open")
+    find_package(OpenBLAS REQUIRED)
+    include_directories(SYSTEM ${OpenBLAS_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${OpenBLAS_LIB})
+  elseif(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
+    find_package(MKL REQUIRED)
+    include_directories(SYSTEM ${MKL_INCLUDE_DIR})
+    list(APPEND Caffe_LINKER_LIBS ${MKL_LIBRARIES})
+    add_definitions(-DUSE_MKL)
+  endif()
+elseif(APPLE)
+  find_package(vecLib REQUIRED)
+  include_directories(SYSTEM ${vecLib_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${vecLib_LINKER_LIBS})
+endif()
+
+# ---[ Python
+if(BUILD_python)
+  if(NOT "${python_version}" VERSION_LESS "3.0.0")
+    # use python3
+    find_package(PythonInterp 3.0)
+    find_package(PythonLibs 3.0)
+    find_package(NumPy 1.7.1)
+    # Find the matching boost python implementation
+    set(version ${PYTHONLIBS_VERSION_STRING})
+
+    STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+    find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+    set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+    while(NOT "${version}" STREQUAL "" AND NOT Boost_PYTHON_FOUND)
+      STRING( REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version ${version} )
+
+      STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+      find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+      set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+      STRING( REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version ${version} )
+      if("${has_more_version}" STREQUAL "")
+        break()
+      endif()
+    endwhile()
+    if(NOT Boost_PYTHON_FOUND)
+      find_package(Boost 1.46 COMPONENTS python)
+    endif()
+  else()
+    # disable Python 3 search
+    find_package(PythonInterp 2.7)
+    find_package(PythonLibs 2.7)
+    find_package(NumPy 1.7.1)
+    find_package(Boost 1.46 COMPONENTS python)
+  endif()
+  if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND Boost_PYTHON_FOUND)
+    set(HAVE_PYTHON TRUE)
+    if(BUILD_python_layer)
+      add_definitions(-DWITH_PYTHON_LAYER)
+      include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+      list(APPEND Caffe_LINKER_LIBS ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+    endif()
+  endif()
+endif()
+
+# ---[ Matlab
+if(BUILD_matlab)
+  find_package(MatlabMex)
+  if(MATLABMEX_FOUND)
+    set(HAVE_MATLAB TRUE)
+  endif()
+
+  # sudo apt-get install liboctave-dev
+  find_program(Octave_compiler NAMES mkoctfile DOC "Octave C++ compiler")
+
+  if(HAVE_MATLAB AND Octave_compiler)
+    set(Matlab_build_mex_using "Matlab" CACHE STRING "Select Matlab or Octave if both detected")
+    set_property(CACHE Matlab_build_mex_using PROPERTY STRINGS "Matlab;Octave")
+  endif()
+endif()
+
+# ---[ Doxygen
+if(BUILD_docs)
+  find_package(Doxygen)
+endif()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Targets.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Targets.cmake
@@ -1,0 +1,174 @@
+################################################################################################
+# Defines global Caffe_LINK flag, This flag is required to prevent linker from excluding
+# some objects which are not addressed directly but are registered via static constructors
+macro(caffe_set_caffe_link)
+  if(BUILD_SHARED_LIBS)
+    set(Caffe_LINK ${tgtName})
+  else()
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      set(Caffe_LINK -Wl,-force_load ${tgtName})
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      set(Caffe_LINK -Wl,--whole-archive ${tgtName} -Wl,--no-whole-archive)
+    endif()
+  endif()
+endmacro()
+################################################################################################
+# Convenient command to setup source group for IDEs that support this feature (VS, XCode)
+# Usage:
+#   caffe_source_group(<group> GLOB[_RECURSE] <globbing_expression>)
+function(caffe_source_group group)
+  cmake_parse_arguments(CAFFE_SOURCE_GROUP "" "" "GLOB;GLOB_RECURSE" ${ARGN})
+  if(CAFFE_SOURCE_GROUP_GLOB)
+    file(GLOB srcs1 ${CAFFE_SOURCE_GROUP_GLOB})
+    source_group(${group} FILES ${srcs1})
+  endif()
+
+  if(CAFFE_SOURCE_GROUP_GLOB_RECURSE)
+    file(GLOB_RECURSE srcs2 ${CAFFE_SOURCE_GROUP_GLOB_RECURSE})
+    source_group(${group} FILES ${srcs2})
+  endif()
+endfunction()
+
+################################################################################################
+# Collecting sources from globbing and appending to output list variable
+# Usage:
+#   caffe_collect_sources(<output_variable> GLOB[_RECURSE] <globbing_expression>)
+function(caffe_collect_sources variable)
+  cmake_parse_arguments(CAFFE_COLLECT_SOURCES "" "" "GLOB;GLOB_RECURSE" ${ARGN})
+  if(CAFFE_COLLECT_SOURCES_GLOB)
+    file(GLOB srcs1 ${CAFFE_COLLECT_SOURCES_GLOB})
+    set(${variable} ${variable} ${srcs1})
+  endif()
+
+  if(CAFFE_COLLECT_SOURCES_GLOB_RECURSE)
+    file(GLOB_RECURSE srcs2 ${CAFFE_COLLECT_SOURCES_GLOB_RECURSE})
+    set(${variable} ${variable} ${srcs2})
+  endif()
+endfunction()
+
+################################################################################################
+# Short command getting caffe sources (assuming standard Caffe code tree)
+# Usage:
+#   caffe_pickup_caffe_sources(<root>)
+function(caffe_pickup_caffe_sources root)
+  # put all files in source groups (visible as subfolder in many IDEs)
+  caffe_source_group("Include"        GLOB "${root}/include/caffe/*.h*")
+  caffe_source_group("Include\\Util"  GLOB "${root}/include/caffe/util/*.h*")
+  caffe_source_group("Include"        GLOB "${PROJECT_BINARY_DIR}/caffe_config.h*")
+  caffe_source_group("Source"         GLOB "${root}/src/caffe/*.cpp")
+  caffe_source_group("Source\\Util"   GLOB "${root}/src/caffe/util/*.cpp")
+  caffe_source_group("Source\\Layers" GLOB "${root}/src/caffe/layers/*.cpp")
+  caffe_source_group("Source\\Cuda"   GLOB "${root}/src/caffe/layers/*.cu")
+  caffe_source_group("Source\\Cuda"   GLOB "${root}/src/caffe/util/*.cu")
+  caffe_source_group("Source\\Proto"  GLOB "${root}/src/caffe/proto/*.proto")
+
+  # source groups for test target
+  caffe_source_group("Include"      GLOB "${root}/include/caffe/test/test_*.h*")
+  caffe_source_group("Source"       GLOB "${root}/src/caffe/test/test_*.cpp")
+  caffe_source_group("Source\\Cuda" GLOB "${root}/src/caffe/test/test_*.cu")
+
+  # collect files
+  file(GLOB test_hdrs    ${root}/include/caffe/test/test_*.h*)
+  file(GLOB test_srcs    ${root}/src/caffe/test/test_*.cpp)
+  file(GLOB_RECURSE hdrs ${root}/include/caffe/*.h*)
+  file(GLOB_RECURSE srcs ${root}/src/caffe/*.cpp)
+  list(REMOVE_ITEM  hdrs ${test_hdrs})
+  list(REMOVE_ITEM  srcs ${test_srcs})
+
+  # adding headers to make the visible in some IDEs (Qt, VS, Xcode)
+  list(APPEND srcs ${hdrs} ${PROJECT_BINARY_DIR}/caffe_config.h)
+  list(APPEND test_srcs ${test_hdrs})
+
+  # collect cuda files
+  file(GLOB    test_cuda ${root}/src/caffe/test/test_*.cu)
+  file(GLOB_RECURSE cuda ${root}/src/caffe/*.cu)
+  list(REMOVE_ITEM  cuda ${test_cuda})
+
+  # add proto to make them editable in IDEs too
+  file(GLOB_RECURSE proto_files ${root}/src/caffe/*.proto)
+  list(APPEND srcs ${proto_files})
+
+  # convet to absolute paths
+  caffe_convert_absolute_paths(srcs)
+  caffe_convert_absolute_paths(cuda)
+  caffe_convert_absolute_paths(test_srcs)
+  caffe_convert_absolute_paths(test_cuda)
+
+  # propagate to parent scope
+  set(srcs ${srcs} PARENT_SCOPE)
+  set(cuda ${cuda} PARENT_SCOPE)
+  set(test_srcs ${test_srcs} PARENT_SCOPE)
+  set(test_cuda ${test_cuda} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+# Short command for setting defeault target properties
+# Usage:
+#   caffe_default_properties(<target>)
+function(caffe_default_properties target)
+  set_target_properties(${target} PROPERTIES
+    DEBUG_POSTFIX ${Caffe_DEBUG_POSTFIX}
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+  # make sure we build all external depepdencies first
+  if (DEFINED external_project_dependencies)
+    add_dependencies(${target} ${external_project_dependencies})
+  endif()
+endfunction()
+
+################################################################################################
+# Short command for setting runtime directory for build target
+# Usage:
+#   caffe_set_runtime_directory(<target> <dir>)
+function(caffe_set_runtime_directory target dir)
+  set_target_properties(${target} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${dir}")
+endfunction()
+
+################################################################################################
+# Short command for setting solution folder property for target
+# Usage:
+#   caffe_set_solution_folder(<target> <folder>)
+function(caffe_set_solution_folder target folder)
+  if(USE_PROJECT_FOLDERS)
+    set_target_properties(${target} PROPERTIES FOLDER "${folder}")
+  endif()
+endfunction()
+
+################################################################################################
+# Reads lines from input file, prepends source directory to each line and writes to output file
+# Usage:
+#   caffe_configure_testdatafile(<testdatafile>)
+function(caffe_configure_testdatafile file)
+  file(STRINGS ${file} __lines)
+  set(result "")
+  foreach(line ${__lines})
+    set(result "${result}${PROJECT_SOURCE_DIR}/${line}\n")
+  endforeach()
+  file(WRITE ${file}.gen.cmake ${result})
+endfunction()
+
+################################################################################################
+# Filter out all files that are not included in selected list
+# Usage:
+#   caffe_leave_only_selected_tests(<filelist_variable> <selected_list>)
+function(caffe_leave_only_selected_tests file_list)
+  if(NOT ARGN)
+    return() # blank list means leave all
+  endif()
+  string(REPLACE "," ";" __selected ${ARGN})
+  list(APPEND __selected caffe_main)
+
+  set(result "")
+  foreach(f ${${file_list}})
+    get_filename_component(name ${f} NAME_WE)
+    string(REGEX REPLACE "^test_" "" name ${name})
+    list(FIND __selected ${name} __index)
+    if(NOT __index EQUAL -1)
+      list(APPEND result ${f})
+    endif()
+  endforeach()
+  set(${file_list} ${result} PARENT_SCOPE)
+endfunction()
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/docs/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/docs/CMakeLists.txt
@@ -1,0 +1,106 @@
+# Building docs script
+# Requirements:
+#   sudo apt-get install doxygen texlive ruby-dev
+#   sudo gem install jekyll execjs therubyracer
+
+if(NOT BUILD_docs OR NOT DOXYGEN_FOUND)
+  return()
+endif()
+
+#################################################################################################
+# Gather docs from <root>/examples/**/readme.md
+function(gather_readmes_as_prebuild_cmd target gathered_dir root)
+  set(full_gathered_dir ${root}/${gathered_dir})
+
+  file(GLOB_RECURSE readmes ${root}/examples/readme.md ${root}/examples/README.md)
+  foreach(file ${readmes})
+    # Only use file if it is to be included in docs.
+    file(STRINGS ${file} file_lines REGEX "include_in_docs: true")
+
+    if(file_lines)
+      # Since everything is called readme.md, rename it by its dirname.
+      file(RELATIVE_PATH file ${root} ${file})
+      get_filename_component(folder ${file} PATH)
+      set(new_filename ${full_gathered_dir}/${folder}.md)
+
+      # folder value might be like <subfolder>/readme.md. That's why make directory.
+      get_filename_component(new_folder ${new_filename} PATH)
+      add_custom_command(TARGET ${target} PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${new_folder}
+        COMMAND ln -sf ${root}/${file} ${new_filename}
+        COMMENT "Creating symlink ${new_filename} -> ${root}/${file}"
+        WORKING_DIRECTORY ${root} VERBATIM)
+    endif()
+  endforeach()
+endfunction()
+
+################################################################################################
+# Gather docs from examples/*.ipynb and add YAML front-matter.
+function(gather_notebooks_as_prebuild_cmd target gathered_dir root)
+  set(full_gathered_dir ${root}/${gathered_dir})
+
+  if(NOT PYTHON_EXECUTABLE)
+    message(STATUS "Python interpeter is not found. Can't include *.ipynb files in docs. Skipping...")
+    return()
+  endif()
+
+  file(GLOB_RECURSE notebooks ${root}/examples/*.ipynb)
+  foreach(file ${notebooks})
+    file(RELATIVE_PATH file ${root} ${file})
+    set(new_filename ${full_gathered_dir}/${file})
+
+    get_filename_component(new_folder ${new_filename} PATH)
+    add_custom_command(TARGET ${target} PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${new_folder}
+      COMMAND ${PYTHON_EXECUTABLE} scripts/copy_notebook.py ${file} ${new_filename}
+      COMMENT "Copying notebook ${file} to ${new_filename}"
+      WORKING_DIRECTORY ${root} VERBATIM)
+  endforeach()
+
+  set(${outputs_var} ${outputs} PARENT_SCOPE)
+endfunction()
+
+################################################################################################
+########################## [ Non macro part ] ##################################################
+
+# Gathering is done at each 'make doc'
+file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/docs/gathered)
+
+# Doxygen config file path
+set(DOXYGEN_config_file ${PROJECT_SOURCE_DIR}/.Doxyfile CACHE FILEPATH "Doxygen config file")
+
+# Adding docs target
+add_custom_target(docs COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_config_file}
+                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                       COMMENT "Launching doxygen..." VERBATIM)
+
+# Gathering examples into docs subfolder
+gather_notebooks_as_prebuild_cmd(docs docs/gathered ${PROJECT_SOURCE_DIR})
+gather_readmes_as_prebuild_cmd(docs docs/gathered  ${PROJECT_SOURCE_DIR})
+
+# Auto detect output directory
+file(STRINGS ${DOXYGEN_config_file} config_line REGEX "OUTPUT_DIRECTORY[ \t]+=[^=].*")
+if(config_line)
+  string(REGEX MATCH "OUTPUT_DIRECTORY[ \t]+=([^=].*)" __ver_check "${config_line}")
+  string(STRIP ${CMAKE_MATCH_1} output_dir)
+  message(STATUS "Detected Doxygen OUTPUT_DIRECTORY: ${output_dir}")
+else()
+  set(output_dir ./doxygen/)
+  message(STATUS "Can't find OUTPUT_DIRECTORY in doxygen config file. Try to use default: ${output_dir}")
+endif()
+
+if(NOT IS_ABSOLUTE ${output_dir})
+  set(output_dir ${PROJECT_SOURCE_DIR}/${output_dir})
+  get_filename_component(output_dir ${output_dir} ABSOLUTE)
+endif()
+
+# creates symlink in docs subfolder to code documentation built by doxygen
+add_custom_command(TARGET docs POST_BUILD VERBATIM
+                   COMMAND ln -sfn "${output_dir}/html" doxygen
+                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+                   COMMENT "Creating symlink ${PROJECT_SOURCE_DIR}/docs/doxygen -> ${output_dir}/html")
+
+# for quick launch of jekyll
+add_custom_target(jekyll COMMAND jekyll serve -w -s . -d _site --port=4000
+                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+                         COMMENT "Launching jekyll..." VERBATIM)

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/examples/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/examples/CMakeLists.txt
@@ -1,0 +1,36 @@
+if(NOT BUILD_examples)
+  return()
+endif()
+
+file(GLOB_RECURSE examples_srcs "${PROJECT_SOURCE_DIR}/examples/*.cpp")
+
+foreach(source_file ${examples_srcs})
+  # get file name
+  get_filename_component(name ${source_file} NAME_WE)
+  set(name ${tgtName}_${name})
+    
+  # get folder name
+  get_filename_component(path ${source_file} PATH)
+  get_filename_component(folder ${path} NAME_WE)
+    
+  add_executable(${name} ${source_file})
+  target_link_libraries(${name} ${Caffe_LINK})
+  caffe_default_properties(${name})
+
+  # set back RUNTIME_OUTPUT_DIRECTORY
+  set_target_properties(${name} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/examples/${folder}")
+
+  caffe_set_solution_folder(${name} examples)
+
+  # install
+  install(TARGETS ${name} DESTINATION bin)
+
+  if(UNIX OR APPLE)
+    # Funny command to make tutorials work
+    # TODO: remove in future as soon as naming is standartaized everywhere
+    set(__outname ${PROJECT_BINARY_DIR}/examples/${folder}/${name}${Caffe_POSTFIX})
+    add_custom_command(TARGET ${name} POST_BUILD
+                       COMMAND ln -sf "${__outname}" "${__outname}.bin")
+  endif()
+endforeach()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/matlab/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/matlab/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Builds Matlab (or Octave) interface. In case of Matlab caffe must be
+# compield as shared library. Octave can link static or shared caffe library
+# To install octave run: sudo apt-get install liboctave-dev
+
+if(NOT BUILD_matlab)
+  return()
+endif()
+
+if(HAVE_MATLAB AND Octave_compiler)
+  set(build_using ${Matlab_build_mex_using})
+elseif(HAVE_MATLAB AND NOT Octave_compiler)
+  set(build_using "Matlab")
+elseif(NOT HAVE_MATLAB AND Octave_compiler)
+  set(build_using "Octave")
+else()
+  return()
+endif()
+
+if(NOT BUILD_SHARED_LIBS AND build_using MATCHES Matlab)
+  message(FATAL_ERROR "Matlab MEX interface (with default mex options file) can only be built if caffe is compiled as shared library. Please enable 'BUILD_SHARED_LIBS' in CMake. Aternativelly you can switch to Octave compiler.")
+endif()
+
+# helper function to set proper mex file extension
+function(caffe_fetch_and_set_proper_mexext mexfile_variable)
+  execute_process(COMMAND ${Matlab_mexext} OUTPUT_STRIP_TRAILING_WHITESPACE RESULT_VARIABLE res OUTPUT_VARIABLE ext)
+  if(res MATCHES 0)
+    get_filename_component(folder  ${${mexfile_variable}} PATH)
+    get_filename_component(name_we ${${mexfile_variable}} NAME_WE)
+    set(${mexfile_variable} ${folder}/${name_we}.${ext} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# global settings
+file(GLOB Matlab_srcs +caffe/private/caffe_.cpp)
+set(Matlab_caffe_mex ${PROJECT_SOURCE_DIR}/matlab/+caffe/private/caffe_.mex)
+
+caffe_get_current_cflags(cflags)
+caffe_parse_linker_libs(Caffe_LINKER_LIBS folders libflags macos_frameworks)
+set(folders $<TARGET_LINKER_FILE_DIR:${tgtName}> ${folders})
+
+# prepare linker flag lists
+string(REPLACE ";" ";-L" link_folders "-L${folders}")
+string(REPLACE ";" ":"  rpath_folders   "${folders}")
+
+if(build_using MATCHES "Matlab")
+  set(libflags -l${tgtName}${Caffe_POSTFIX} ${libflags}) # Matlab R2014a complans for -Wl,--whole-archive
+
+  caffe_fetch_and_set_proper_mexext(Matlab_caffe_mex)
+  add_custom_command(OUTPUT ${Matlab_caffe_mex} COMMAND ${Matlab_mex}
+      ARGS -output ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${libflags}
+      DEPENDS ${tgtName} COMMENT "Building Matlab interface: ${Matlab_caffe_mex}" VERBATIM)
+  add_custom_target(matlab ALL DEPENDS ${Matlab_caffe_mex} SOURCES ${Matlab_srcs})
+
+elseif(build_using MATCHES "Octave")
+
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(libflags -Wl,-force_load,$<TARGET_LINKER_FILE:${tgtName}> ${libflags})
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(libflags -Wl,--whole-archive -l${tgtName}${Caffe_POSTFIX} -Wl,--no-whole-archive ${libflags})
+  endif()
+
+  add_custom_command(OUTPUT ${Matlab_caffe_mex} COMMAND ${Octave_compiler}
+      ARGS --mex -o ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${libflags} -Wl,-rpath,${rpath_folders}
+      DEPENDS ${tgtName} COMMENT "Building Octave interface: ${Matlab_caffe_mex}" VERBATIM)
+
+  add_custom_target(octave ALL DEPENDS ${Matlab_caffe_mex} SOURCES ${Matlab_srcs})
+endif()
+
+# ---[ Install
+file(GLOB mfiles caffe/*.m)
+install(FILES ${mfiles} ${Matlab_caffe_mex} DESTINATION matlab)
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/python/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/python/CMakeLists.txt
@@ -1,0 +1,40 @@
+if(NOT HAVE_PYTHON)
+  message(STATUS "Python interface is disabled or not all required dependencies found. Building without it...")
+  return()
+endif()
+
+include_directories(${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+file(GLOB_RECURSE python_srcs ${PROJECT_SOURCE_DIR}/python/*.cpp)
+
+add_library(py${tgtName} SHARED ${python_srcs})
+target_link_libraries(py${tgtName} ${Caffe_LINK} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+set_target_properties(py${tgtName} PROPERTIES PREFIX "" OUTPUT_NAME "_${tgtName}")
+caffe_default_properties(py${tgtName})
+
+if(UNIX OR APPLE)
+    set(__linkname "${PROJECT_SOURCE_DIR}/python/${tgtName}/_${tgtName}.so")
+    add_custom_command(TARGET py${tgtName} POST_BUILD
+                       COMMAND ln -sf $<TARGET_LINKER_FILE:py${tgtName}> "${__linkname}"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/python/${tgtName}/proto
+                       COMMAND touch ${PROJECT_SOURCE_DIR}/python/${tgtName}/proto/__init__.py
+                       COMMAND cp ${proto_gen_folder}/*.py ${PROJECT_SOURCE_DIR}/python/${tgtName}/proto/
+                       COMMENT "Creating symlink ${__linkname} -> ${PROJECT_BINARY_DIR}/lib/_${tgtName}${Caffe_POSTFIX}.so")
+endif()
+
+# ---[ Install
+# scripts
+file(GLOB python_files *.py requirements.txt)
+install(FILES ${python_files} DESTINATION python)
+
+# module
+install(DIRECTORY ${tgtName}
+    DESTINATION python
+    FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "ilsvrc_2012_mean.npy"
+    PATTERN "test" EXCLUDE
+    )
+
+# _caffe.so
+install(TARGETS py${tgtName}  DESTINATION python/${tgtName})
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/src/caffe/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/src/caffe/CMakeLists.txt
@@ -1,0 +1,40 @@
+# generate protobuf sources
+file(GLOB proto_files proto/*.proto)
+caffe_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto_python ${proto_files})
+
+# include python files either to force generation
+add_library(proto STATIC ${proto_hdrs} ${proto_srcs} ${proto_python})
+set(Caffe_LINKER_LIBS proto ${Caffe_LINKER_LIBS}) # note, crucial to prepend!
+caffe_default_properties(proto)
+
+# --[ Caffe library
+
+# creates 'test_srcs', 'srcs', 'test_cuda', 'cuda' lists
+caffe_pickup_caffe_sources(${PROJECT_SOURCE_DIR})
+
+if(HAVE_CUDA)
+  caffe_cuda_compile(cuda_objs ${cuda})
+  list(APPEND srcs ${cuda_objs} ${cuda})
+endif()
+
+add_library(${tgtName} ${srcs})
+target_link_libraries(${tgtName} proto ${Caffe_LINKER_LIBS})
+caffe_default_properties(${tgtName})
+set_target_properties(${tgtName} PROPERTIES
+    VERSION   ${CAFFE_TARGET_VERSION}
+    SOVERSION ${CAFFE_TARGET_SOVERSION}
+    )
+
+# ---[ Tests
+ add_subdirectory(test)
+
+# ---[ Install
+install(DIRECTORY ${Caffe_INCLUDE_DIR}/caffe/ DESTINATION include/${tgtName})
+install(FILES ${proto_hdrs} DESTINATION include/${tgtName}/proto)
+install(TARGETS ${tgtName} proto EXPORT ${projName}Targets DESTINATION lib)
+
+file(WRITE ${PROJECT_BINARY_DIR}/__init__.py)
+list(APPEND proto_python ${PROJECT_BINARY_DIR}/__init__.py)
+install(PROGRAMS ${proto_python} DESTINATION python/${tgtName}/proto)
+
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/src/gtest/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/src/gtest/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(NOT BUILD_tests)
+  return()
+endif()
+
+add_library(${tgtName}_gtest STATIC EXCLUDE_FROM_ALL gtest.h gtest-all.cpp)
+caffe_default_properties(${tgtName}_gtest)
+

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/tools/CMakeLists.txt
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/tools/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Collect source files
+file(GLOB_RECURSE srcs ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Build each source file independently
+foreach(source ${srcs})
+  get_filename_component(name ${source} NAME_WE)
+
+  # caffe target already exits
+  if(name MATCHES "caffe")
+    set(name ${tgtName}.bin)
+  else()
+    set(name ${tgtName}_${name})
+  endif()
+
+  # target
+  add_executable(${name} ${source})
+  target_link_libraries(${name} ${Caffe_LINK})
+  caffe_default_properties(${name})
+
+  # set back RUNTIME_OUTPUT_DIRECTORY
+  caffe_set_runtime_directory(${name} "${PROJECT_BINARY_DIR}/tools")
+  caffe_set_solution_folder(${name} tools)
+
+  # restore output name without suffix
+  if(name MATCHES "${tgtName}.bin")
+    set_target_properties(${name} PROPERTIES OUTPUT_NAME ${tgtName})
+  endif()
+
+  # Install
+  install(TARGETS ${name} DESTINATION bin)
+endforeach(source)


### PR DESCRIPTION
I added a zip for this repository to girder : https://github.com/TimoSaemann/caffe-segnet-cudnn5
(Note that maybe out of date due to : https://github.com/TimoSaemann/ENet)

Anyway
What cool in this PR, is the patch, while all the caffe cmake files, allows you to uniquely identify your caffe fork when you do an external_project_add, provide a fork name (ex. -DCAFFE_FORK_SUFFIX:STRING=Segnet)
And the cmake patch files will post fix this to all the targets, configurations, install directories, etc. that it creates.
For this Segnet fork of caffe, it will create/install to the following:
fletch/install/headers/caffe_segnet
libraries and example binaries named : caffe_segnet
the cmake configuration name is updated to Caffe_SegnetConfig.cmake

Of course this will not work if the CMake files are changed, but these cmake files glob up source and headers, so I do not think they are likely to change frequently, and between forks. But we can patch if they do. 

I think we can use these cmake files in our kwiver/caffe fork and name it something like caffe_kw, so if somebody wants to use a different caffe fork, they don't have to name change theirs, theirs would make a regular default named 'caffe' binary, library, header, configuration in fletch.

Food for thought.