### PR TITLE
Patch OpenCV_contrib MacOS linker issue

### DIFF
--- a/Patches/OpenCV_contrib/3.4.0/Patch.cmake
+++ b/Patches/OpenCV_contrib/3.4.0/Patch.cmake
@@ -9,3 +9,7 @@ message("Patching OpenCV contrib in ${OpenCV_contrib_source}")
 file(COPY ${OpenCV_contrib_patch}/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
   DESTINATION ${OpenCV_contrib_source}/modules/xobjdetect/tools/waldboost_detector/
 )
+
+file(COPY ${OpenCV_contrib_patch}/modules/freetype/CMakeLists.txt
+  DESTINATION ${OpenCV_contrib_source}/modules/freetype
+)

--- a/Patches/OpenCV_contrib/3.4.0/modules/freetype/CMakeLists.txt
+++ b/Patches/OpenCV_contrib/3.4.0/modules/freetype/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(the_description "FreeType module. It enables to draw strings with outlines and mono-bitmaps/gray-bitmaps.")
+if(APPLE_FRAMEWORK)
+  ocv_module_disable(freetype)
+endif()
+
+if(PKG_CONFIG_FOUND)
+  pkg_search_module(FREETYPE freetype2)
+  pkg_search_module(HARFBUZZ harfbuzz)
+endif()
+
+if(NOT FREETYPE_FOUND)
+  message(STATUS "freetype2:   NO")
+else()
+  message(STATUS "freetype2:   YES")
+endif()
+
+if(NOT HARFBUZZ_FOUND)
+  message(STATUS "harfbuzz:    NO")
+else()
+  message(STATUS "harfbuzz:    YES")
+endif()
+
+
+if( FREETYPE_FOUND AND HARFBUZZ_FOUND )
+  ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)
+  ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})
+  ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )
+else()
+  ocv_module_disable(freetype)
+endif()

--- a/Patches/OpenCV_contrib/3.4.0/modules/freetype/CMakeLists.txt
+++ b/Patches/OpenCV_contrib/3.4.0/modules/freetype/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 
 if( FREETYPE_FOUND AND HARFBUZZ_FOUND )
+  link_directories( ${FREETYPE_LIBRARY_DIRS} ${HARFBUZZ_LIBRARY_DIRS} )
   ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)
   ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})
   ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )


### PR DESCRIPTION
This was a problem with OpenCV 3.4.0 on MacOS using freetype from macports

See also upstream PR here
https://github.com/opencv/opencv_contrib/pull/1972