### PR TITLE
Add OpenCV 4.2

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -302,10 +302,10 @@ endif()
 list(APPEND fletch_external_sources Qt)
 
 # OpenCV
-# Support 2.4.13 and 3.4 optionally
+# Support 2.4.13, 3.4, and 4.2 optionally
 if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
   set(OpenCV_SELECT_VERSION 3.4.0 CACHE STRING "Select the  version of OpenCV to build.")
-  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "2.4.13" "3.4.0")
+  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "2.4.13" "3.4.0" "4.2.0")
 
   set(OpenCV_version ${OpenCV_SELECT_VERSION})
   set(OpenCV_url "http://github.com/Itseez/opencv/archive/${OpenCV_version}.zip")
@@ -323,7 +323,10 @@ if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPE
   endif()
 
   # Paired contrib repo information
-  if (OpenCV_version VERSION_EQUAL 3.4.0)
+  if (OpenCV_version VERSION_EQUAL 4.2.0)
+    set(OpenCV_md5 "b02b54115f1f99cb9e885d1e5988ff70")
+    set(OpenCV_contrib_md5 "4776354662667c85a91bcd19f6a13da7")
+  elseif (OpenCV_version VERSION_EQUAL 3.4.0)
     set(OpenCV_md5 "ed60f8bbe7a448f325d0a0f58fcf2063")
     set(OpenCV_contrib_md5 "92c09ce6c837329f05802a8d17136148")
   elseif (OpenCV_version VERSION_EQUAL 2.4.13)

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -304,7 +304,7 @@ list(APPEND fletch_external_sources Qt)
 # OpenCV
 # Support 2.4.13, 3.4, and 4.2 optionally
 if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
-  set(OpenCV_SELECT_VERSION 3.4.0 CACHE STRING "Select the  version of OpenCV to build.")
+  set(OpenCV_SELECT_VERSION 4.2.0 CACHE STRING "Select the  version of OpenCV to build.")
   set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "2.4.13" "3.4.0" "4.2.0")
 
   set(OpenCV_version ${OpenCV_SELECT_VERSION})


### PR DESCRIPTION
Add support for OpenCV 4.2 (see also #618). Make it the default version.

Note that this is not intended to be merged at this time, but is rather being submitted for CI to pick up and test.