### PR TITLE
Fixes for Qt5 on MSVC

### DIFF
--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -211,6 +211,14 @@ if (Qt_version VERSION_LESS 5.0.0)
     -fast )
 endif()
 
+
+if (WIN32 AND NOT (Qt_version VERSION_LESS 5.0.0) )
+  # Dynamic OpenGL is the recommended way to build Qt5 on Windows
+  # and is required by VTK
+  list( APPEND Qt_configure
+    -opengl dynamic )
+endif()
+
 if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if (Qt_version VERSION_LESS 5.0.0)
     list (APPEND Qt_configure

--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -213,6 +213,10 @@ endif()
 
 
 if (WIN32 AND NOT (Qt_version VERSION_LESS 5.0.0) )
+  # The qtlocation module from Qt5 is currently broken on Windows.
+  # Disable until a fix is found.
+  list( APPEND Qt_configure
+    -skip qtlocation )
   # Dynamic OpenGL is the recommended way to build Qt5 on Windows
   # and is required by VTK
   list( APPEND Qt_configure


### PR DESCRIPTION
This branch contains two fixes to get Qt5 to build in Fletch on Windows with MSVC (tested on Visual Studio 2017).  The first is to disable the qtlocation module, which is broken.  This is a temporary fix and should be reverted once we have a solution to that build problem.  The second is to enable [dynamic loading](http://doc.qt.io/qt-5/windows-requirements.html#dynamically-loading-graphics-drivers) of OpenGL in Qt5.  Dynamic loading is not need to successfully build Qt5, but it is needed to build VTK against Qt5.  Also, this seems like the behavior we want anyway and is recommended by the Qt5 docs.