### PR TITLE
Add option to enable/disable VTK Python wrappings

### DIFF
--- a/CMake/External_ITK.cmake
+++ b/CMake/External_ITK.cmake
@@ -2,9 +2,6 @@
 
 include(${fletch_CMAKE_DIR}/Utils.cmake)
 
-
-
-
 # ZLIB
 if (fletch_ENABLE_ZLib)
   add_package_dependency(
@@ -45,10 +42,28 @@ if (fletch_ENABLE_PNG)
 endif()
 
 list (APPEND itk_cmake_args
-  -DITK_WRAP_PYTHON:BOOL=${fletch_BUILD_WITH_PYTHON}
   -DITK_LEGACY_SILENT:BOOL=ON
   -DBUILD_TESTING:BOOL=OFF
   )
+
+if (fletch_BUILD_WITH_PYTHON)
+  option(fletch_ENABLE_ITK_PYTHON "Enable Python wrappings for ITK" ON)
+  mark_as_advanced(fletch_ENABLE_ITK_PYTHON)
+
+  if (fletch_ENABLE_ITK_PYTHON)
+    list (APPEND itk_cmake_args
+      -DITK_WRAP_PYTHON:BOOL=ON
+      )
+  else()
+    list (APPEND itk_cmake_args
+      -DITK_WRAP_PYTHON:BOOL=OFF
+      )
+  endif()
+else()
+  list (APPEND itk_cmake_args
+    -DITK_WRAP_PYTHON:BOOL=OFF
+    )
+endif()
 
 if (fletch_ENABLE_VXL)
   list (APPEND itk_cmake_args

--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -187,24 +187,27 @@ set(vtk_cmake_args ${vtk_cmake_args}
   )
 
 # PYTHON
-if (fletch_BUILD_WITH_PYTHON AND NOT MSVC14 )
+if(fletch_BUILD_WITH_PYTHON AND NOT MSVC14 )
+  option(fletch_ENABLE_VTK_PYTHON "Enable Python wrappings for VTK" ON)
   find_package(PythonInterp)
   find_package(PythonLibs)
 
-  if(PythonInterp_FOUND AND PythonLibs_FOUND)
+  if(PythonInterp_FOUND AND PythonLibs_FOUND AND fletch_ENABLE_VTK_PYTHON)
     set(VTK_WRAP_PYTHON ON)
     message(STATUS "VTK building with python support")
   else()
     set(VTK_WRAP_PYTHON OFF)
-    message(WARNING "VTK building without python support. Python NOT found.")
+    if(fletch_ENABLE_VTK_PYTHON)
+      message(WARNING "VTK building without python support. Python NOT found.")
+    endif()
   endif()
 elseif(fletch_BUILD_WITH_PYTHON AND MSVC14)
   message(WARNING "VTK Python will not build correctly on Visual Studio 2015. VTK 7.0 of higher is required.")
 endif()
 
-if (fletch_ENABLE_VTK AND VTK_WRAP_PYTHON AND VTK_SELECT_VERSION VERSION_LESS 7.0.0)
-  if (NOT fletch_PYTHON_MAJOR_VERSION VERSION_LESS 3)
-    if (fletch_BUILD_WITH_PYTHON)
+if(fletch_ENABLE_VTK AND VTK_WRAP_PYTHON AND VTK_SELECT_VERSION VERSION_LESS 7.0.0)
+  if(NOT fletch_PYTHON_MAJOR_VERSION VERSION_LESS 3)
+    if(fletch_BUILD_WITH_PYTHON)
       message(WARNING "Enabling Python 3 in VTK requires VTK 7.0 or greater")
     endif()
     # Enabling Python 3 in VTK requires VTK 7.0 or greater
@@ -237,7 +240,7 @@ list(APPEND vtk_cmake_args
   )
 
 set (VTK_PATCH_DIR ${fletch_SOURCE_DIR}/Patches/VTK/${VTK_SELECT_VERSION})
-if (EXISTS ${VTK_PATCH_DIR})
+if(EXISTS ${VTK_PATCH_DIR})
   set(VTK_PATCH_COMMAND ${CMAKE_COMMAND}
     -DVTK_PATCH_DIR=${VTK_PATCH_DIR}
     -DVTK_SOURCE_DIR=${fletch_BUILD_PREFIX}/src/VTK

--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -189,6 +189,8 @@ set(vtk_cmake_args ${vtk_cmake_args}
 # PYTHON
 if(fletch_BUILD_WITH_PYTHON AND NOT MSVC14 )
   option(fletch_ENABLE_VTK_PYTHON "Enable Python wrappings for VTK" ON)
+  mark_as_advanced(fletch_ENABLE_VTK_PYTHON)
+
   find_package(PythonInterp)
   find_package(PythonLibs)
 


### PR DESCRIPTION
The default VIAME build currently fails when Python wrappings for VTK are enabled in Python 3.7. While it might be possible to fix this in VIAME by updating the default VTK version, an alternative option is to simply disable `VTK_WRAP_PYTHON`. This has the additional benefit of shortening build time. 

I added a new option `fletch_ENABLE_VTK_PYTHON`, which does this. It defaults to "ON", so original behavior is preserved. I modified the warning messages so no warning will happen when fletch_ENABLE_VTK_PYTHON is OFF. 

Lastly, this local block of code has a inconsistency in spacing after "if" statements, so I modified those to make them consistent while I was editing the file. 