### PR TITLE
Fix typo in CMake symbol name.

### DIFF
--- a/CMake/External_YAMLcpp.cmake
+++ b/CMake/External_YAMLcpp.cmake
@@ -11,7 +11,7 @@ endif()
 ExternalProject_Add(YAMLcpp
   DEPENDS ${_YAMLCPP_DEPENDS}
   URL ${YAMLcpp_url}
-  URL_MD5 ${YAMPcpp_md5}
+  URL_MD5 ${YAMLcpp_md5}
   DOWNLOAD_NAME ${YAMLcpp_dlname}
   ${COMMON_EP_ARGS}
   ${COMMON_CMAKE_EP_ARGS}


### PR DESCRIPTION
This type causes YAML to be downloaded even if it has already been done.