### PR TITLE
Add package specific variables to External_*.cmake

### DIFF
--- a/CMake/External_GFlags.cmake
+++ b/CMake/External_GFlags.cmake
@@ -22,6 +22,11 @@ fletch_external_project_force_install(PACKAGE GFlags)
 
 set(GFlags_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
 
+get_system_library_name( gflags gflags_libname )
+
+set(GFlags_INCLUDE_DIR "${fletch_BUILD_INSTALL_PREFIX}/include")
+set(GFlags_LIBRARY "${fletch_BUILD_INSTALL_PREFIX}/lib/${gflags_libname}")
+
 file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # GFlags

--- a/CMake/External_GLog.cmake
+++ b/CMake/External_GLog.cmake
@@ -28,6 +28,10 @@ fletch_external_project_force_install(PACKAGE GLog)
 
 set(GLog_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
 
+get_system_library_name( glog glog_libname )
+set(GLog_INCLUDE_DIR:PATH="${GLog_ROOT}/include")
+set(GLog_LIBRARY:PATH="${GLog_ROOT}/lib/${glog_libname}")
+
 file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # GLog

--- a/CMake/External_LMDB.cmake
+++ b/CMake/External_LMDB.cmake
@@ -28,6 +28,9 @@ endif()
 fletch_external_project_force_install(PACKAGE LMDB)
 
 set(LMDB_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+get_system_library_name( lmdb lmdb_libname )
+set(LMDB_INCLUDE_DIR "${LMDB_ROOT}/include")
+set(LMDB_LIBRARIES "${LMDB_ROOT}/lib/${lmdb_libname}")
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################

--- a/CMake/External_LevelDB.cmake
+++ b/CMake/External_LevelDB.cmake
@@ -34,6 +34,9 @@ ExternalProject_Add(LevelDB
 fletch_external_project_force_install(PACKAGE LevelDB)
 
 set(LevelDB_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "")
+get_system_library_name( leveldb leveldb_libname )
+set(LevelDB_INCLUDE_DIR ${LevelDB_ROOT}/include)
+set(LevelDB_LIBRARY ${LevelDB_ROOT}/lib/${leveldb_libname})
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################

--- a/CMake/External_Protobuf.cmake
+++ b/CMake/External_Protobuf.cmake
@@ -47,6 +47,20 @@ fletch_external_project_force_install(PACKAGE Protobuf)
 
 set(Protobuf_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "")
 
+get_system_library_name( protobuf protobuf_libname )
+get_system_library_name( protobuf-lite protobuf-lite_libname )
+get_system_library_name( protoc protoc_libname )
+
+set(PROTOBUF_INCLUDE_DIR "${Protobuf_ROOT}/include")
+set(PROTOBUF_LIBRARY "${Protobuf_ROOT}/lib/${protobuf_libname}")
+set(PROTOBUF_LIBRARY_DEBUG "${Protobuf_ROOT}/lib/${protobuf_libname}")
+set(PROTOBUF_LITE_LIBRARY "${Protobuf_ROOT}/lib/${protobuf-lite_libname}")
+set(PROTOBUF_LITE_LIBRARY_DEBUG "${Protobuf_ROOT}/lib/${protobuf-lite_libname}")
+set(PROTOBUF_PROTOC_EXECUTABLE "${Protobuf_ROOT}/bin/protoc")
+set(PROTOBUF_PROTOC_LIBRARY "${Protobuf_ROOT}/lib/${protoc_libname}")
+set(PROTOBUF_PROTOC_LIBRARY_DEBUG "${Protobuf_ROOT}/lib/${protoc_libname}")
+
+
 file(APPEND ${fletch_CONFIG_INPUT} "
 #######################################
 # Google Protobuf


### PR DESCRIPTION
Applies the pattern used in #339 to define variables relevant to a package in their `External_*.cmake`. This PR just defines the variables (so I can use them in my caffe2 branch), but does not simplify the corresponding places in the Caffe and Caffe_Segnet build scripts. This does cause temporary duplication of code, but it also makes it easier to review.  