### PR TITLE
Dev/update eigen

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -148,9 +148,9 @@ if(_FFmpeg_supported)
 endif()
 
 # EIGEN
-set(Eigen_version 3.2.9)
+set(Eigen_version 3.3.4)
 set(Eigen_url "http://bitbucket.org/eigen/eigen/get/${Eigen_version}.tar.gz")
-set(Eigen_md5 "6a578dba42d1c578d531ab5b6fa3f741")
+set(Eigen_md5 "1a47e78efe365a97de0c022d127607c3")
 set(Eigen_dlname "eigen-${Eigen_version}.tar.gz")
 list(APPEND fletch_external_sources Eigen)
 

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -32,6 +32,8 @@ New Packages
 
 Package Upgrades
 
+ * Upgrade Eigen to version 3.3.4
+
  * Upgrade libgeotiff to version 1.4.2
 
  * Upgrade GLog to version 0.3.5


### PR DESCRIPTION
Caffe2 needs Eigen at least version `3.3`, this upgrades to support that. 