### PR TITLE
WIP: Update Qt to 5.15.2

### DIFF
--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -176,14 +176,17 @@ else()
   set(Qt_install_cmd ${MAKE_EXECUTABLE} install)
   set(Qt_args_other -no-cups -optimized-qmake)
 
-  if (Qt_version VERSION_GREATER 5.12)
+  if (Qt_version VERSION_GREATER_EQUAL 5.12)
     list(APPEND Qt_configure
-      -skip qtconnectivity -skip qtgamepad -skip qtlocation -skip qtmultimedia -skip qtsensors -skip qtserialport -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -nomake examples -nomake tests -no-dbus -no-openssl)
+      -skip qtconnectivity -skip qtgamepad -skip qtlocation -skip qtmultimedia
+      -skip qtsensors -skip qtserialport -skip qtwayland -skip qtwebchannel
+      -skip qtwebengine -skip qtwebsockets -nomake examples -nomake tests
+      -no-dbus -no-openssl)
     list(APPEND Qt_configure
-      -qt-libjpeg -qt-pcre -system-zlib -system-libpng)
+      -qt-pcre)
     if (UNIX AND NOT APPLE)
       list(APPEND Qt_configure
-        -qt-xcb -fontconfig -xkbcommon)
+        -fontconfig)
     endif()
   endif()
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -271,11 +271,11 @@ set(libkml_dlname "libkml-${libkml_version}.zip")
 list(APPEND fletch_external_sources libkml)
 
 # Qt
-# Support 4.8.6 and 5.11 optionally
+# Support options for multiple versions
 if (fletch_ENABLE_Qt OR fletch_ENABLE_VTK OR fletch_ENABLE_qtExtensions OR
     fletch_ENABLE_ALL_PACKAGES)
   set(Qt_SELECT_VERSION 5.11.2 CACHE STRING "Select the version of Qt to build.")
-  set_property(CACHE Qt_SELECT_VERSION PROPERTY STRINGS "4.8.6" "5.11.2" "5.12.8")
+  set_property(CACHE Qt_SELECT_VERSION PROPERTY STRINGS "4.8.6" "5.11.2" "5.12.8" "5.15.2")
 
   set(Qt_version ${Qt_SELECT_VERSION})
   string(REPLACE "." ";" Qt_VERSION_LIST ${Qt_version})
@@ -291,6 +291,10 @@ if (fletch_ENABLE_Qt OR fletch_ENABLE_VTK OR fletch_ENABLE_qtExtensions OR
     set(Qt_release_location archive) # official_releases or new_archive
     set(Qt_url "https://download.qt.io/${Qt_release_location}/qt/5.12/${Qt_version}/single/qt-everywhere-src-${Qt_version}.tar.xz")
     set(Qt_md5 "8ec2a0458f3b8e9c995b03df05e006e4")
+  elseif (Qt_version VERSION_EQUAL 5.15.2)
+    set(Qt_release_location official_releases) # official_releases or new_archive
+    set(Qt_url "https://download.qt.io/${Qt_release_location}/qt/5.15/${Qt_version}/single/qt-everywhere-src-${Qt_version}.tar.xz")
+    set(Qt_md5 "e1447db4f06c841d8947f0a6ce83a7b5")
   elseif (Qt_version VERSION_EQUAL 4.8.6)
     set(Qt_release_location new_archive)
     set(Qt_url "https://download.qt.io/${Qt_release_location}/qt/4.8/${Qt_version}/qt-everywhere-opensource-src-${Qt_version}.tar.gz")

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -274,7 +274,7 @@ list(APPEND fletch_external_sources libkml)
 # Support options for multiple versions
 if (fletch_ENABLE_Qt OR fletch_ENABLE_VTK OR fletch_ENABLE_qtExtensions OR
     fletch_ENABLE_ALL_PACKAGES)
-  set(Qt_SELECT_VERSION 5.11.2 CACHE STRING "Select the version of Qt to build.")
+  set(Qt_SELECT_VERSION 5.15.2 CACHE STRING "Select the version of Qt to build.")
   set_property(CACHE Qt_SELECT_VERSION PROPERTY STRINGS "4.8.6" "5.11.2" "5.12.8" "5.15.2")
 
   set(Qt_version ${Qt_SELECT_VERSION})


### PR DESCRIPTION
This branch pushes Qt5 to the latest 5.15.2.  This branch is for CI testing.  It may be better to use 5.15 and just skip 5.12. 