### PR TITLE
update eigen source to gitlab, bitbucket is a deprecated host

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -148,8 +148,8 @@ endif()
 
 # EIGEN
 set(Eigen_version 3.3.4)
-set(Eigen_url "http://bitbucket.org/eigen/eigen/get/${Eigen_version}.tar.gz")
-set(Eigen_md5 "1a47e78efe365a97de0c022d127607c3")
+set(Eigen_url "https://gitlab.com/libeigen/eigen/-/archive/${Eigen_version}/eigen-${Eigen_version}.tar.gz")
+set(Eigen_md5 "7bff43034070a626687d901f4c8f54a0")
 set(Eigen_dlname "eigen-${Eigen_version}.tar.gz")
 list(APPEND fletch_external_sources Eigen)
 


### PR DESCRIPTION
Please see:

http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th