### PR TITLE
Move ZLib inline fixup-install code to a cmake 'patch' script

### DIFF
--- a/CMake/External_ZLib.cmake
+++ b/CMake/External_ZLib.cmake
@@ -15,32 +15,12 @@ ExternalProject_Add(ZLib
     -DBUILD_SHARED_LIBS:BOOL=ON
 )
 
-if(WIN32)
-  # Copy zlib to zdll for Qt
-  ExternalProject_Add_Step(ZLib fixup-install
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/zlib.lib
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/zdll.lib
-    DEPENDEES install
-    )
-elseif(NOT APPLE)
-  # For Linux machines
-  ExternalProject_Add_Step(ZLib fixup-install
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.so
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.so
-    DEPENDEES install
-    )
-else()
-  # APPLE
-  ExternalProject_Add_Step(ZLib fixup-install
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.dylib
-      ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.dylib
-    DEPENDEES install
-    )
-endif()
-
+ExternalProject_Add_Step(ZLib fixup-install
+  COMMAND ${CMAKE_COMMAND}
+    -Dfletch_BUILD_INSTALL_PREFIX:PATH=${fletch_BUILD_INSTALL_PREFIX}
+    -P ${fletch_SOURCE_DIR}/Patches/ZLib/fixup-install.cmake
+  DEPENDEES install
+)
 fletch_external_project_force_install(PACKAGE ZLib STEP_NAMES install fixup-install)
 
 set(ZLIB_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)

--- a/Patches/ZLib/fixup-install.cmake
+++ b/Patches/ZLib/fixup-install.cmake
@@ -1,0 +1,27 @@
+# Make a copy of built libraries with Qt expected name
+
+if(WIN32)
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/zlib.lib)
+   execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/zlib.lib ${fletch_BUILD_INSTALL_PREFIX}/lib/zdll.lib)
+  endif()
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/zlib${CMAKE_DEBUG_POSTFIX}.lib)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/zlib${CMAKE_DEBUG_POSTFIX}.lib ${fletch_BUILD_INSTALL_PREFIX}/lib/zdll${CMAKE_DEBUG_POSTFIX}.lib)
+  endif()
+elseif(NOT APPLE)
+  # For Linux machines
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.lib)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.lib ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.lib)
+  endif()
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/libz${CMAKE_DEBUG_POSTFIX}.lib)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/libz${CMAKE_DEBUG_POSTFIX}.lib ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib${CMAKE_DEBUG_POSTFIX}.lib)
+  endif()
+else()
+  # APPLE
+  
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.dylib)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/libz.dylib ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib.dylib)
+  endif()
+  if(EXISTS ${fletch_BUILD_INSTALL_PREFIX}/lib/libz${CMAKE_DEBUG_POSTFIX}.dylib)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${fletch_BUILD_INSTALL_PREFIX}/lib/libz${CMAKE_DEBUG_POSTFIX}.dylib ${fletch_BUILD_INSTALL_PREFIX}/lib/libzlib${CMAKE_DEBUG_POSTFIX}.dylib)
+  endif()
+endif()


### PR DESCRIPTION
This provides more flexibility to the script.
This can check if files exist or not (and not fail the build)
This also supports output names modified by CMake variables, such as CMAKE_DEBUG_POSTFIX