### PR TITLE
Build GDAL without curl, netcdf, kea, and use fletch geos

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -27,22 +27,29 @@ endif()
 if (WIN32)
   if(fletch_ENABLE_PNG)
     set(_GDAL_ARGS_PNG)
-    set(_GDAL_ARGS_PNG PNGDIR=${fletch_BUILD_INSTALL_PREFIX}/include PNG_LIB=${fletch_BUILD_INSTALL_PREFIX}/lib/libpng.lib)
+    set(_GDAL_ARGS_PNG PNGDIR=${fletch_BUILD_INSTALL_PREFIX}/include PNG_LIB=${PNG_LIBRARY})
     list(APPEND _GDAL_DEPENDS PNG)
   endif()
 
   if(fletch_ENABLE_libtiff)
     list(APPEND _GDAL_DEPENDS libtiff)
-    set( _GDAL_TIFF_ARGS TIFF_INC=-I${fletch_BUILD_INSTALL_PREFIX}/include TIFF_LIB=${fletch_BUILD_INSTALL_PREFIX}/lib/tiff.lib)
+    set( _GDAL_TIFF_ARGS TIFF_INC=-I${fletch_BUILD_INSTALL_PREFIX}/include TIFF_LIB=${TIFF_LIBRARY})
   endif()
 
   if(fletch_ENABLE_libgeotiff)
     list(APPEND _GDAL_DEPENDS libgeotiff)
-    set( _GDAL_GEOTIFF_ARGS GEOTIFF_INC=-I${fletch_BUILD_INSTALL_PREFIX}/include GEOTIFF_LIB=${fletch_BUILD_INSTALL_PREFIX}/lib/geotiff_i.lib)
+    set( _GDAL_GEOTIFF_ARGS GEOTIFF_INC=-I${fletch_BUILD_INSTALL_PREFIX}/include GEOTIFF_LIB=${libgeotiff_LIBRARY})
+  endif()
+
+  if(fletch_ENABLE_GEOS)
+    list(APPEND _GDAL_DEPENDS libgeos)
+    set( _GDAL_GEOS_ARGS GEOS_INC=-I${fletch_BUILD_INSTALL_PREFIX}/include GEOS_LIB=${GEOS_C_LIBRARY}))
   endif()
 
   # Here is where you add any new package related args for tiff, so we don't keep repeating them below.
-  set (GDAL_PKG_ARGS  ${_GDAL_MSVC_ARGS_LTISDK} ${_GDAL_ARGS_PNG} ${_GDAL_TIFF_ARGS} ${_GDAL_GEOTIFF_ARGS})
+  set (GDAL_PKG_ARGS  ${_GDAL_MSVC_ARGS_LTISDK} ${_GDAL_ARGS_PNG}
+                      ${_GDAL_TIFF_ARGS} ${_GDAL_GEOTIFF_ARGS}
+                      ${_GDAL_GEOS_ARGS})
   file(TO_NATIVE_PATH ${fletch_BUILD_INSTALL_PREFIX} _gdal_native_fletch_BUILD_INSTALL_PREFIX)
   set (GDAL_ARGS MSVC_VER=${MSVC_VERSION}
     DATADIR=${_gdal_native_fletch_BUILD_INSTALL_PREFIX}\\share\\gdal
@@ -74,7 +81,7 @@ else()
     # from macports.  GDAL's '--with-libiconv-prefix' option looks like it should handle
     # this but in fact seems to do nothing.
     #
-    # Note: previously this var disabled curl and netcdf which are no handled
+    # Note: previously this var disabled curl and netcdf which are now handled
     # by _GDAL_ARGS_UNSUPPORTED
     set(_GDAL_ARGS_APPLE --without-libtool --with-local=/usr)
   endif()
@@ -133,9 +140,8 @@ else()
   if(fletch_ENABLE_GEOS)
     list(APPEND _GDAL_DEPENDS GEOS)
     set( _GDAL_GEOS_ARGS "--with-geos=${GEOS_ROOT}")
-    message(STATUS "GEOS_ROOT = ${GEOS_ROOT}")
   else()
-    # TODO / FIXME: allow use of system geos? What is the best way to add that option?
+    # TODO: should we allow use of system geos?
     set(_GDAL_GEOS_ARGS --with-geos=no)
   endif()
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -352,6 +352,12 @@ set(libgeotiff_url "http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-${li
 set(libgeotiff_md5 "a7c7e11e301b7c17e44ea3107cd86e4e")
 list(APPEND fletch_external_sources libgeotiff)
 
+# GEOS
+set(GEOS_version "3.6.2" )
+set(GEOS_url "http://download.osgeo.org/geos/geos-${GEOS_version}.tar.bz2" )
+set(GEOS_md5 "a32142343c93d3bf151f73db3baa651f" )
+list(APPEND fletch_external_sources GEOS )
+
 # GDAL
 if (fletch_ENABLE_GDAL OR fletch_ENABLE_ALL_PACKAGES)
   set(GDAL_SELECT_VERSION 2.3.2 CACHE STRING "Select the major version of GDAL to build.")
@@ -370,12 +376,6 @@ if (fletch_ENABLE_GDAL OR fletch_ENABLE_ALL_PACKAGES)
   endif()
 endif()
 list(APPEND fletch_external_sources GDAL)
-
-# GEOS
-set(GEOS_version "3.6.2" )
-set(GEOS_url "http://download.osgeo.org/geos/geos-${GEOS_version}.tar.bz2" )
-set(GEOS_md5 "a32142343c93d3bf151f73db3baa651f" )
-list(APPEND fletch_external_sources GEOS )
 
 # PDAL
 set(PDAL_version 1.7.2)


### PR DESCRIPTION
I'm making this PR because I kept getting errors when trying to build fletch while my conda environment was enabled. Ideally this shouldn't influence anything because fletch builds all of its dependencies from source. However, due to GDAL's configuration system, I was finding that it the build process kept pulling incorrect libraries for proj4. This was weird because there is literally a `--with-proj=${PROJ4_ROOT}` flag passed to the gdal configure command in the External_GDAL.cmake file. Yet, it kept trying to include a "proj.h" file from my conda directory. 

I found out the reason was because GDAL found curl in my conda directory, which added my conda include and lib to the include / library search paths, which also included proj. Therefore there was no way for GDAL to determine which proj include file was correct (either the one provided by fletch or the one in my conda include dir), and it was picking the wrong one. 

I was able to work around this issue by simply disabling curl, netcdf, kea, and geos in the GDAL configure command. I'm not sure if we depend on any of that functionality (I haven't tested this with KWIVER yet), but I think if we do require those libs we probably should be building them ourselves anyway? 

So this purpose of this PR is to explicitly disable libs that GDAL might use that are not provided by fletch, but could be found in the system. There might be more than the four I added, but this is a start. Also it looks like netcdf and curl were already being disabled on OSX for similar reasons, so I consolidated those flags into a new `_GDAL_ARGS_UNSUPPORTED` var. 