### PR TITLE
Geotiff force fletch proj4

### DIFF
--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -26,6 +26,10 @@ else()
   list(APPEND libgeotiff_pkg_args -DWITH_JPEG:BOOL=OFF)
 endif()
 
+if (NOT fletch_ENABLE_PROJ4)
+  message(FATAL " You must enable PROJ4 from fletch to build libgeotiff. There are issues with the system version")
+endif()
+
 # Proj4
 add_package_dependency(
   PACKAGE libgeotiff

--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -34,6 +34,7 @@ endif()
 add_package_dependency(
   PACKAGE libgeotiff
   PACKAGE_DEPENDENCY PROJ4
+  OPTIONAL
 )
 
 # libgeotiff_WITH_* means it was either enabled or found. Dsicover which below.


### PR DESCRIPTION
Make the add_package_dependency of PROJ4 optional.

The system version seems to have issues on several linux distributions. Libraries are missing symbols which makes it  impossible for geotiff to link.
 
We are making the add_package_dependency optional to avoid the confusing error message about using the system version. We can safely make this call optional since we have the fatal error before it which forces enabling proj4.
