### PR TITLE
Fix names of KML variables

### DIFF
--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -45,17 +45,17 @@ ExternalProject_Add(libkml
 
 fletch_external_project_force_install(PACKAGE libkml)
 
-set(LIBKML_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "" FORCE)
-set(LIBKML_DIR "${LIBKML_ROOT}/lib/cmake" CACHE PATH "" FORCE)
-set(LIBKML_LIBNAME kml)
+set(KML_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE STRING "" FORCE)
+set(KML_DIR "${LIBKML_ROOT}/lib/cmake" CACHE PATH "" FORCE)
+set(KML_LIBNAME kml)
 
 file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # libkml
 ########################################
-set(LIBKML_ROOT    \${fletch_ROOT})
-set(LIBKML_DIR     \${fletch_ROOT}/lib/cmake)
-set(LIBKML_LIBNAME @LIBKML_LIBNAME@)
+set(KML_ROOT    \${fletch_ROOT})
+set(KML_DIR     \${fletch_ROOT}/lib/cmake)
+set(KML_LIBNAME @KML_LIBNAME@)
 
 set(fletch_ENABLED_libkml TRUE)
 ")


### PR DESCRIPTION
Change the exported KML variables from `LIBKML_*` to `KML_*`. This correctly matches the exported package name, and is necessary for consumers to be able to find KML automagically when using fletch.