### PR TITLE
Remove the hard geotiff requirement from VXL

### DIFF
--- a/CMake/External_VXL.cmake
+++ b/CMake/External_VXL.cmake
@@ -24,7 +24,21 @@ add_package_dependency(
   PACKAGE VXL
   PACKAGE_DEPENDENCY libgeotiff
   PACKAGE_DEPENDENCY_ALIAS GEOTIFF
+  OPTIONAL
   )
+
+# Geotiff requires special treatment here. First, there is no CMake provided FindModule
+# and the one provided by VXL is insufficient to find it. For now we have included a FindGEOTIFF.cmake
+# which is a fixed version of the one provided by VXL. We are not able to update to VXL master
+# currently because its treatment of FFmpeg is broken. Once we are able to upgrade to a version that
+# contains the fixed FindGEOTIFF.cmake, our copy of it can get deleted and the manually setting of
+# the library and include_dir for VXL here can probably go away too.
+if (GEOTIFF_FOUND)
+  list(APPEND VXL_EXTRA_BUILD_FLAGS
+    -DGEOTIFF_INCLUDE_DIR:PATH=${GEOTIFF_INCLUDE_DIR}
+    -DGEOTIFF_LIBRARY:FILEPATH=${GEOTIFF_LIBRARY}
+    )
+endif()
 
 # libpng
 add_package_dependency(

--- a/CMake/FindGEOTIFF.cmake
+++ b/CMake/FindGEOTIFF.cmake
@@ -1,0 +1,31 @@
+# - Find GEOTIFF library
+# Find the native GEOTIFF includes and library
+# This module defines
+#  GEOTIFF_INCLUDE_DIR, where to find tiff.h, etc.
+#  GEOTIFF_LIBRARIES, libraries to link against to use GEOTIFF.
+#  GEOTIFF_FOUND, If false, do not try to use GEOTIFF.
+# also defined, but not for general use are
+#  GEOTIFF_LIBRARY, where to find the GEOTIFF library.
+
+find_path(GEOTIFF_INCLUDE_DIR geotiff.h
+  PATH_SUFFIXES geotiff
+  PATHS
+    /usr/local/include
+    /usr/include
+    /usr/include/libgeotiff
+)
+
+set(GEOTIFF_NAMES ${GEOTIFF_NAMES} geotiff)
+find_library(GEOTIFF_LIBRARY
+  NAMES ${GEOTIFF_NAMES}
+  PATHS /usr/lib /usr/local/lib /usr/lib64
+  )
+
+set( GEOTIFF_FOUND "NO" )
+if(GEOTIFF_INCLUDE_DIR)
+  if(GEOTIFF_LIBRARY)
+    set( GEOTIFF_FOUND "YES" )
+    set( GEOTIFF_LIBRARIES ${GEOTIFF_LIBRARY} )
+  endif()
+endif()
+

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -28,3 +28,4 @@ Fixes since v1.1.0
 
  * Patched PNG to enable support for ARM64/AARCH64 processors
 
+ * Remove the hard geotiff requirement from VXL but fix its inclusion in VXL when user has a system version installed.


### PR DESCRIPTION
We should not be requiring geotiff in VXL. This branch removes the hard requirement but also fixes the problems VXL has finding geotiff when it exists on the system. Now if fletch builds geotiff or it's installed on the system, VXL will have access to it. If it doesn't exist though, VXL still tries to build its very old version.