### PR TITLE
update ZLib to 1.2.9, fix ZLib find errors

### DIFF
--- a/CMake/External_PNG.cmake
+++ b/CMake/External_PNG.cmake
@@ -8,7 +8,7 @@ add_package_dependency(
 )
 if(NOT ZLIB_FOUND)
   set(ZLIB_INCLUDE_DIRS ${fletch_BUILD_INSTALL_PREFIX}/include)
-  get_system_library_name(z zlib_lib)
+  get_system_library_name(zlib zlib_lib)
   set(ZLIB_LIBRARIES ${fletch_BUILD_INSTALL_PREFIX}/lib/${zlib_lib})
 endif()
 set(png_cmake_args ${png_cmake_args}

--- a/CMake/External_PNG.cmake
+++ b/CMake/External_PNG.cmake
@@ -8,7 +8,7 @@ add_package_dependency(
 )
 if(NOT ZLIB_FOUND)
   set(ZLIB_INCLUDE_DIRS ${fletch_BUILD_INSTALL_PREFIX}/include)
-  get_system_library_name(zlib zlib_lib)
+  get_system_library_name(z zlib_lib)
   set(ZLIB_LIBRARIES ${fletch_BUILD_INSTALL_PREFIX}/lib/${zlib_lib})
 endif()
 set(png_cmake_args ${png_cmake_args}

--- a/CMake/External_ZLib.cmake
+++ b/CMake/External_ZLib.cmake
@@ -23,8 +23,8 @@ elseif(NOT APPLE)
   # For Linux machines
   ExternalProject_Add_Step(ZLib fixup-install
     COMMAND ${CMAKE_COMMAND} -E copy
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.so
       ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.so
+      ${fletch_BUILD_INSTALL_PREFIX}/lib/liblibz.so
     DEPENDEES install
     )
 endif()

--- a/CMake/External_ZLib.cmake
+++ b/CMake/External_ZLib.cmake
@@ -27,6 +27,14 @@ elseif(NOT APPLE)
       ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.so
     DEPENDEES install
     )
+else()
+  # APPLE
+  ExternalProject_Add_Step(ZLib fixup-install
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.dylib
+      ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.dylib
+    DEPENDEES install
+    )
 endif()
 
 fletch_external_project_force_install(PACKAGE ZLib STEP_NAMES install fixup-install)

--- a/CMake/External_ZLib.cmake
+++ b/CMake/External_ZLib.cmake
@@ -24,7 +24,7 @@ elseif(NOT APPLE)
   ExternalProject_Add_Step(ZLib fixup-install
     COMMAND ${CMAKE_COMMAND} -E copy
       ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.so
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/liblibz.so
+      ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.so
     DEPENDEES install
     )
 endif()

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -42,10 +42,9 @@ endif()
 list(APPEND fletch_external_sources Boost)
 
 # ZLib
-set(ZLib_version 1.2.8)
-set(ZLib_tag "66a753054b356da85e1838a081aa94287226823e")
-set(ZLib_url "https://github.com/commontk/zlib/archive/${ZLib_tag}.zip")
-set(zlib_md5 "1d0e64ac4f7c7fe3a73ae044b70ef857")
+set(ZLib_version 1.2.9)
+set(ZLib_url "https://github.com/madler/zlib/archive/v${ZLib_version}.zip")
+set(zlib_md5 "d71ee9e2998abd2fdfb6a40c8f3c7bd7")
 set(zlib_dlname "zlib-${ZLib_version}.zip")
 list(APPEND fletch_external_sources ZLib)
 

--- a/Patches/ZLib/CMakeLists.txt
+++ b/Patches/ZLib/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 2.8)
+
+PROJECT(ZLIB)
+
+SET(ZLIB_MANGLE_PREFIX "" CACHE STRING "Mangle prefix. For example 'cm_zlib_', 'z_', ...")
+
+SET(ZLIB_VERSION_MAJOR "1")
+SET(ZLIB_VERSION_MINOR "2")
+SET(ZLIB_VERSION_PATCH "9")
+
+INCLUDE_DIRECTORIES(
+  "${ZLIB_SOURCE_DIR}"
+  "${ZLIB_SOURCE_DIR}"
+  "${ZLIB_BINARY_DIR}"
+  )
+
+# source files for zlib
+SET(ZLIB_SRCS
+  adler32.c  compress.c  crc32.c  deflate.c  gzio.c   inffast.c
+  inflate.c  inftrees.c  trees.c  uncompr.c  zutil.c
+  )
+
+# for windows add the .def and .rc files to the source list
+# if building shared libs
+IF(WIN32)
+  IF(BUILD_SHARED_LIBS)
+    SET(ZLIB_DLL 1)
+    IF(NOT UNIX)
+      IF(NOT BORLAND)
+        IF(NOT MINGW)
+          CONFIGURE_FILE(zlib.def.in ${ZLIB_BINARY_DIR}/zlib.def)
+          SET(ZLIB_SRCS ${ZLIB_SRCS} ${ZLIB_BINARY_DIR}/zlib.def zlib.rc)
+        ENDIF(NOT MINGW)
+      ENDIF(NOT BORLAND) 
+    ENDIF(NOT UNIX)   
+  ENDIF(BUILD_SHARED_LIBS)
+ENDIF(WIN32)
+
+CONFIGURE_FILE(${ZLIB_SOURCE_DIR}/.NoDartCoverage
+  ${ZLIB_BINARY_DIR}/.NoDartCoverage)
+CONFIGURE_FILE(${ZLIB_SOURCE_DIR}/zlibDllConfig.h.in
+  ${ZLIB_BINARY_DIR}/zlibDllConfig.h)
+CONFIGURE_FILE(${ZLIB_SOURCE_DIR}/zlib_mangle.h.in
+  ${ZLIB_BINARY_DIR}/zlib_mangle.h)
+    
+FOREACH(name zlib zconf)
+  CONFIGURE_FILE(${ZLIB_SOURCE_DIR}/${name}.h
+    ${ZLIB_BINARY_DIR}/${name}.h COPYONLY)
+ENDFOREACH(name)
+
+ADD_LIBRARY(zlib ${ZLIB_SRCS})
+
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  SET_TARGET_PROPERTIES(zlib PROPERTIES COMPILE_FLAGS "-fPIC")
+ENDIF()
+
+# Configure install locations.  This allows parent projects to modify
+# the install location.
+IF(NOT ZLIB_INSTALL_BIN_DIR)
+  SET(ZLIB_INSTALL_BIN_DIR bin)
+ENDIF()
+
+IF(NOT ZLIB_INSTALL_INCLUDE_DIR)
+  SET(ZLIB_INSTALL_INCLUDE_DIR include)
+ENDIF()
+
+IF(NOT ZLIB_INSTALL_LIB_DIR)
+  SET(ZLIB_INSTALL_LIB_DIR lib)
+ENDIF()
+
+IF(NOT ZLIB_INSTALL_DOC_DIR)
+  SET(ZLIB_INSTALL_DOC_DIR
+    doc/zlib-${ZLIB_VERSION_MAJOR}.${ZLIB_VERSION_MINOR}.${ZLIB_VERSION_PATCH}
+    )
+ENDIF()
+
+# Install library
+INSTALL(TARGETS zlib
+  RUNTIME DESTINATION ${ZLIB_INSTALL_BIN_DIR} COMPONENT RuntimeLibraries
+  LIBRARY DESTINATION ${ZLIB_INSTALL_LIB_DIR} COMPONENT RuntimeLibraries
+  ARCHIVE DESTINATION ${ZLIB_INSTALL_LIB_DIR} COMPONENT Development
+  )
+
+# Install public headers
+INSTALL(FILES
+  zlib.h
+  zconf.h
+  ${ZLIB_BINARY_DIR}/zlib_mangle.h
+  ${ZLIB_BINARY_DIR}/zlibDllConfig.h
+  DESTINATION ${ZLIB_INSTALL_INCLUDE_DIR} COMPONENT Development
+  )
+
+INSTALL(FILES Copyright.txt DESTINATION ${ZLIB_INSTALL_DOC_DIR} COMPONENT RuntimeLibraries)

--- a/Patches/ZLib/Patch.cmake
+++ b/Patches/ZLib/Patch.cmake
@@ -1,0 +1,6 @@
+#+
+# This file is called as CMake -P script for the patch step of
+# External_Zlib.cmake
+#-
+
+file(COPY ${zlib_patch}/CMakeLists.txt	DESTINATION ${zlib_source})


### PR DESCRIPTION
Prerequisite to #502 

Update ZLib from version 1.2.8 (or 1.2.3 according to the CMakeLists.txt) to version 1.2.9, which is required to build libkml 1.3.0 for this PR #502.

This also changes the ZLib source from a Kitware fork to an official ZLib release. (Injecting our custom CMakeLists.txt to build it)

...as well as a bonus ZLib library find fix for Apple