### PR TITLE
Patch PNG for arm64

### DIFF
--- a/Patches/PNG/CMakeLists.txt
+++ b/Patches/PNG/CMakeLists.txt
@@ -98,6 +98,15 @@ if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
 endif(MSVC)
 
+# setting definitions and sources for arm
+# "-DPNG_ARM_NEON_OPT=0" needed to build on arm64
+# see: https://github.com/glennrp/libpng/blob/a54a0562c53daf2d627f1631be0dd6531cca1694/CMakeLists.txt#L195
+ 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
+   CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+  add_definitions(-DPNG_ARM_NEON_OPT=0)
+endif()
+
 if(PNG_DEBUG)
   add_definitions(-DPNG_DEBUG)
 endif()


### PR DESCRIPTION
Patch fixes this error while building on arm64 processors:

> undefined reference to `png_init_filter_functions_neon'
> collect2: error: ld returned 1 exit status

related: https://github.com/opencv/opencv/issues/7600

The fix was to take:
> if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
>    CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
>   add_definitions(-DPNG_ARM_NEON_OPT=0)
> endif()

 from the official PNG [CMakelists.txt ](https://github.com/glennrp/libpng/blob/a54a0562c53daf2d627f1631be0dd6531cca1694/CMakeLists.txt#L195), and inject it into the custom one we supply.
