### PR TITLE
Make caffe version selectable

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -511,9 +511,12 @@ if(NOT WIN32)
 endif()
 
 # Caffe
-set(InternalCaffe True)
+set(Caffe_SELECT_VERSION "2" CACHE STRING "Select the  version of Caffe to build.")
+set_property(CACHE Caffe_SELECT_VERSION PROPERTY STRINGS "1" "2")
 
-if(InternalCaffe)
+set(Caffe_version ${Caffe_SELECT_VERSION})
+
+if (Caffe_version VERSION_EQUAL 2)
   # Use the internal kitware hosted Caffe, which contain additional
   # functionality that has not been merged into the BVLC version.
   # This is the recommended option.
@@ -527,7 +530,6 @@ if(InternalCaffe)
     set(Caffe_md5 "29b5ddbd6e2f47836cee5e55c88e098f")
   endif()
 else()
-  # The original BVLC Caffe does not currently contain required functionality.
   set(Caffe_version "1.0")
   set(Caffe_url "https://github.com/BVLC/caffe/archive/${Caffe_version}.tar.gz")
   set(Caffe_md5 "5fbb0e32e7cd8de3de46e6fe6e4cd2b5")

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -522,12 +522,12 @@ if (Caffe_version VERSION_EQUAL 2)
   # This is the recommended option.
   if(WIN32)
     set(Caffe_version "527f97c0692f116ada7cb97eed8172ef7da05416")
-    set(Caffe_url "https://gitlab.kitware.com/kwiver/caffe/repository/fletch%2Fwindows/archive.zip")
-    set(Caffe_md5 "a8376d867d87b6340313b82d87743bc7")
+    set(Caffe_url "https://gitlab.kitware.com/kwiver/caffe/-/archive/fletch/windows/caffe-fletch-windows.zip")
+    set(Caffe_md5 "4f3f8c56f9bf8f0e7a5534a1080d4ef1")
   else()
     set(Caffe_version "7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b")
-    set(Caffe_url "https://gitlab.kitware.com/kwiver/caffe/repository/fletch%2Flinux/archive.zip")
-    set(Caffe_md5 "29b5ddbd6e2f47836cee5e55c88e098f")
+    set(Caffe_url "https://gitlab.kitware.com/kwiver/caffe/-/archive/fletch/linux/caffe-fletch-linux.zip")
+    set(Caffe_md5 "8eda68aa96d0bbdd446e2125553f46de")
   endif()
 else()
   set(Caffe_version "1.0")
@@ -549,8 +549,8 @@ endif()
 
 # Darknet
 # The Darket package used is a fork maintained by kitware that uses CMake and supports building/running on windows
-set(Darknet_url "https://gitlab.kitware.com/kwiver/darknet/repository/fletch%2Fmaster/archive.zip")
-set(Darknet_md5 "d206b6da7af1f43340a217d6b05db5e3")
+set(Darknet_url "https://gitlab.kitware.com/kwiver/darknet/-/archive/master/darknet-master.zip")
+set(Darknet_md5 "5dd51e1965848b5186c08ddab2414489")
 set(Darnet_dlname "darknent-d206b6da7af1f4.zip")
 list(APPEND fletch_external_sources Darknet)
 


### PR DESCRIPTION
Make Caffe version selectable. The options are for either version 1 or version 2, with 2 being the default.