### PR TITLE
Upgrade OpenCV 3.4.0 to 3.4.1

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -287,8 +287,8 @@ list(APPEND fletch_external_sources Qt)
 # OpenCV
 # Support 2.4.13 and 3.4 optionally
 if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
-  set(OpenCV_SELECT_VERSION 3.4.0 CACHE STRING "Select the  version of OpenCV to build.")
-  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "2.4.13" "3.4.0")
+  set(OpenCV_SELECT_VERSION 3.4.1 CACHE STRING "Select the  version of OpenCV to build.")
+  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "2.4.13" "3.4.1")
 
   set(OpenCV_version ${OpenCV_SELECT_VERSION})
   set(OpenCV_url "http://github.com/Itseez/opencv/archive/${OpenCV_version}.zip")
@@ -306,9 +306,9 @@ if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPE
   endif()
 
   # Paired contrib repo information
-  if (OpenCV_version VERSION_EQUAL 3.4.0)
-    set(OpenCV_md5 "ed60f8bbe7a448f325d0a0f58fcf2063")
-    set(OpenCV_contrib_md5 "92c09ce6c837329f05802a8d17136148")
+  if (OpenCV_version VERSION_EQUAL 3.4.1)
+    set(OpenCV_md5 "8464ce888f4c283895626950bada1e44")
+    set(OpenCV_contrib_md5 "a255639242d58dd7e329556d43f2c316")
   elseif (OpenCV_version VERSION_EQUAL 2.4.13)
     set(OpenCV_md5 "886b0c511209b2f3129649928135967c")
   else()

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -14,6 +14,8 @@ New Packages
 
 Package Upgrades
 
+ - OpenCV has been upgraded from 3.4.0 to 3.4.1. The new version contains fixes for
+   multiple bugs.
 
 Fixes since v1.2.0
 ------------------


### PR DESCRIPTION
3.4.1 includes several bug fixes, one in particular that i've seen pop up on our Windows dashboard.
(apparently only occurs when enabling Qt5...)
`error C2079: 'cvv::view::DualFilterView::rawImages_' uses undefined class 'std::array<cv::Mat,2>' `
See: https://open.cdash.org/viewBuildError.php?buildid=5752586

This error is holding up https://github.com/Kitware/fletch/pull/485 from getting merged.

Fix here: https://github.com/Microsoft/vcpkg/issues/3024
