### PR TITLE
Opencv contrib link directories

### DIFF
--- a/Patches/OpenCV_contrib/3.4.0/Patch.cmake
+++ b/Patches/OpenCV_contrib/3.4.0/Patch.cmake
@@ -1,0 +1,11 @@
+#+
+# This file is called as CMake -P script for the patch step of
+# External_OpenCV_contrib.cmake when building with OpenCV contrib
+#-
+
+message("Patching OpenCV contrib in ${OpenCV_contrib_source}")
+
+
+file(COPY ${OpenCV_contrib_patch}/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
+  DESTINATION ${OpenCV_contrib_source}/modules/xobjdetect/tools/waldboost_detector/
+)

--- a/Patches/OpenCV_contrib/3.4.0/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
+++ b/Patches/OpenCV_contrib/3.4.0/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
@@ -1,0 +1,34 @@
+set(name waldboost_detector)
+set(the_target opencv_${name})
+
+set(OPENCV_${the_target}_DEPS opencv_core opencv_imgproc opencv_imgcodecs opencv_videoio
+    opencv_highgui opencv_xobjdetect)
+
+ocv_check_dependencies(${OPENCV_${the_target}_DEPS})
+
+if(NOT OCV_DEPENDENCIES_FOUND)
+  return()
+endif()
+
+project(${the_target})
+
+ocv_include_directories("${OpenCV_SOURCE_DIR}/include/opencv")
+ocv_include_modules_recurse(${OPENCV_${the_target}_DEPS})
+
+file(GLOB ${the_target}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+add_executable(${the_target} ${${the_target}_SOURCES})
+
+ocv_target_link_libraries(${the_target} ${OPENCV_${the_target}_DEPS})
+
+set_target_properties(${the_target} PROPERTIES
+                      DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
+                      ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
+                      RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}
+                      OUTPUT_NAME ${the_target})
+
+if(ENABLE_SOLUTION_FOLDERS)
+  set_target_properties(${the_target} PROPERTIES FOLDER "applications")
+endif()
+
+install(TARGETS ${the_target} OPTIONAL RUNTIME DESTINATION bin COMPONENT main)

--- a/Patches/OpenCV_contrib/3.4.0/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
+++ b/Patches/OpenCV_contrib/3.4.0/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 project(${the_target})
 
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
+
 ocv_include_directories("${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_include_modules_recurse(${OPENCV_${the_target}_DEPS})
 


### PR DESCRIPTION
@aaron-bray have a look. I don't know for sure if I got the actual install directory correct. It changed in OpenCV 3.4 but it looks like the contrib didn't. I followed what's in contrib, but it's possible that you will need to drop the ${CMAKE_INSTALL_PREFIX}/ from the start of it.
