### PR TITLE
Dev/fix opencv gotoblas

### DIFF
--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -230,14 +230,8 @@ else()
   set(PYTHON_ARGS -DBUILD_python:BOOL=OFF -DBUILD_python_layer:BOOL=OFF)
 endif()
 
-if(fletch_ENABLE_OpenBLAS)
-  get_system_library_name(openblas openblas_libname)
-  set(CAFFE_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_ROOT}/include"
-    "-DOpenBLAS_LIB=${OpenBLAS_ROOT}/lib/${openblas_libname}")
-else()
-  set(CAFFE_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_INCLUDE_DIR}"
-    "-DOpenBLAS_LIB=${OpenBLAS_LIBRARY}")
-endif()
+set(CAFFE_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_INCLUDE_DIR}"
+  "-DOpenBLAS_LIB=${OpenBLAS_LIB}")
 
 if(fletch_BUILD_WITH_CUDA)
   format_passdowns("CUDA" CUDA_BUILD_FLAGS)

--- a/CMake/External_Caffe_Segnet.cmake
+++ b/CMake/External_Caffe_Segnet.cmake
@@ -235,14 +235,8 @@ else()
   set(PYTHON_ARGS -DBUILD_python:BOOL=OFF -DBUILD_python_layer:BOOL=OFF)
 endif()
 
-if(fletch_ENABLE_OpenBLAS)
-  get_system_library_name(openblas openblas_libname)
-  set(CAFFE_SEGNET_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_ROOT}/include"
-    "-DOpenBLAS_LIB=${OpenBLAS_ROOT}/lib/${openblas_libname}")
-else()
-  set(CAFFE_SEGNET_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_INCLUDE_DIR}"
-    "-DOpenBLAS_LIB=${OpenBLAS_LIBRARY}")
-endif()
+set(CAFFE_SEGNET_OPENBLAS_ARGS "-DOpenBLAS_INCLUDE_DIR=${OpenBLAS_INCLUDE_DIR}"
+  "-DOpenBLAS_LIB=${OpenBLAS_LIB}")
 
 if(fletch_BUILD_WITH_CUDA)
   format_passdowns("CUDA" CUDA_BUILD_FLAGS)

--- a/CMake/External_OpenBLAS.cmake
+++ b/CMake/External_OpenBLAS.cmake
@@ -44,11 +44,20 @@ endif()
 
 fletch_external_project_force_install(PACKAGE OpenBLAS)
 
