### PR TITLE
Added missing exported fletch_ENABLED_* variables

### DIFF
--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -346,4 +346,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # Caffe
 ########################################
 set(Caffe_ROOT    \${fletch_ROOT})
+set(fletch_ENABLED_Caffe TRUE)
 ")

--- a/CMake/External_CppDB.cmake
+++ b/CMake/External_CppDB.cmake
@@ -41,5 +41,6 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # CppDB
 ########################################
 set(CppDB_ROOT @CppDB_ROOT@)
+set(fletch_ENABLED_CppDB TRUE)
 ")
 

--- a/CMake/External_FFmpeg.cmake
+++ b/CMake/External_FFmpeg.cmake
@@ -115,4 +115,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # FFmpeg
 #######################################
 set(FFmpeg_ROOT \${fletch_ROOT})
+set(fletch_ENABLED_FFmpeg TRUE)
 ")

--- a/CMake/External_GEOS.cmake
+++ b/CMake/External_GEOS.cmake
@@ -34,4 +34,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 ########################################
 set(GEOS_ROOT \${fletch_ROOT})
 set(GEOS_C_LIBRARY @GEOS_C_LIBRARY@)
+set(fletch_ENABLED_GEOS TRUE)
 ")

--- a/CMake/External_GFlags.cmake
+++ b/CMake/External_GFlags.cmake
@@ -27,4 +27,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # GFlags
 #######################################
 set(GFlags_ROOT \${fletch_ROOT})
+set(fletch_ENABLED_GFlags TRUE)
 ")

--- a/CMake/External_GLog.cmake
+++ b/CMake/External_GLog.cmake
@@ -33,4 +33,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # GLog
 #######################################
 set(GLog_ROOT \${fletch_ROOT})
+set(fletch_ENABLED_GLog TRUE)
 ")

--- a/CMake/External_HDF5.cmake
+++ b/CMake/External_HDF5.cmake
@@ -43,4 +43,5 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # HDF5
 #######################################
 set(HDF5_ROOT \${fletch_ROOT})
+set(fletch_ENABLED_HDF5 TRUE)
 ")

--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -152,4 +152,5 @@ ExternalProject_Add(libgeotiff
 set(libgeotiff_ROOT \${fletch_ROOT})
 set(libgeotiff_LIBRARY \${libgeotiff_LIBRARY})
 
+set(fletch_ENABLED_libgeotiff TRUE)
 ")


### PR DESCRIPTION
A convention in Fletch is that each enabled package will export a variable `fletch_ENABLED_packagename` in fletchConfig.cmake so that users can easily check which packages were provided by Fletch.  A few of these exports were missing and are added in this branch.