### PR TITLE
When enabling mrsid in gdal, explicitly disable openjpeg

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -135,6 +135,8 @@ else()
     set(JPEG_ARG "--with-openjpeg=${openjpeg_ROOT}")
     list(APPEND _GDAL_DEPENDS openjpeg)
     set( _GDAL_PKG_CONFIG_PATH "PKG_CONFIG_PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/pkgconfig" )
+  else()
+    set(JPEG_ARG "--without-openjpeg")
   endif()
 
   # Here is where you add any new package related args for tiff, so we don't keep repeating them below.


### PR DESCRIPTION
If we don't explicitly disable openjpeg, GDAL will find it and include the plugin. If GDAL has both mrsid and openjpeg plugins, it favours openjpeg which is not capable of opening some of our nitf files..