+
 set(OpenBLAS_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+
+# Find the OpenBLAS library name that will be passed to OpenCV / Caffe / etc..
+# Note: the lib does not exist yet, but we can be pretty sure what it will be
+get_system_library_name(openblas openblas_libname)
+set(OpenBLAS_LIB "${OpenBLAS_ROOT}/lib/${openblas_libname}")
+set(OpenBLAS_INCLUDE_DIR "${OpenBLAS_ROOT}/include")
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # OpenBLAS
 ########################################
 set(OpenBLAS_ROOT    \${fletch_ROOT})
+set(OpenBLAS_LIB     \${OpenBLAS_LIB})
+set(OpenBLAS_INCLUDE_DIR \${OpenBLAS_INCLUDE_DIR})
 ")

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -86,11 +86,15 @@ if(fletch_ENABLE_OpenBLAS)
   if (NOT OpenCV_version VERSION_LESS 3.2.0)
     message(STATUS "OpenCV depending on fletch OpenBLAS")
     set(_OpenCV_ENABLE_OPENBLAS_DEFAULT TRUE)
-    #list(APPEND OpenCV_DEPENDS OpenBLAS)  # complains that this target doesnt exist. Does it?
+    list(APPEND OpenCV_DEPENDS OpenBLAS)
     list(APPEND OpenCV_EXTRA_BUILD_FLAGS
-      -DWITH_LAPACK:BOOL=FALSE  # workaround for undefined referenec to `gotoblas`
+      # FIXME: If LAPACK is on, opencv_traincascade fails to link.
+      # The error is: liblapack.so - undefined reference to `gotoblas`.
+      # note: the problem may be multiple cblas.h
+      # A temporary workaround is to turn LAPACK off.
+      -DWITH_LAPACK:BOOL=FALSE
       -DOpenBLAS_INCLUDE_DIR:PATH="${OpenBLAS_ROOT}/include"
-      -DOpenBLAS_LIB:PATH="${OpenBLAS_ROOT}/lib/${openblas_libname}"
+      #-DOpenBLAS_LIB:PATH="${OpenBLAS_ROOT}/lib/${openblas_libname}"
       )
   endif()
 endif()

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -83,8 +83,7 @@ endif()
 
 
 if(fletch_ENABLE_OpenBLAS)
-  if (OpenCV_version VERSION_LESS 3.2.0)
-  else()
+  if (NOT OpenCV_version VERSION_LESS 3.2.0)
     message(STATUS "OpenCV depending on fletch OpenBLAS")
     set(_OpenCV_ENABLE_OPENBLAS_DEFAULT TRUE)
     #list(APPEND OpenCV_DEPENDS OpenBLAS)  # complains that this target doesnt exist. Does it?

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -82,6 +82,22 @@ else()
 endif()
 
 
+if(fletch_ENABLE_OpenBLAS)
+  if (OpenCV_version VERSION_LESS 3.2.0)
+  else()
+    message(STATUS "OpenCV depending on fletch OpenBLAS")
+    set(_OpenCV_ENABLE_OPENBLAS_DEFAULT TRUE)
+    #list(APPEND OpenCV_DEPENDS OpenBLAS)  # complains that this target doesnt exist. Does it?
+    list(APPEND OpenCV_EXTRA_BUILD_FLAGS
+      -DWITH_LAPACK:BOOL=FALSE  # workaround for undefined referenec to `gotoblas`
+      -DOPENCV_ENABLE_LAPACK:BOOL=FALSE  # workaround for undefined referenec to `gotoblas`
+      -DOpenBLAS_INCLUDE_DIR:PATH="${OpenBLAS_ROOT}/include"
+      -DOpenBLAS_LIB:PATH="${OpenBLAS_ROOT}/lib/${openblas_libname}"
+      )
+  endif()
+endif()
+
+
 # Handle GPU disable flag
 if(fletch_ENABLE_OpenCV_CUDA)
   format_passdowns("CUDA" CUDA_BUILD_FLAGS)

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -93,8 +93,8 @@ if(fletch_ENABLE_OpenBLAS)
       # note: the problem may be multiple cblas.h
       # A temporary workaround is to turn LAPACK off.
       -DWITH_LAPACK:BOOL=FALSE
-      -DOpenBLAS_INCLUDE_DIR:PATH="${OpenBLAS_ROOT}/include"
-      #-DOpenBLAS_LIB:PATH="${OpenBLAS_ROOT}/lib/${openblas_libname}"
+      -DOpenBLAS_INCLUDE_DIR:PATH="${OpenBLAS_INCLUDE_DIR}"
+      -DOpenBLAS_LIB:PATH="${OpenBLAS_LIB}"
       )
   endif()
 endif()

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -90,7 +90,6 @@ if(fletch_ENABLE_OpenBLAS)
     #list(APPEND OpenCV_DEPENDS OpenBLAS)  # complains that this target doesnt exist. Does it?
     list(APPEND OpenCV_EXTRA_BUILD_FLAGS
       -DWITH_LAPACK:BOOL=FALSE  # workaround for undefined referenec to `gotoblas`
-      -DOPENCV_ENABLE_LAPACK:BOOL=FALSE  # workaround for undefined referenec to `gotoblas`
       -DOpenBLAS_INCLUDE_DIR:PATH="${OpenBLAS_ROOT}/include"
       -DOpenBLAS_LIB:PATH="${OpenBLAS_ROOT}/lib/${openblas_libname}"
       )

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -156,17 +156,9 @@ list(APPEND fletch_external_sources Eigen)
 
 #OpenBLAS
 if(NOT WIN32)
-  #set(OpenBLAS_version "0.2.15")
   set(OpenBLAS_version "0.2.20")
   set(OpenBLAS_url "https://github.com/xianyi/OpenBLAS/archive/v${OpenBLAS_version}.tar.gz")
