### PR TITLE
Add GDAL dependency on libxml2

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -108,6 +108,11 @@ else()
     set(GDAL_CONFIGURE_COMMAND ${env} ${env_var} ${GDAL_CONFIGURE_COMMAND})
   endif()
 
+  if(fletch_ENABLE_libxml2)
+    list(APPEND _GDAL_DEPENDS libxml2)
+    set(_GDAL_ARGS_XML2 "--with-xml2=${LIBXML2_ROOT}/bin/xml2-config")
+  endif()
+
   #+
   # GDAL Python dosen't work well for GDAL 1, nor does it work well on Apple at the moment
   #-
@@ -125,8 +130,9 @@ endif()
 
   # Here is where you add any new package related args for tiff, so we don't keep repeating them below.
   set (GDAL_PKG_ARGS
-    ${_GDAL_ARGS_PYTHON} ${_GDAL_PNG_ARGS} ${_GDAL_GEOTIFF_ARGS} ${_GDAL_ARGS_PG} ${_GDAL_ARGS_PROJ4}
-    ${_GDAL_TIFF_ARGS} ${_GDAL_ARGS_SQLITE} ${_GDAL_ARGS_ZLIB} ${_GDAL_ARGS_LTIDSDK} ${JPEG_ARG}
+    ${_GDAL_ARGS_PYTHON} ${_GDAL_PNG_ARGS} ${_GDAL_GEOTIFF_ARGS} ${_GDAL_ARGS_PG}
+    ${_GDAL_ARGS_PROJ4} ${_GDAL_ARGS_XML2} ${_GDAL_TIFF_ARGS} ${_GDAL_ARGS_SQLITE}
+    ${_GDAL_ARGS_ZLIB} ${_GDAL_ARGS_LTIDSDK} ${JPEG_ARG}
     --without-jasper
     )
 

--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -1,0 +1,16 @@
+Fletch v1.2.1 Release Notes
+===========================
+
+This is a patch release of Fletch that provides fixes over the previous v1.2.0 release.
+
+
+Updates since v1.2.0
+--------------------
+
+
+Fixes since v1.2.0
+------------------
+ 
+ * GDAL now has explicit dependency on libxml2 if enabled in Fletch.
+   Previously it was possibly to for GDAL to find a conflicting
+   system package for libxml2.


### PR DESCRIPTION
This change seems to fix my issue on macOS.  It seem like it might be relevant on other platforms too.