### PR TITLE
Add Extra Symlink for Boost Python

### DIFF
--- a/Patches/Boost/Install.cmake
+++ b/Patches/Boost/Install.cmake
@@ -4,13 +4,6 @@ file(COPY ${Boost_BUILD_DIR}/boost
   USE_SOURCE_PERMISSIONS
   )
 
-if (fletch_BUILD_WITH_PYTHON)
-  file(COPY ${Boost_source}/boost/python/raw_function.hpp
-    DESTINATION ${Boost_INSTALL_DIR}/include/boost/python
-    USE_SOURCE_PERMISSIONS
-    )
-endif()
-
 message("Boost.Install: Installing link libraries")
 foreach(SUFFIX lib so a dylib)
   file(COPY ${Boost_BUILD_DIR}/stage/lib/
@@ -19,6 +12,20 @@ foreach(SUFFIX lib so a dylib)
     FILES_MATCHING PATTERN "*.${SUFFIX}*"
   )
 endforeach()
+
+if (fletch_BUILD_WITH_PYTHON)
+  file(COPY ${Boost_source}/boost/python/raw_function.hpp
+    DESTINATION ${Boost_INSTALL_DIR}/include/boost/python
+    USE_SOURCE_PERMISSIONS
+    )
+  if( NOT WIN32
+      AND NOT EXISTS ${Boost_INSTALL_DIR}/lib/libboost_python.so
+      AND EXISTS ${Boost_INSTALL_DIR}/lib/libboost_python3.so )
+    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+      ${Boost_INSTALL_DIR}/lib/libboost_python3.so
+      ${Boost_INSTALL_DIR}/lib/libboost_python.so )
+  endif()
+endif()
 
 if(WIN32)
   message("Boost.Install: Installing runtime libraries")


### PR DESCRIPTION
This change should become deprecated in the future as boost python is removed, but in the current state it's still useful for a few projects when building with Python3 as opposed to Python2 (with 3 it get's generated as boost_python3.so vs just boost_python.so which messes up linking in Caffe and other packages).