### PR TITLE
Update GeographicLib to 1.49

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -350,9 +350,9 @@ endif()
 list(APPEND fletch_external_sources GDAL)
 
 # GeographicLib
-set(GeographicLib_version "1.30" )
+set(GeographicLib_version "1.49" )
 set(GeographicLib_url "http://downloads.sourceforge.net/geographiclib/distrib/GeographicLib-${GeographicLib_version}.tar.gz" )
-set(GeographicLib_md5 "eadf39013bfef1f87387e7964a2adf02" )
+set(GeographicLib_md5 "11300e88b4a38692b6a8712d5eafd4d7" )
 list(APPEND fletch_external_sources GeographicLib )
 
 # GEOS


### PR DESCRIPTION
Update GeographicLib. This brings us more in sync with modern distro packages, which is helpful for enabling consumers to build with either our (Fletch's) version or a distro package. This version also provides namespaced imported targets.