### PR TITLE
Bug fix, vxl was forcing geotiff off if tiff was built

### DIFF
--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -19,7 +19,7 @@ add_package_dependency(
   PACKAGE_DEPENDENCY_ALIAS TIFF
   )
 
-# libtiff
+# libgeotiff
 add_package_dependency(
   PACKAGE VXL
   PACKAGE_DEPENDENCY libgeotiff
@@ -107,6 +107,7 @@ ExternalProject_Add(VXL
     -DVXL_USE_DCMTK:BOOL=OFF
     -DJPEG_LIBRARY:FILEPATH=${JPEG_LIBRARY}
     -DJPEG_INCLUDE_DIR:PATH=${JPEG_INCLUDE_DIR}
+    -DGEOTIFF_LIBRARY=${libgeotiff_LIBRARY}
     ${VXL_EXTRA_BUILD_FLAGS}
     DOWNLOAD_DIR ${fletch_DOWNLOAD_DIR}
     INSTALL_DIR ${fletch_BUILD_INSTALL_PREFIX}

--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -19,6 +19,13 @@ add_package_dependency(
   PACKAGE_DEPENDENCY_ALIAS TIFF
   )
 
+# libtiff
+add_package_dependency(
+  PACKAGE VXL
+  PACKAGE_DEPENDENCY libgeotiff
+  PACKAGE_DEPENDENCY_ALIAS GEOTIFF
+  )
+
 # libpng
 add_package_dependency(
   PACKAGE VXL
@@ -66,14 +73,6 @@ elseif(WIN32)
   set(VXL_ARGS_V3P
     # Geotiff
     )
-endif()
-
-if(${fletch_ENABLE_libtiff})
-  # When using the TIFF library from Fletch we need to explicitly
-  # disable the GeoTIFF library in VXL, because if a system GeoTiff package
-  # is found it will link against a system TIFF library, causing conflicts.
-  # This may change in the future if GeoTIFF is added to Fletch.
-  list(APPEND VXL_EXTRA_BUILD_FLAGS -DVXL_USE_GEOTIFF:BOOL=OFF)
 endif()
 
 ExternalProject_Add(VXL

--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -134,10 +134,22 @@ ExternalProject_Add(libgeotiff
       )
   endif()
 
+  if (WIN32)
+    set (geotiff_lib_name geotiff_i.lib)
+  elseif(APPLE)
+    set (geotiff_lib_name libgeotiff.dylib)
+  else()
+    set (geotiff_lib_name libgeotiff.so)
+  endif()
   set(libgeotiff_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
+
+  set(libgeotiff_LIBRARY ${fletch_BUILD_INSTALL_PREFIX}/lib/${geotiff_lib_name} CACHE FILEPATH "" FORCE)
+
   file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 # libgeotiff
 ########################################
 set(libgeotiff_ROOT \${fletch_ROOT})
+set(libgeotiff_LIBRARY \${libgeotiff_LIBRARY})
+
 ")


### PR DESCRIPTION
This was done previously because a build of geotiff was not available in fletch. Now that it is, we need to pass geotiff to VXL otherwise vxl produces a library which causes conflicts.