### PR TITLE
Build boost b2b in release mode

### DIFF
--- a/CMake/External_Boost.cmake
+++ b/CMake/External_Boost.cmake
@@ -50,6 +50,7 @@ ExternalProject_Add(Boost
   PATCH_COMMAND
     ${Boost_PATCH_COMMAND}
   CONFIGURE_COMMAND ${CMAKE_COMMAND}
+    -DCMAKE_BUILD_TYPE=$<CONFIGURATION>
     -DCMAKE_VARS_FILE=${fletch_BUILD_PREFIX}/tmp/Boost/CMakeVars.cmake
     -DBoost_EXTRA_LIBS=${fletch_EXTRA_BOOST_LIBS}
     ${_Boost_DIR_ARGS}

--- a/Patches/Boost/Configure.cmake
+++ b/Patches/Boost/Configure.cmake
@@ -39,6 +39,12 @@ execute_command_wrapper(
   ${BOOTSTRAP} ${BOOTSTRAP_ARGS}
 )
 
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "debug") # adjust for relwithdebinfo
+  set(CMAKE_BUILD_TYPE "release")
+endif()
+message("Boost.Configure.BCP.Build: Using variant=${CMAKE_BUILD_TYPE}")
+
 # Note: BCP has known issues with some msvc release builds so we always build
 # it in debug.
 execute_command_wrapper(

--- a/Patches/Boost/Configure.cmake
+++ b/Patches/Boost/Configure.cmake
@@ -45,7 +45,7 @@ execute_command_wrapper(
   "Boost.Configure.BCP.Build"
   ${Boost_SOURCE_DIR}/tools/bcp
   ${Boost_SOURCE_DIR}/b2${CMAKE_EXECUTABLE_SUFFIX}
-  variant=debug ${B2_ARGS}
+  variant=${CMAKE_BUILD_TYPE} ${B2_ARGS}
 )
 
 execute_command_wrapper(


### PR DESCRIPTION
I don't actually know enough about this change (or why it was necessary in the first place) so maybe this branch should be abandoned if there's a reason, but using the set release type from cmake caused no issues on my end so maybe the reason for the forced debug is gone/deprecated?