### PR TITLE
Update qtExtensions

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -546,10 +546,10 @@ set(YAMLcpp_dlname "yaml-cpp-release-${YAMLcpp_version}.tar.gz")
 list(APPEND fletch_external_sources YAMLcpp)
 
 # qtExtensions
-set(qtExtensions_version "20180706gitc2259d52")
-set(qtExtensions_tag "c2259d52fd9bf2c6f3a7dea18aea08f81010cfb5")
+set(qtExtensions_version "20180815gitb21dbab3")
+set(qtExtensions_tag "b21dbab3e660dc1a3809f347b906f282afd865e1")
 set(qtExtensions_url "https://github.com/Kitware/qtextensions/archive/${qtExtensions_tag}.zip")
-set(qtExtensions_md5 "928fcd80b6c7e5534bf23c3b2fd76363")
+set(qtExtensions_md5 "8097dec38761b7178c12de4d88c9e2c2")
 set(qtExtensions_dlname "qtExtensions-${qtExtensions_version}.zip")
 list(APPEND fletch_external_sources qtExtensions)
 


### PR DESCRIPTION
Update to latest qtExtensions, bringing in a fix for a header that was not being installed, and the "new" `qtProcess` class.