-
-  if (OpenBLAS_version VERSION_EQUAL 0.2.20)
-    set(OpenBLAS_md5 "48637eb29f5b492b91459175dcc574b1")
-  elseif (OpenBLAS_version VERSION_EQUAL 0.2.15)
-    set(OpenBLAS_md5 "b1190f3d3471685f17cfd1ec1d252ac9")
-  else()
-    message("Unknown OpenBLAS version = ${OpenBLAS_version}")
-  endif()
+  set(OpenBLAS_md5 "48637eb29f5b492b91459175dcc574b1")
   set(OpenBLAS_dlname "openblas-${OpenBLAS_version}.zip")
   list(APPEND fletch_external_sources OpenBLAS)
 endif()

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -154,6 +154,23 @@ set(Eigen_md5 "6a578dba42d1c578d531ab5b6fa3f741")
 set(Eigen_dlname "eigen-${Eigen_version}.tar.gz")
 list(APPEND fletch_external_sources Eigen)
 
+#OpenBLAS
+if(NOT WIN32)
+  #set(OpenBLAS_version "0.2.15")
+  set(OpenBLAS_version "0.2.20")
+  set(OpenBLAS_url "https://github.com/xianyi/OpenBLAS/archive/v${OpenBLAS_version}.tar.gz")
+
+  if (OpenBLAS_version VERSION_EQUAL 0.2.20)
+    set(OpenBLAS_md5 "48637eb29f5b492b91459175dcc574b1")
+  elseif (OpenBLAS_version VERSION_EQUAL 0.2.15)
+    set(OpenBLAS_md5 "b1190f3d3471685f17cfd1ec1d252ac9")
+  else()
+    message("Unknown OpenBLAS version = ${OpenBLAS_version}")
+  endif()
+  set(OpenBLAS_dlname "openblas-${OpenBLAS_version}.zip")
+  list(APPEND fletch_external_sources OpenBLAS)
+endif()
+
 # OpenCV
 # Support 2.4.13 and 3.1, and 3.3 optionally
 if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
@@ -222,23 +239,6 @@ set(GTest_url "https://github.com/google/googletest/archive/release-${GTest_vers
 set(GTest_md5 "16877098823401d1bf2ed7891d7dce36")
 set(GTest_dlname "gtest-${GTest_version}.tar.gz")
 list(APPEND fletch_external_sources GTest)
-
-#OpenBLAS
-if(NOT WIN32)
-  #set(OpenBLAS_version "0.2.15")
-  set(OpenBLAS_version "0.2.20")
-  set(OpenBLAS_url "https://github.com/xianyi/OpenBLAS/archive/v${OpenBLAS_version}.tar.gz")
-
-  if (OpenBLAS_version VERSION_EQUAL 0.2.20)
-    set(OpenBLAS_md5 "48637eb29f5b492b91459175dcc574b1")
-  elseif (OpenBLAS_version VERSION_EQUAL 0.2.15)
-    set(OpenBLAS_md5 "b1190f3d3471685f17cfd1ec1d252ac9")
-  else()
-    message("Unknown OpenBLAS version = ${OpenBLAS_version}")
-  endif()
-  set(OpenBLAS_dlname "openblas-${OpenBLAS_version}.zip")
-  list(APPEND fletch_external_sources OpenBLAS)
-endif()
 
 #SuiteSparse
 set(SuiteSparse_version 4.4.5)

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -81,6 +81,8 @@ Package Upgrades
 Fixes since v1.0.0
 ------------------
 
+ * Fix issue building OpenCV 3.4 with OpenBLAS
+
  * Increase minimum_cmake_required to support CMAKE_CXX_STANDARD
 
  * Fix python version selection.


### PR DESCRIPTION
OpenCV 3.4 has an option `OpenBLAS_LIB`. I'm not sure if it exists in previous versions. ~~I need to check that in order to correctly set the version if statement~~ ( Turns out OpenBLAS support was added in `3.2`, so I happened to guess right. ). The first function of this PR is to pass down that info when it is needed. 

The second function is to fix an issue I get:
```
    [ 97%] Linking CXX executable ../../bin/opencv_traincascade
    //usr/lib/liblapack.so.3: undefined reference to `gotoblas`
    collect2: error: ld returned 1 exit status
    apps/traincascade/CMakeFiles/opencv_traincascade.dir/build.make:392: recipe for target 'bin/opencv_traincascade' failed
```

A workaround for this seems to be to set `WITH_LAPACK=False`. It would be better if I understood the issue more, but I don't. 
