### PR TITLE
The add_package_dependency macro was incorrectly checking for FOUND variable DEFINED, which is not what we want

### DIFF
--- a/CMake/Utils.cmake
+++ b/CMake/Utils.cmake
@@ -119,10 +119,9 @@ macro(add_package_dependency)
     # Handle both casing (For package foo, we can have either
     # foo_FOUND or FOO_FOUND defined)
     string(TOUPPER ${dependency_name}_FOUND uppercase_found)
-
-    if(DEFINED ${dependency_name}_FOUND)
+    if(${dependency_name}_FOUND)
       set(dependency_found ${${dependency_name}_FOUND})
-    elseif(DEFINED uppercase_found)
+    elseif(uppercase_found)
       set(dependency_found ${uppercase_found})
     endif()
 


### PR DESCRIPTION
From the CMake documentation:

if(DEFINED <variable>)
    True if the given variable is defined. It does not matter if the variable is true or false just if it has been set. (Note macro arguments are not variables.)

In the case of var_FOUND we want it to be true so would prefer the syntax ...

if(<variable>)


