### PR TITLE
Upgrade OpenCV to 4.5.1

### DIFF
--- a/CMake/External_Caffe.cmake
+++ b/CMake/External_Caffe.cmake
@@ -103,6 +103,10 @@ else()
 endif()
 
 if(fletch_ENABLE_OpenCV)
+  if(OpenCV_SELECT_VERSION VERSION_GREATER_EQUAL 4.0)
+    MESSAGE(FATAL_ERROR "Caffe requires OpenCV version less than 4.0 "
+                        "but ${OpenCV_SELECT_VERSION} is selected")
+  endif()
   set( CAFFE_OPENCV_ARGS
     -DOpenCV_DIR:PATH=${fletch_BUILD_PREFIX}/src/OpenCV-build
     -DOpenCV_LIB_PATH:PATH=${OpenCV_ROOT}/lib

--- a/CMake/External_Caffe_Segnet.cmake
+++ b/CMake/External_Caffe_Segnet.cmake
@@ -104,6 +104,10 @@ else()
 endif()
 
 if(fletch_ENABLE_OpenCV)
+  if(OpenCV_SELECT_VERSION VERSION_GREATER_EQUAL 4.0)
+    MESSAGE(FATAL_ERROR "Segnet requires OpenCV version less than 4.0 "
+                        "but ${OpenCV_SELECT_VERSION} is selected")
+  endif()
   set( CAFFE_SEGNET_OPENCV_ARGS
     -DOpenCV_DIR:PATH=${fletch_BUILD_PREFIX}/src/OpenCV-build
     -DOpenCV_LIB_PATH:PATH=${OpenCV_ROOT}/lib

--- a/CMake/External_Darknet.cmake
+++ b/CMake/External_Darknet.cmake
@@ -7,6 +7,10 @@ else()
   unset(fletch_ENABLE_Darknet_OpenCV CACHE)
 endif()
 if(fletch_ENABLE_Darknet_OpenCV)
+  if(OpenCV_SELECT_VERSION VERSION_GREATER_EQUAL 4.0)
+    MESSAGE(FATAL_ERROR "Darknet requires OpenCV version less than 4.0 "
+                        "but ${OpenCV_SELECT_VERSION} is selected")
+  endif()
   set(DARKNET_OPENCV_ARGS -DUSE_OPENCV:BOOL=ON)
   add_package_dependency(
     PACKAGE Darknet

--- a/CMake/External_OpenCV.cmake
+++ b/CMake/External_OpenCV.cmake
@@ -310,6 +310,7 @@ ExternalProject_Add(OpenCV
     -DBUILD_TESTS:BOOL=False
     -DWITH_EIGEN:BOOL=${fletch_ENABLE_EIGEN}
     -DWITH_JASPER:BOOL=False
+    -DWITH_PROTOBUF:BOOL=False
     ${OpenCV_EXTRA_BUILD_FLAGS}
     ${OpenCV_PYTHON_FLAGS}
   )

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -302,10 +302,10 @@ endif()
 list(APPEND fletch_external_sources Qt)
 
 # OpenCV
-# Support 2.4.13, 3.4, and 4.2 optionally
+# Support 3.4, 4.2, and 4.5.1 optionally
 if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
   set(OpenCV_SELECT_VERSION 3.4.0 CACHE STRING "Select the  version of OpenCV to build.")
-  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "3.4.0" "4.2.0")
+  set_property(CACHE OpenCV_SELECT_VERSION PROPERTY STRINGS "3.4.0" "4.2.0" "4.5.1")
 
   set(OpenCV_version ${OpenCV_SELECT_VERSION})
   set(OpenCV_url "http://github.com/Itseez/opencv/archive/${OpenCV_version}.zip")
@@ -323,7 +323,10 @@ if (fletch_ENABLE_OpenCV OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPE
   endif()
 
   # Paired contrib repo information
-  if (OpenCV_version VERSION_EQUAL 4.2.0)
+  if (OpenCV_version VERSION_EQUAL 4.5.1)
+    set(OpenCV_md5 "cc13d83c3bf989b0487bb3798375ee08")
+    set(OpenCV_contrib_md5 "ddb4f64d6cf31d589a8104655d39c99b")
+  elseif (OpenCV_version VERSION_EQUAL 4.2.0)
     set(OpenCV_md5 "b02b54115f1f99cb9e885d1e5988ff70")
     set(OpenCV_contrib_md5 "4776354662667c85a91bcd19f6a13da7")
   elseif (OpenCV_version VERSION_EQUAL 3.4.0)

--- a/Doc/release-notes/master.txt
+++ b/Doc/release-notes/master.txt
@@ -15,6 +15,7 @@ Updates since v1.4.0
  * Update libtiff from 4.0.6 to 4.1.0
  * Update ZLib from 1.2.9 to 1.2.11
  * Update Eigen from 3.3.4 to 3.3.7
+ * Added options for OpenCV 4.2 and 4.5.1
  * Remove support for OpenCV 2
  * Add VTK version 9.0.1
  * Update PyBind11 from 2.2.1 to 2.5.0


### PR DESCRIPTION
Add the latest (as of today) OpenCV version, 4.5.1 since 4.2 is still not recent enough to support CUDA 11.  If 4.5.1 works for everyone we can likely remove 4.2 support.

The last commit makes 4.5.1 the default for dashboard testing purposes.