### PR TITLE
Update pybind11 to 2.2.1

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -526,9 +526,9 @@ set(Darknet_md5 "d781157ba5eb81b8658aac0173fd5f09")
 list(APPEND fletch_external_sources Darknet)
 
 # pybind11
-set(pybind11_version "2.2.0")
+set(pybind11_version "2.2.1")
 set(pybind11_url "https://github.com/pybind/pybind11/archive/v${pybind11_version}.tar.gz")
-set(pybind11_md5 "978b26aea1c6bfc4f88518ef33771af2")
+set(pybind11_md5 "bab1d46bbc465af5af3a4129b12bfa3b")
 set(pybind11_dlname "pybind11-${pybind11_version}.tar.gz")
 list(APPEND fletch_external_sources pybind11)
 

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -32,6 +32,8 @@ New Packages
 
 Package Upgrades
 
+ * pybind11 to version 2.2.1
+
  * Upgrade libgeotiff to version 1.4.2
 
  * Upgrade GLog to version 0.3.5


### PR DESCRIPTION
Updates from 2.2.0 to 2.2.1 to get these changes: 

https://github.com/pybind/pybind11/blob/86e2ad4f77442c3350f9a2476650da6bee253c52/docs/changelog.rst#v221-september-14-2017

This is to address a build issue in my Caffe2 branch.

@KyleFromKitware I'm not sure if this breaks anything or introduces any issues for KWIVER / VIAME, From my understanding of the change log it seems like a safe upgrade to me. Do you have any intuition here?