### PR TITLE
Quote exported paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ set(fletch_INSTALL_BUILD_DIR ${fletch_BUILD_INSTALL_PREFIX})
 file(WRITE ${fletch_CONFIG_INPUT} "
 # Configuration file for the fletch build
 set(fletch_VERSION ${fletch_VERSION})
-set(fletch_ROOT @fletch_INSTALL_BUILD_DIR@)
+set(fletch_ROOT \"@fletch_INSTALL_BUILD_DIR@\")
 set(fletch_WITH_PYTHON ${fletch_BUILD_WITH_PYTHON})
 set(fletch_PYTHON_MAJOR_VERSION ${fletch_PYTHON_MAJOR_VERSION})
 ")
@@ -238,7 +238,7 @@ if (fletch_BUILD_WITH_CUDA)
 ########################################
 # CUDA
 ########################################
-set(CUDA_TOOLKIT_ROOT_DIR    ${CUDA_TOOLKIT_ROOT_DIR})
+set(CUDA_TOOLKIT_ROOT_DIR    \"${CUDA_TOOLKIT_ROOT_DIR}\")
 set(fletch_BUILT_WITH_CUDA TRUE)
 set(fletch_CUDA_VERSION_MAJOR ${CUDA_VERSION_MAJOR})
 set(fletch_CUDA_VERSION_MINOR ${CUDA_VERSION_MINOR})

--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -14,3 +14,7 @@ Fixes since v1.2.0
  * GDAL now has explicit dependency on libxml2 if enabled in Fletch.
    Previously it was possibly to for GDAL to find a conflicting
    system package for libxml2.
+
+ * Paths in fletchConfig.cmake were not quoted causing problems if the path
+   contains spaces (spaces were replaced with semicolons by CMake).  Quotes
+   are now added to some paths that are more likely to have spaces.


### PR DESCRIPTION
The concrete reason for this change is a bug I found with CUDA on Windows.  By default, CUDA is installed in ` C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2` but importing `fletchConfig.cmake` into KWIVER set `CUDA_TOOLKIT_ROOT_DIR=C:/Program;Files/NVIDIA;GPU;Computing;Toolkit/CUDA/v9.2` which caused all sort of problems.

The solution is to add quotes around the path in `fletchConfig.cmake`.  I've done this for `CUDA_TOOLKIT_ROOT_DIR` and `fletch_ROOT`, which are user configurable an may contain spaces.  There are many other paths in the file that could be quoted for added safety, but I don't think they will be a problem since the paths are hard coded relative to `fletch_ROOT`.  However, if someone else wants to add the missing quotes it's probably not a bad idea.