### PR TITLE
Dev/update pybind11

### DIFF
--- a/CMake/External_pybind11.cmake
+++ b/CMake/External_pybind11.cmake
@@ -12,9 +12,6 @@ ExternalProject_Add(pybind11
   DOWNLOAD_NAME ${pybind11_dlname}
   ${COMMON_EP_ARGS}
   ${COMMON_CMAKE_EP_ARGS}
-  PATCH_COMMAND ${CMAKE_COMMAND} -E copy
-    ${fletch_SOURCE_DIR}/Patches/pybind11/include/pybind11/pybind11.h
-    ${fletch_BUILD_PREFIX}/src/pybind11/include/pybind11/pybind11.h
   CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
     # PYTHON_EXECUTABLE addded to cover when it's installed in nonstandard loc.

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -575,9 +575,9 @@ set(Darnet_dlname "darknent-d206b6da7af1f4.zip")
 list(APPEND fletch_external_sources Darknet)
 
 # pybind11
-set(pybind11_version "2.2.1")
+set(pybind11_version "2.5.0")
 set(pybind11_url "https://github.com/pybind/pybind11/archive/v${pybind11_version}.tar.gz")
-set(pybind11_md5 "bab1d46bbc465af5af3a4129b12bfa3b")
+set(pybind11_md5 "1ad2c611378fb440e8550a7eb6b31b89")
 set(pybind11_dlname "pybind11-${pybind11_version}.tar.gz")
 list(APPEND fletch_external_sources pybind11)
 

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -17,6 +17,7 @@ Updates since v1.4.0
  * Update Eigen from 3.3.4 to 3.3.7
  * Remove support for OpenCV 2
  * Add VTK version 9.0.1
+ * Update PyBind11 from 2.2.1 to 2.5.0
 
 Fixes since v1.4.0
 ------------------


### PR DESCRIPTION
The current pybind version installed by Fletch and subsequently used by Kwiver is fairly out of date. The process of backporting AutoPyBind11 into Kwiver requires the use of PyBind11 version 2.5.0. This branch implements that upgrade.