### PR TITLE
Add VTK 8.2-pre

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -226,6 +226,12 @@ list(APPEND vtk_cmake_args
   -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
   )
 
+# TODO: Remove this when we replace 8.2-pre with 8.2 (official)
+if(VTK_dlname)
+  set(VTK_DOWNLOAD_NAME DOWNLOAD_NAME ${VTK_dlname})
+else()
+  set(VTK_DOWNLOAD_NAME "")
+endif()
 
 set (VTK_PATCH_DIR ${fletch_SOURCE_DIR}/Patches/VTK/${VTK_SELECT_VERSION})
 if (EXISTS ${VTK_PATCH_DIR})
@@ -241,6 +247,7 @@ ExternalProject_Add(VTK
   DEPENDS ${VTK_DEPENDS}
   URL ${VTK_file}
   URL_MD5 ${VTK_md5}
+  ${VTK_DOWNLOAD_NAME}
   ${COMMON_EP_ARGS}
   ${COMMON_CMAKE_EP_ARGS}
   PATCH_COMMAND ${VTK_PATCH_COMMAND}

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -399,10 +399,19 @@ list(APPEND fletch_external_sources CppDB)
 # VTK
 if (fletch_ENABLE_VTK OR fletch_ENABLE_ALL_PACKAGES)
   set(VTK_SELECT_VERSION 8.0 CACHE STRING "Select the version of VTK to build.")
-  set_property(CACHE VTK_SELECT_VERSION PROPERTY STRINGS 6.2 8.0 8.1)
+  set_property(CACHE VTK_SELECT_VERSION PROPERTY STRINGS 6.2 8.0 8.1 8.2-pre)
 endif()
 
-if (VTK_SELECT_VERSION VERSION_EQUAL 8.1)
+if (VTK_SELECT_VERSION VERSION_EQUAL 8.2-pre)
+  set(VTK_SELECT_VERSION 8.2)
+  set(VTK_tag "3ad789a980dd8da13f86dd79f37cf2e67f4d4dbf")
+  set(VTK_url "http://www.vtk.org/gitweb?p=VTK.git&a=snapshot&h=${VTK_tag}")
+  set(VTK_md5 "cb6857024e6559ccbad34e84573f5a1b")
+  # TODO: Remove corresponding logic in External_VTK.cmake when we replace
+  # this with 8.2 (official)
+  set(VTK_dlname "VTK-${VTK_tag}.tar.gz")
+elseif (VTK_SELECT_VERSION VERSION_EQUAL 8.1)
+  # TODO: Remove when we support 8.2 (official, not 8.2-pre)?
   set(VTK_version 8.1.1)
   set(VTK_url "http://www.vtk.org/files/release/${VTK_SELECT_VERSION}/VTK-${VTK_version}.zip")
   set(VTK_md5 "64f3acd5c28b001d5bf0e5a95b3a0af5")  # v8.1.1
@@ -411,7 +420,7 @@ elseif (VTK_SELECT_VERSION VERSION_EQUAL 8.0)
   set(VTK_url "http://www.vtk.org/files/release/${VTK_SELECT_VERSION}/VTK-${VTK_version}.zip")
   set(VTK_md5 "0bec6b6aa3c92cc9e058a12e80257990")  # v8.0.0
 elseif (VTK_SELECT_VERSION VERSION_EQUAL 6.2)
-  # TODO remove when we remove support for OpenCV < 3.2
+  # TODO: Remove when we remove support for OpenCV < 3.2
   set(VTK_version 6.2.0)
   set(VTK_url "http://www.vtk.org/files/release/${VTK_SELECT_VERSION}/VTK-${VTK_version}.zip")
   set(VTK_md5 "2363432e25e6a2377e1c241cd2954f00")  # v6.2


### PR DESCRIPTION
Add ability to select a pre-release of VTK 8.2. This is needed for [TeleSculptor](https://github.com/Kitware/maptk), which depends on post-8.1 changes, and because 8.2 is not officially released yet. (Later, this will be replaced with the official 8.2 release, at which point likely 8.1 will be dropped.)