### PR TITLE
parameterize the dockerfile to accept build args

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -40,7 +40,6 @@ RUN apt-get clean \
 #
 # Build Fletch
 #
-RUN echo "$PY_MAJOR_VERSION"
 COPY . /fletch
 RUN mkdir -p /fletch/build /opt/kitware/fletch \
   && cd /fletch/build \

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,12 @@
 # Fletch Dockerfile
 # Installs the fletch binary to /opt/kitware/fletch
-ARG BASE_IMAGE=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
+ARG BASE_IMAGE=Ubuntu:18.04
 FROM ${BASE_IMAGE}
+
 ARG PY_MAJOR_VERSION=3
-ARG ENABLE_CUDA=ON
+ARG ENABLE_CUDA=OFF
+
 #
 # Install System Dependencies
 #
@@ -23,6 +25,7 @@ RUN apt-get update && \
                                                libreadline-dev \
                                                zlib1g-dev \
                                                cmake
+                                               
 # conditional python package installation based on version
 RUN if [ "$PY_MAJOR_VERSION" = "2" ]; then \
       apt-get install --no-install-recommends -y python2.7-dev \
@@ -35,11 +38,14 @@ RUN if [ "$PY_MAJOR_VERSION" = "2" ]; then \
       pip3 install numpy && \
       ln -s /usr/bin/python3 /usr/local/bin/python; \
     fi
+    
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+    
 #
 # Build Fletch
 #
+ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH
 COPY . /fletch
 RUN mkdir -p /fletch/build /opt/kitware/fletch \
   && cd /fletch/build \
@@ -52,4 +58,3 @@ RUN mkdir -p /fletch/build /opt/kitware/fletch \
     ../ \
   && make -j$(nproc) -k \
   && rm -rf /fletch
-ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH

--- a/dockerfile
+++ b/dockerfile
@@ -1,49 +1,56 @@
 # Fletch Dockerfile
 # Installs the fletch binary to /opt/kitware/fletch
+ARG BASE_IMAGE=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
-ARG UBUNTU_VER=18.04
-FROM ubuntu:${UBUNTU_VER}
-
+FROM ${BASE_IMAGE}
+ARG PY_MAJOR_VERSION=3
+ARG ENABLE_CUDA=ON
 #
 # Install System Dependencies
 #
-
-RUN apt-get update && apt-get install --no-install-recommends -y \ 
- build-essential \ 
- libgl1-mesa-dev \
- libexpat1-dev \
- libgtk2.0-dev \
- libxt-dev \
- libxml2-dev \
- libssl-dev \
- liblapack-dev \
- openssl \
- curl \
- git \
- python3-dev \
- python3-pip \
- libreadline-dev \
- zlib1g-dev \
- cmake \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && pip3 install numpy
-
-RUN ln -s /usr/bin/python3 /usr/local/bin/python
-
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y build-essential \
+                                               libgl1-mesa-dev \
+                                               libexpat1-dev \
+                                               libgtk2.0-dev \
+                                               libxt-dev \
+                                               libxml2-dev \
+                                               libssl-dev \
+                                               liblapack-dev \
+                                               openssl \
+                                               curl \
+                                               git \
+                                               libreadline-dev \
+                                               zlib1g-dev \
+                                               cmake
+# conditional python package installation based on version
+RUN if [ "$PY_MAJOR_VERSION" = "2" ]; then \
+      apt-get install --no-install-recommends -y python2.7-dev \
+                                                 python-pip && \
+      pip install numpy; \
+    else \
+      apt-get install --no-install-recommends -y python3 \
+                                                 python3-dev \
+                                                 python3-pip && \
+      pip3 install numpy && \
+      ln -s /usr/bin/python3 /usr/local/bin/python; \
+    fi
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 #
 # Build Fletch
 #
-
-ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH
+RUN echo "$PY_MAJOR_VERSION"
 COPY . /fletch
 RUN mkdir -p /fletch/build /opt/kitware/fletch \
   && cd /fletch/build \
   && cmake -DCMAKE_BUILD_TYPE=Release \
     -Dfletch_ENABLE_ALL_PACKAGES=ON \
     -Dfletch_BUILD_WITH_PYTHON=ON \
-    -Dfletch_PYTHON_MAJOR_VERSION=3 \
+    -Dfletch_BUILD_WITH_CUDA=${ENABLE_CUDA} \
+    -Dfletch_PYTHON_MAJOR_VERSION=${PY_MAJOR_VERSION} \
     -Dfletch_BUILD_INSTALL_PREFIX=/opt/kitware/fletch \
     ../ \
-  && make -j`nproc` -k \
-  && rm -rf /fletch 
+  && make -j$(nproc) -k \
+  && rm -rf /fletch
+ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH

--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 # Fletch Dockerfile
 # Installs the fletch binary to /opt/kitware/fletch
 
-ARG BASE_IMAGE=Ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:18.04
 FROM ${BASE_IMAGE}
 
 ARG PY_MAJOR_VERSION=3


### PR DESCRIPTION
Adds the following parameters:
- BASE_IMAGE
- PY_MAJOR_VERSION
- ENABLE_CUDA

These can be specified at 'docker build' time:

`docker build -t fletch:latest --build-arg BASE_IMAGE=ubuntu:16.04 . `