### PR TITLE
Increase min cmake version and set it higher if VXL built with cxx11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.3.0)
 project(fletch)
+
+if (fletch_ENABLE_VXL AND fletch_BUILD_CXX11)
+  cmake_minimum_required(VERSION 3.9.5)
+  message(STATUS "Building VXL with CXX 11 support requires CMake 3.9.5")
+endif()
 
 # Policy to address @foo@ variable expansion
 if(POLICY CMP0053)


### PR DESCRIPTION
VXL with cxx11 requires CMake version 3.9.5, otherwise it requires 3.3. This branch makes the minimum CMake version for fletch 3.3 since several packages require that. It also conditionally increases that to 3.9.5 if VXL and cxx11 are enabled.