### PR TITLE
disables GDAL with libkml

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -118,6 +118,10 @@ else()
     set(_GDAL_ARGS_XML2 "--with-xml2=${LIBXML2_ROOT}/bin/xml2-config")
   endif()
 
+  # GDAL has a tendency to pick up old libkml versions and fail.
+  #   Thus, disable GDAL with libkml.
+  set(_GDAL_ARGS_libKML "--with-libkml=no")
+
   #+
   # GDAL Python dosen't work well for GDAL 1, nor does it work well on Apple at the moment
   #-
@@ -137,7 +141,7 @@ endif()
   set (GDAL_PKG_ARGS
     ${_GDAL_ARGS_PYTHON} ${_GDAL_PNG_ARGS} ${_GDAL_GEOTIFF_ARGS} ${_GDAL_ARGS_PG}
     ${_GDAL_ARGS_PROJ4} ${_GDAL_ARGS_XML2} ${_GDAL_TIFF_ARGS} ${_GDAL_ARGS_SQLITE}
-    ${_GDAL_ARGS_ZLIB} ${_GDAL_ARGS_LTIDSDK} ${JPEG_ARG}
+    ${_GDAL_ARGS_ZLIB} ${_GDAL_ARGS_LTIDSDK} ${JPEG_ARG} ${_GDAL_ARGS_libKML}
     --without-jasper
     )
 

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -21,3 +21,6 @@ Fixes since v1.2.0
 - Libjpeg-turbo and libtiff are now requirements to build libgeotiff. It was possible to
   try to build libgeotiff without libjpeg-tubo and libtiff enabled, this would result in
   several build errors.
+
+- GDAL will now no longer built with google libkml support. GDAL would fail occasionally
+  as a result of automatically finding and using an old libkml version.


### PR DESCRIPTION
Prevent GDAL from failing as a result of picking up an old libkml version.