### PR TITLE
Update PostGIS version

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -411,9 +411,9 @@ list(APPEND fletch_external_sources PostgreSQL)
 # PostGIS
 # Currently it seems the this version of PostGIS will work with all provided PostgreSQL versions
 if(NOT WIN32)
-  set(PostGIS_version "2.4.3" )
+  set(PostGIS_version "2.5.3" )
   set(PostGIS_url "http://download.osgeo.org/postgis/source/postgis-${PostGIS_version}.tar.gz" )
-  set(PostGIS_md5 "60395f3dc96505ca4e313449d6463c6a" )
+  set(PostGIS_md5 "475bca6249ee11f675b899de14fd3f42" )
   list(APPEND fletch_external_sources PostGIS )
 endif()
 


### PR DESCRIPTION
Aside from bringing PostGIS to a more modern version that's still compatible with the other current database packages, this upgrade version introduced a bug fix to allow consistent parallel builds of raster. Previous versions attempted a dependant library, rtloader at the same time as building its required corelib. This would lead to build failures on some systems.