### PR TITLE
Patch GDAL to build on OSX (fixes missing strdup() prototype).

### DIFF
--- a/Patches/GDAL/2.3.2/Patch.cmake
+++ b/Patches/GDAL/2.3.2/Patch.cmake
@@ -8,3 +8,6 @@
 message("Copying ${GDAL_patch}/data/nitf_spec.xml to ${GDAL_source}/data/nitf_spec.xml")
 file(COPY ${GDAL_patch}/data/nitf_spec.xml DESTINATION ${GDAL_source}/data/)
 
+message("Copying ${GDAL_patch}/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile to ${GDAL_source}/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile")
+file(COPY ${GDAL_patch}/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile DESTINATION ${GDAL_source}/ogr/ogrsf_frmts/geojson/libjson/)
+

--- a/Patches/GDAL/2.3.2/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile
+++ b/Patches/GDAL/2.3.2/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile
@@ -1,0 +1,33 @@
+# $Id$
+#
+# Makefile building json-c library (http://oss.metaparadigm.com/json-c/)
+# 
+include ../../../../GDALmake.opt
+
+OBJ = \
+	arraylist.o \
+	debug.o \
+	json_object.o \
+	json_tokener.o \
+	json_util.o \
+	linkhash.o \
+	printbuf.o \
+	json_object_iterator.o \
+	json_c_version.o
+
+O_OBJ = $(foreach file,$(OBJ),../../o/$(file))
+
+CPPFLAGS := $(CPPFLAGS)
+
+default:	$(O_OBJ:.o=.$(OBJ_EXT))
+
+# -D_XOPEN_SOURCE=500 to enable strdup() definition in C11 mode
+# ...actually, needs to be -->600<-- to get strdup; per https://bugs.launchpad.net/libvterm/+bug/1638205
+CPPFLAGS := -D_XOPEN_SOURCE=600 $(CPPFLAGS)
+
+../../o/%.$(OBJ_EXT):	%.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+clean:
+	rm -f *.o $(O_OBJ)
+	rm -f *~

--- a/Patches/GDAL/2.3.2/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile
+++ b/Patches/GDAL/2.3.2/ogr/ogrsf_frmts/geojson/libjson/GNUmakefile
@@ -21,9 +21,14 @@ CPPFLAGS := $(CPPFLAGS)
 
 default:	$(O_OBJ:.o=.$(OBJ_EXT))
 
-# -D_XOPEN_SOURCE=500 to enable strdup() definition in C11 mode
-# ...actually, needs to be -->600<-- to get strdup; per https://bugs.launchpad.net/libvterm/+bug/1638205
+#ifdef __APPLE__
+# ...actually, needs to be -->600<-- to get strdup;
+# per https://bugs.launchpad.net/libvterm/+bug/1638205
 CPPFLAGS := -D_XOPEN_SOURCE=600 $(CPPFLAGS)
+#else
+# -D_XOPEN_SOURCE=500 to enable strdup() definition in C11 mode
+CPPFLAGS := -D_XOPEN_SOURCE=500 $(CPPFLAGS)
+#endif
 
 ../../o/%.$(OBJ_EXT):	%.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<


### PR DESCRIPTION
This patch updates the _XOPEN_SOURCE macro to 600 so GDAL's libjson
finds strdup(). Via https://bugs.launchpad.net/libvterm/+bug/1638205