### PR TITLE
Fix libgeotiff depends

### DIFF
--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -78,6 +78,10 @@ else()
 endif()
 
 # libtiff
+if (NOT fletch_ENABLE_libtiff)
+  message(FATAL " You must enable libtiff from fletch to build libgeotiff.")
+endif()
+
 add_package_dependency(
   PACKAGE libgeotiff
   PACKAGE_DEPENDENCY libtiff

--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -1,6 +1,10 @@
 # The libgeotiff external project for fletch
 
 # JPEG
+if (NOT fletch_ENABLE_libjpeg-turbo)
+  message(FATAL " You must enable libjpeg-turbo from fletch to build libgeotiff.")
+endif()
+
 add_package_dependency(
   PACKAGE libgeotiff
   PACKAGE_DEPENDENCY libjpeg-turbo

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -1,14 +1,8 @@
-Fletch v1.2.0 Release Notes
+Fletch v1.3.0 Release Notes
 ===========================
 
-This is a minor release of Fletch that provides both new functionality
-and fixes over the previous v1.1.0 release.
-
-This release updates many existing packages, and adds the finishing touches on support for ARM64/AARCH64 
-processors. Also, the minimum CMake version required to build Fletch has been increased to 3.3.0.
-
-Major packages that received updates in this release: QT, GDAL, ITK, and VXL. There has also been general 
-organizational and stability improvements.
+This is a minor release of Fletch that provides both new functionality and fixes over 
+the previous v1.2.0 release.
 
 There are many other changes in this release. These are detailed in the change log below.
 
@@ -20,3 +14,10 @@ New Packages
 
 Package Upgrades
 
+
+Fixes since v1.2.0
+------------------
+
+- Libjpeg-turbo and libtiff are now requirements to build libgeotiff. It was possible to
+  try to build libgeotiff without libjpeg-tubo and libtiff enabled, this would result in
+  several build errors.


### PR DESCRIPTION
This PR makes libtiff and libjpeg-turbo requirements to build libgeotiff.

When you only enable libgeotiff (and its hard dependency proj4), libgeotiff fails to build and you get these errors:
This error is from libjpeg not being built
```
make[5]: *** No rule to make target `/Users/taylorcook/kitware/fletch/src/build/install/lib/libjpeg.dylib', needed by `lib/libgeotiff.2.1.2.dylib'.  Stop.
make[4]: *** [CMakeFiles/geotiff_library.dir/all] Error 2
```
This error is from libtiff not being built
```
Scanning dependencies of target geotiff_library
[  2%] Building C object CMakeFiles/geotiff_library.dir/cpl_serv.c.o
In file included from /home/kitware/jenkins/workspace/fletch/build1/build/src/libgeotiff/geo_tiffp.h:37:0,
                 from /home/kitware/jenkins/workspace/fletch/build1/build/src/libgeotiff/cpl_serv.c:28:
/home/kitware/jenkins/workspace/fletch/build1/build/src/libgeotiff/libxtiff/xtiffio.h:10:20: fatal error: tiffio.h: No such file or directory
 #include "tiffio.h"
                    ^
compilation terminated.
make[5]: *** [CMakeFiles/geotiff_library.dir/cpl_serv.c.o] Error 1
make[4]: *** [CMakeFiles/geotiff_library.dir/all] Error 2
```