### PR TITLE
Fix OpenCV ITK depends

### DIFF
--- a/CMake/External_ITK.cmake
+++ b/CMake/External_ITK.cmake
@@ -63,7 +63,7 @@ if (fletch_ENABLE_OpenCV)
     -DModule_ITKVideoBridgeOpenCV:BOOL=ON
     -DOpenCV_DIR:PATH=${OpenCV_ROOT}
     )
-  list(APPEND ITK_DEPENDS VXL)
+  list(APPEND ITK_DEPENDS OpenCV)
 endif()
 
 ExternalProject_Add(ITK


### PR DESCRIPTION
ITK is trying to build before OpenCV has finished building, and errors because ITK can't find OpenCV.

This PR fixes it.

```
CMake Error at Modules/Video/BridgeOpenCV/itk-module-init.cmake:4 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.

  Could not find a package configuration file provided by "OpenCV" with any
  of the following names:

    OpenCVConfig.cmake
    opencv-config.cmake

  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
  "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMake/ITKModuleEnablement.cmake:318 (include)
  CMakeLists.txt:426 (include)--
-- Configuring incomplete, errors occurred!
 
See also "/root/viame/build/build/src/fletch-build/build/src/ITK-build/CMakeFiles/CMakeOutput.log".
See also "/root/viame/build/build/src/fletch-build/build/src/ITK-build/CMakeFiles/CMakeError.log".
CMakeFiles/ITK.dir/build.make:115: recipe for target 'build/src/ITK-stamp/ITK-configure' failed
make[5]: *** [build/src/ITK-stamp/ITK-configure] Error 1
```
 
Then I see all the way down (~500 lines later) in the log:

```
[ 97%] Completed 'OpenCV'
[ 97%] Built target OpenCV
```