### PR TITLE
Set cmake policy CMP0074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,16 @@ cmake_minimum_required(VERSION 3.3.0)
 project(fletch)
 
 # Policy to address @foo@ variable expansion
+# https://cmake.org/cmake/help/git-stage/policy/CMP0053.html
 if(POLICY CMP0053)
   cmake_policy(SET CMP0053 NEW)
+endif()
+
+# Policy CMP0074 allows CMake to search
+# "prefixes specified by the <PackageName>_ROOT in find_package"
+# https://cmake.org/cmake/help/git-stage/policy/CMP0074.html
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 #+

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -27,3 +27,4 @@ Fixes since v1.4.0
  * Disable the 'examples' build for Darknet. It was causing a build failure on WIN32.
  * When building Boost in Fletch, always ignore the systemsite-config. That is the config from an installed version and will conflict with our build.
  * Force PDAL to ignore libjson. It can't use the Fletch package nor can it use similar system packages.
+ * Set cmake_policy CMP0074 to NEW.


### PR DESCRIPTION
CMP0074 allows CMake to search prefixes specified by <PackageName>_ROOT.