### PR TITLE
Copy all Boost header files to build/install tree

### DIFF
--- a/Patches/Boost/Configure.cmake
+++ b/Patches/Boost/Configure.cmake
@@ -59,3 +59,8 @@ execute_command_wrapper(
   integer property_tree graph spirit fusion ${Boost_EXTRA_LIBS}
   ${Boost_BUILD_DIR}
 )
+
+# Copy all Boost header files to the build tree.
+file(COPY        "${Boost_SOURCE_DIR}/boost/"
+     DESTINATION "${Boost_BUILD_DIR}/boost/"
+     USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
This solves the problem of downstream packages not being able to find Boost header files that they expect.

For header-only libraries, this is easier and more reliable than specifying additional libraries as `fletch_EXTRA_BOOST_LIBS`.