### PR TITLE
Update FFMPEG default version to 3.3.3

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -92,7 +92,7 @@ set(yasm_md5 "fc9e586751ff789b34b1f21d572d96af")
 set(_FFmpeg_supported TRUE)
 if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
   # allow different versions to be selected for testing purposes
-  set(FFmpeg_SELECT_VERSION 2.6.2 CACHE STRING "Select the version of FFmpeg to build.")
+  set(FFmpeg_SELECT_VERSION 3.3.3 CACHE STRING "Select the version of FFmpeg to build.")
   set_property(CACHE FFmpeg_SELECT_VERSION PROPERTY STRINGS "2.6.2" "3.3.3")
   mark_as_advanced(FFmpeg_SELECT_VERSION)
 
@@ -108,7 +108,7 @@ if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
     include(CheckTypeSize)
     if (CMAKE_SIZEOF_VOID_P EQUAL 4)  # 32 Bits
       set(bitness 32)
-      message(FATAL_ERROR "Fletch does NOT support FMPEG 32 bit. Please use 64bit.")
+      message(FATAL_ERROR "Fletch does NOT support FFMPEG 32 bit. Please use 64 bit.")
     endif()
     # On windows download prebuilt binaries and shared libraries
     # dev contains headers .lib, .def, and mingw .dll.a files

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -15,6 +15,8 @@ New Packages
 
 Package Upgrades
 
+ * Updated default FFMPEG version from 2.6.2 to 3.3.3.
+
  * Added option for VTK 8.2 and removed older 8.1 and 8.2-pre
 
 


### PR DESCRIPTION
Recently approved change in KWIVER (Kitware/kwiver#799) require newer FFMPEG for fast accurate seeking in the FFMPEG arrow.  Some tests will fail if we use the older version 2.6.2.

The only potential downside is that the old VXL implementation (vidl_ffmpeg) used in KWIVER may not work as reliably with the new FFMPEG.  I suggest we update the default version but continue to support 2.6.2 as an option.  This will force us to either update or abandon vidl_ffmpeg.