### PR TITLE
Don't use a system Boost site-config.

### DIFF
--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -23,3 +23,4 @@ Fixes since v1.4.0
  * Change the default flag that provides Qt to the OpenCV build to False.
  * Patch the ZLib CMakeLists.txt to elimate the 'd' suffix on the library name on WIN32.
  * Disable the 'examples' build for Darknet. It was causing a build failure on WIN32.
+ * When building Boost in Fletch, always ignore the systemsite-config. That is the config from an installed version and will conflict with our build.

--- a/Patches/Boost/Common.cmake
+++ b/Patches/Boost/Common.cmake
@@ -89,7 +89,7 @@ endif()
 # Compile the complete list of B2 args
 set(B2_ARGS
   --abbreviate-paths -j${NCPU} --toolset=${BOOST_TOOLSET} --disable-icu ${_fletch_boost_python_arg}
-  -sNO_BZIP2=1 ${BOOST_CXX_ARGS}
+  -sNO_BZIP2=1 ${BOOST_CXX_ARGS} --ignore-site-config
   ${B2_FLAVOR_ARGS}
 )
 


### PR DESCRIPTION
Without the --ignore-site-config, Boost tries to use a system installed Boost's config. That can cause a build error by altering the Fletch Boost parameters.