### PR TITLE
Fix opencv nvcc ccache errors

### DIFF
--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -245,6 +245,15 @@ else()
     message("Unknown Python version")
 endif()
 
+if (CMAKE_CXX_COMPILER MATCHES ".*ccache*" AND
+    CMAKE_COMPILER_IS_GNUCC AND
+    fletch_BUILD_WITH_CUDA AND
+    CUDA_HOST_COMPILER STREQUAL CMAKE_C_COMPILER
+    )
+  message(WARNING
+    "You are using ccache as your compiler and CUDA support is enabled. This configuration is known to fail with nvcc. Make sure you pass -DCUDA_HOST_COMPILER=/usr/bin/cc as an argument to cmake. Adjust the path to match your actual C compiler's location")
+endif()
+
 ExternalProject_Add(OpenCV
   DEPENDS ${OpenCV_DEPENDS}
   URL ${OpenCV_url}

--- a/Patches/OpenCV/3.1.0/FindCUDA.cmake
+++ b/Patches/OpenCV/3.1.0/FindCUDA.cmake
@@ -450,8 +450,9 @@ option(CUDA_HOST_COMPILATION_CPP "Generated file extension" ON)
 # Extra user settable flags
 set(CUDA_NVCC_FLAGS "" CACHE STRING "Semi-colon delimit multiple arguments.")
 
-unset(CUDA_HOST_COMPILER CACHE)
+
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  unset(CUDA_HOST_COMPILER CACHE)
   set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)Tools/MSVC/$(VCToolsVersion)/bin/Host$(Platform)/$(PlatformTarget)")
   if(MSVC_VERSION LESS 1910)
    set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)bin")

--- a/Patches/OpenCV/3.3.1/FindCUDA.cmake
+++ b/Patches/OpenCV/3.3.1/FindCUDA.cmake
@@ -450,8 +450,8 @@ option(CUDA_HOST_COMPILATION_CPP "Generated file extension" ON)
 # Extra user settable flags
 set(CUDA_NVCC_FLAGS "" CACHE STRING "Semi-colon delimit multiple arguments.")
 
-unset(CUDA_HOST_COMPILER CACHE)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  unset(CUDA_HOST_COMPILER CACHE)
   set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)Tools/MSVC/$(VCToolsVersion)/bin/Host$(Platform)/$(PlatformTarget)")
   if(MSVC_VERSION LESS 1910)
    set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)bin")

--- a/Patches/OpenCV/3.4.0/FindCUDA.cmake
+++ b/Patches/OpenCV/3.4.0/FindCUDA.cmake
@@ -450,8 +450,8 @@ option(CUDA_HOST_COMPILATION_CPP "Generated file extension" ON)
 # Extra user settable flags
 set(CUDA_NVCC_FLAGS "" CACHE STRING "Semi-colon delimit multiple arguments.")
 
-unset(CUDA_HOST_COMPILER CACHE)
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  unset(CUDA_HOST_COMPILER CACHE)
   set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)Tools/MSVC/$(VCToolsVersion)/bin/Host$(Platform)/$(PlatformTarget)")
   if(MSVC_VERSION LESS 1910)
    set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)bin")


### PR DESCRIPTION
OpenCV has issues when GPU support is enabled and the default complier is ccache. Nvcc is trying to use ccache directly and passing a -E argument which is invalid. This patch reallows the override of CUDA_HOST_COMPILER and alerts the user if they fall into the failure situation and provides advice on the fix.