### PR TITLE
New version of darknet

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -491,8 +491,8 @@ endif()
 
 # Darknet
 # The Darket package used is a fork maintained by kitware that uses CMake and supports building/running on windows
-set(Darknet_url "https://data.kitware.com/api/v1/file/59cbedae8d777f7d33e9d9df/download/darknet-1e3a9ceb.zip")
-set(Darknet_md5 "89fef1913972ec855c7b31a598c9c52f")
+set(Darknet_url "https://data.kitware.com/api/v1/file/59fb6e718d777f31ac6480fa/download/darknet-678f60dd.zip")
+set(Darknet_md5 "ee8e66b65914ee375a258b338b1a786a")
 list(APPEND fletch_external_sources Darknet)
 
 # PyBind11


### PR DESCRIPTION
This version will produce a proper DarknetConfig.cmake file that points to fletch install for includes/libs
Previously it pointed to the fletch darknet build directory, which does not exist in an install only fletch

After the builds, check the <fletch_DIR>/install/CMake/DarknetConfig.cmake and ensure you see 

set( Darknet_INCLUDE_DIR "<fletch_DIR>/install/include/darknet")
set( Darknet_LIBRARY_DIR "<fletch_DIR>/install/lib" )