### PR TITLE
Set GDAL datadir on win32

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -44,8 +44,12 @@ if (WIN32)
 
   # Here is where you add any new package related args for tiff, so we don't keep repeating them below.
   set (GDAL_PKG_ARGS  ${_GDAL_MSVC_ARGS_LTISDK} ${_GDAL_ARGS_PNG} ${_GDAL_TIFF_ARGS} ${_GDAL_GEOTIFF_ARGS})
-
   file(TO_NATIVE_PATH ${fletch_BUILD_INSTALL_PREFIX} _gdal_native_fletch_BUILD_INSTALL_PREFIX)
+  set (GDAL_ARGS MSVC_VER=${MSVC_VERSION}
+                 GDAL_HOME=${_gdal_native_fletch_BUILD_INSTALL_PREFIX}
+                 ${_gdal_msvc_win64_option}
+                 ${GDAL_PKG_ARGS})
+
   ExternalProject_Add(GDAL
     DEPENDS ${_GDAL_DEPENDS}
     URL ${GDAL_file}
@@ -54,9 +58,9 @@ if (WIN32)
     BUILD_IN_SOURCE 1
     PATCH_COMMAND ${GDAL_PATCH_COMMAND}
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND nmake -f makefile.vc MSVC_VER=${MSVC_VERSION} GDAL_HOME=${_gdal_native_fletch_BUILD_INSTALL_PREFIX} ${_gdal_msvc_win64_option} ${GDAL_PKG_ARGS}
-    INSTALL_COMMAND nmake -f makefile.vc MSVC_VER=${MSVC_VERSION} GDAL_HOME=${_gdal_native_fletch_BUILD_INSTALL_PREFIX} ${_gdal_msvc_win64_option} ${GDAL_PKG_ARGS} install
-    COMMAND nmake -f makefile.vc MSVC_VER=${MSVC_VERSION} GDAL_HOME=${_gdal_native_fletch_BUILD_INSTALL_PREFIX} ${_gdal_msvc_win64_option} ${GDAL_PKG_ARGS} devinstall
+    BUILD_COMMAND nmake -f makefile.vc ${GDAL_ARGS}
+    INSTALL_COMMAND nmake -f makefile.vc ${GDAL_ARGS} install
+    COMMAND nmake -f makefile.vc ${GDAL_ARGS} devinstall
     )
 else()
 

--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -46,6 +46,7 @@ if (WIN32)
   set (GDAL_PKG_ARGS  ${_GDAL_MSVC_ARGS_LTISDK} ${_GDAL_ARGS_PNG} ${_GDAL_TIFF_ARGS} ${_GDAL_GEOTIFF_ARGS})
   file(TO_NATIVE_PATH ${fletch_BUILD_INSTALL_PREFIX} _gdal_native_fletch_BUILD_INSTALL_PREFIX)
   set (GDAL_ARGS MSVC_VER=${MSVC_VERSION}
+                 DATADIR=${_gdal_native_fletch_BUILD_INSTALL_PREFIX}\\share\\gdal
                  GDAL_HOME=${_gdal_native_fletch_BUILD_INSTALL_PREFIX}
                  ${_gdal_msvc_win64_option}
                  ${GDAL_PKG_ARGS})

--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -14,3 +14,6 @@ Fixes since v1.2.0
  * GDAL now has explicit dependency on libxml2 if enabled in Fletch.
    Previously it was possibly to for GDAL to find a conflicting
    system package for libxml2.
+
+ * GDAL now installs it's data files into share/gdal on Windows,
+   which is consistent to the install location on other platforms.


### PR DESCRIPTION
GDAL was installing it's data files into ${fletch_INSTALL}/data on Windows but ${fletch_INSTALL}/share/gdal on other platforms.  This patch sets the DATADIR variable to make GDAL put it's files in a consistent location on Windows too.