### PR TITLE
VTK fixes for ViViA

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -8,6 +8,17 @@ set(install_include_dir ${fletch_BUILD_INSTALL_PREFIX}/include)
 set(install_library_dir ${fletch_BUILD_INSTALL_PREFIX}/lib)
 set(install_binary_dir ${fletch_BUILD_INSTALL_PREFIX}/bin)
 
+# Rendering backend
+if(VTK_SELECT_VERSION VERSION_LESS 8.1)
+  set(vtk_cmake_args ${vtk_cmake_args}
+      -DVTK_RENDERING_BACKEND:STRING=OpenGL
+      )
+else()
+  set(vtk_cmake_args ${vtk_cmake_args}
+      -DVTK_RENDERING_BACKEND:STRING=OpenGL2
+      )
+endif()
+
 # Boost
 # Do not use boost with VTK. It's unecessary and causes build errors.
 set(vtk_cmake_args ${vtk_cmake_args}
@@ -63,7 +74,6 @@ if(Qt_version_major EQUAL 4)
   if(QT_QMAKE_EXECUTABLE)
     set(BUILD_QT_WEBKIT ${QT_QTWEBKIT_FOUND})
     set(vtk_cmake_args ${vtk_cmake_args}
-      -DVTK_RENDERING_BACKEND:STRING=OpenGL
       -DQT_QMAKE_EXECUTABLE:PATH=${QT_QMAKE_EXECUTABLE}
       -DVTK_QT_VERSION:STRING=4
     )
@@ -77,7 +87,6 @@ else()
       Core Gui Widgets OpenGL Designer UiPlugin
   )
   set(vtk_cmake_args ${vtk_cmake_args}
-    -DVTK_RENDERING_BACKEND:STRING=OpenGL2
     -DQt5_DIR:PATH=${Qt5_DIR}
     -DVTK_QT_VERSION:STRING=5
   )

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -426,9 +426,9 @@ elseif (VTK_SELECT_VERSION VERSION_EQUAL 8.1)
   set(VTK_url "http://www.vtk.org/files/release/${VTK_SELECT_VERSION}/VTK-${VTK_version}.zip")
   set(VTK_md5 "64f3acd5c28b001d5bf0e5a95b3a0af5")  # v8.1.1
 elseif (VTK_SELECT_VERSION VERSION_EQUAL 8.0)
-  set(VTK_version 8.0.0)
+  set(VTK_version 8.0.1)
   set(VTK_url "http://www.vtk.org/files/release/${VTK_SELECT_VERSION}/VTK-${VTK_version}.zip")
-  set(VTK_md5 "0bec6b6aa3c92cc9e058a12e80257990")  # v8.0.0
+  set(VTK_md5 "c248dbe8ffd9b74c6f41199e66d6c690")  # v8.0.1
 elseif (VTK_SELECT_VERSION VERSION_EQUAL 6.2)
   # TODO: Remove when we remove support for OpenCV < 3.2
   set(VTK_version 6.2.0)


### PR DESCRIPTION
Select VTK rendering backend based on VTK version, rather than Qt version. Update from 8.0.0 to 8.0.1. These changes¹ are needed by ViViA, which is [working on transitioning to Qt5](https://github.com/Kitware/vivia/pull/47), but still requires VTK 8.0 due to [API breakage](https://gitlab.kitware.com/vtk/vtk/merge_requests/3451#note_462858) and has not yet been ported to VTK's OpenGL2 backend (which is also suspected of being flaky in 8.0).

Our other main consumer, TeleSculptor, which does use the OpenGL2 backend, requires VTK 8.2.

(¹ Well, pedantically, just the backend selection stuff; I want to update to 8.0.1 because it's what I'm using locally, but I don't know that it's required for anything.)