### PR TITLE
Explicitly disable metis support in CHOLMOD since we don't build it anyway

### DIFF
--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -126,3 +126,5 @@ Fixes since v1.0.0
  * Patch OpenCV so the FFmpeg libraries it uses can find each other
 
  * Add 'experimental' packages to VXL and remove BRL
+
+* Explicitly disable metis support in Suitesparce since it's not used

--- a/Patches/SuiteSparse/SuiteSparse_config.mk
+++ b/Patches/SuiteSparse/SuiteSparse_config.mk
@@ -276,7 +276,7 @@ UMFPACK_CONFIG =
 CHOLMOD_CONFIG = $(GPU_CONFIG)
 
 # uncomment this line to compile CHOLMOD without METIS:
-# CHOLMOD_CONFIG = -DNPARTITION
+CHOLMOD_CONFIG = -DNPARTITION
 
 #------------------------------------------------------------------------------
 # SuiteSparseQR configuration:


### PR DESCRIPTION
CHOLMOD only uses metis if it is explicitly downloaded, which we don't do. Suitesparse usually builds without explicitly disabling metis, but fails on some machines. This branch explicitly disables the support until we decide it's important to include.