### PR TITLE
Ceres requires Suitesparse with requires lapack (on ubuntu 16)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ On Linux systems, Install the following packages before building Fletch::
   sudo apt-get install build-essential libgl1-mesa-dev
   sudo apt-get install libexpat1-dev
   sudo apt-get install libgtk2.0-dev
+  sudo apt-get install liblapack-dev
 
 Fletch uses CMake (www.cmake.org) for easy cross-platform compilation. The
 minimum required version of CMake is 2.8.12, but newer versions are strongly


### PR DESCRIPTION
I needed to do this to get fletch build on a clean linux