### PR TITLE
Fixed the setting of `qtExtensions_DIR`.

### DIFF
--- a/CMake/External_qtExtensions.cmake
+++ b/CMake/External_qtExtensions.cmake
@@ -34,7 +34,7 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # qtExtensions
 ########################################
 set(qtExtensions_ROOT \${fletch_ROOT})
-set(qtExtensions_DIR  \${fletch_ROOT}/lib/cmake)
+set(qtExtensions_DIR  \${fletch_ROOT}/lib/cmake/qtExtensions)
 
 set(fletch_ENABLED_qtExtensions TRUE)
 ")


### PR DESCRIPTION
Fixed `qtExtensions_DIR` so it points to the correct directory that actually contains `qtExtensionsConfig.cmake`.