### PR TITLE
Disable json-c from GDAL v1

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -156,6 +156,10 @@ else()
     set(_GDAL_ARGS_PYTHON --with-python=${PYTHON_EXECUTABLE} )
   endif()
 
+  if (GDAL_SELECT_VERSION VERSION_LESS 2.0)
+    list( APPEND _GDAL_ARGS_UNSUPPORTED --with-libjson-c=internal )
+  endif()
+
   # If we're not using LTIDSDK and we are building openjpeg, use that for jpeg2k decoding
   # OpenJPEG support is not valid for GDAL 1, it requires an older version than we provide.
   if (fletch_ENABLE_openjpeg AND NOT fletch_LTIDSDK_ROOT AND NOT GDAL_SELECT_VERSION VERSION_LESS 2.0)


### PR DESCRIPTION
GDAL v1 gets confused by other json.h files on the system. It's a popular header name from other json related packages. This PR sets json-c to internal so GDAL builds its own version.