### PR TITLE
Fixed issue where pybind11 did not inherit python version from fletch

### DIFF
--- a/CMake/External_PyBind11.cmake
+++ b/CMake/External_PyBind11.cmake
@@ -13,6 +13,10 @@ ExternalProject_Add(PyBind11
   CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
     -DPYBIND11_TEST:BOOL=OFF # To remove dependencies; build can still be tested manually
+    -DPYBIND11_PYTHON_VERSION=${fletch_PYTHON_MAJOR_VERSION}
+    -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+    -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
+    -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR}
   )
 
 fletch_external_project_force_install(PACKAGE PyBind11)


### PR DESCRIPTION
I encountered an issue where something seemed to be linking to python3 even when I had built fletch with python2. I found that pybind11 had python3 variables in its CMakeCache, and then found that fletch did not pass down its python environment to pybind11. This patch fixes that. 