### PR TITLE
Update qtextensions

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -564,10 +564,10 @@ set(YAMLcpp_dlname "yaml-cpp-release-${YAMLcpp_version}.tar.gz")
 list(APPEND fletch_external_sources YAMLcpp)
 
 # qtExtensions
-set(qtExtensions_version "20190206gited20c9ed")
-set(qtExtensions_tag "ed20c9edea67732f0ea363cd6b36d3c7379c8c71")
+set(qtExtensions_version "20190517gita911d919")
+set(qtExtensions_tag "a911d919bc8f01c6f3af067dc95a654b2f27cf16")
 set(qtExtensions_url "https://github.com/Kitware/qtextensions/archive/${qtExtensions_tag}.tar.gz")
-set(qtExtensions_md5 "6c5e11c26146e4964d4e973921501e56")
+set(qtExtensions_md5 "b4be0f7cf4b3bde943fc1d47061fa82a")
 set(qtExtensions_dlname "qtExtensions-${qtExtensions_version}.tar.gz")
 list(APPEND fletch_external_sources qtExtensions)
 

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -15,6 +15,8 @@ New Packages
 
 Package Upgrades
 
+ * Updated qtextensions to 20190517gita911d919.
+
  * Updated default FFMPEG version from 2.6.2 to 3.3.3.
 
  * Added option for VTK 8.2 and removed older 8.1 and 8.2-pre


### PR DESCRIPTION
Update qtextensions to get latest bug fix that allows qte-amc to work on Linux in a superbuild