### PR TITLE
Patch darknet pthread install

### DIFF
--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -9,3 +9,4 @@ Fixes since v1.4.0
  * Patched Boost 1.65 to build on MSVC 2019.
  * Patched OpenCV 3.4 to build on MSVC 2019.
  * Patched Darknet CMakeLists.txt to disable examples
+ * Patched Darknet pthread install to use CMAKE_GENERATOR_PLATFORM instead of CMAKE_GENERATOR to x64 check.

--- a/Patches/Darknet/3rdparty/dll/CMakeLists.txt
+++ b/Patches/Darknet/3rdparty/dll/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )
+  add_subdirectory( x86 )
+else()
+  add_subdirectory( x64 )
+endif()

--- a/Patches/Darknet/3rdparty/dll/CMakeLists.txt
+++ b/Patches/Darknet/3rdparty/dll/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )
-  add_subdirectory( x86 )
-else()
+if("${Darknet_PLATFORM}" MATCHES "(x64|ARM64)")
   add_subdirectory( x64 )
+else()
+  add_subdirectory( x86 )
 endif()

--- a/Patches/Darknet/3rdparty/lib/CMakeLists.txt
+++ b/Patches/Darknet/3rdparty/lib/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )
+  add_subdirectory( x86 )
+else()
+  add_subdirectory( x64 )
+endif()

--- a/Patches/Darknet/3rdparty/lib/CMakeLists.txt
+++ b/Patches/Darknet/3rdparty/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )
-  add_subdirectory( x86 )
-else()
+if("${Darknet_PLATFORM}" MATCHES "(x64|ARM64)")
   add_subdirectory( x64 )
+else()
+  add_subdirectory( x86 )
 endif()

--- a/Patches/Darknet/CMakeLists.txt
+++ b/Patches/Darknet/CMakeLists.txt
@@ -104,10 +104,19 @@ if( USE_OPENCV )
 endif()
 
 if( WIN32 )
-  if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )
-    link_directories( ${CMAKE_SOURCE_DIR}/3rdparty/lib/x86 )
-  else()
+  # Use CMAKE_GENERATOR_PLATFORM to determine specified architecture
+  # If the user didn't specify it, use the CMAKE_VS_PLATFORM_NAME_DEFAULT which is what CMake uses to initialize CMAKE_GENERATOR_PLATFORM
+  # See: https://cmake.org/cmake/help/latest/variable/CMAKE_VS_PLATFORM_NAME_DEFAULT.html#variable:CMAKE_VS_PLATFORM_NAME_DEFAULT
+  # "...for VS 2017 and below this is always Win32. For VS 2019 and above this is based on the host platform"
+  set (Darknet_PLATFORM ${CMAKE_GENERATOR_PLATFORM})
+  if (NOT CMAKE_GENERATOR_PLATFORM)
+    set (Darknet_PLATFORM ${CMAKE_VS_PLATFORM_NAME_DEFAULT})
+  endif()
+
+  if("${Darknet_PLATFORM}" MATCHES "(x64|ARM64)")
     link_directories( ${CMAKE_SOURCE_DIR}/3rdparty/lib/x64 )
+  else()
+    link_directories( ${CMAKE_SOURCE_DIR}/3rdparty/lib/x86 )
   endif()
   list( APPEND DARKNET_LINKED_LIBS pthreadVC2 )
 else()

--- a/Patches/Darknet/Patch.cmake
+++ b/Patches/Darknet/Patch.cmake
@@ -9,3 +9,18 @@ file(
   DESTINATION
   ${Darknet_Source}
   )
+
+
+# Patch the 3rdParty pthread dll and lib CMakeLists.txt files to fix and install problem.
+file(
+  COPY
+  ${Darknet_Patch}/3rdparty/dll/CMakeLists.txt
+  DESTINATION
+  ${Darknet_Source}/3rdparty/dll
+  )
+file(
+  COPY
+  ${Darknet_Patch}/3rdparty/lib/CMakeLists.txt
+  DESTINATION
+  ${Darknet_Source}/3rdparty/lib
+  )


### PR DESCRIPTION
This patch is the last known issue with building Fletch/kwiver on Visual Studio 2019. Darknet was using `if( NOT "${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" )` to determine if it should install the  x86 or x64 pthread lib and dll. That approach isn't consistent with newer CMake which removed the CMAKE_GENERATOR_PLATFORM from CMAKE_GENERATOR. It's more appropriate now to compare CMAKE_GENERATOR_PLATFORM directly which produces "(x64|ARM64)" for the 64-bit versions.

This PR depends on #608 which is in review now too. I will land that one first.