### PR TITLE
Add readme troubleshooting msvc upgrade boost

### DIFF
--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -12,3 +12,4 @@ Fixes since v1.4.0
  * Patched Darknet pthread install to use CMAKE_GENERATOR_PLATFORM instead of CMAKE_GENERATOR to x64 check.
  * Updated old style sourceforge URLs.
  * Host Qt downloads on data.kitware.com. Location removed by Qt.
+ * Add documentation regarding a Boost failure caused by MSVC version upgrades.

--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,17 @@ If you experience a build failure, please create an issue on
 5. Details of exactly which CMake options were changed from the default.
 
 
+Troubleshooting
+============
+
+1. MSVC users may experience build issues with Boost after upgrading their version of Visual Studio.
+   The symptoms of this issue will involve compiler output of `'cl' is not recognized as an internal or external command,
+   operable program or batch file`. The issue comes from Boost caching its version of b2_msvc_*_vcvars*.cmd. To resolve this issue,
+   you will need to delete those files which are typically located in C:\Users\%USERNAME%\AppData\Local\Temp. Any file named b2_msvc*
+   should be moved out of the way so Boost can generate a new version based on the updated Visual Studio version.
+
+
+
 .. Appendix I: References
 .. ======================
 

--- a/README.rst
+++ b/README.rst
@@ -235,10 +235,12 @@ Troubleshooting
 ============
 
 1. MSVC users may experience build issues with Boost after upgrading their version of Visual Studio.
-   The symptoms of this issue will involve compiler output of `'cl' is not recognized as an internal or external command,
-   operable program or batch file`. The issue comes from Boost caching its version of b2_msvc_*_vcvars*.cmd. To resolve this issue,
-   you will need to delete those files which are typically located in C:\Users\%USERNAME%\AppData\Local\Temp. Any file named b2_msvc*
-   should be moved out of the way so Boost can generate a new version based on the updated Visual Studio version.
+   When a Boost build fails, one will find the file ``Boost.Configure.BCP.Build_out.txt`` in the build directory.
+   The symptoms of this issue involve output in that file like ``'cl' is not recognized as an internal or external command,
+   operable program or batch file``. The issue comes from Boost caching its version of b2_msvc_*_vcvars*.cmd.
+   To resolve this issue, you will need to delete those files which are typically located in ``C:\Users\%USERNAME%\AppData\Local\Temp``.
+   Any file named b2_msvc* should be moved out of the way so Boost can generate a new version based on the updated Visual Studio version.
+   Once those files have regenerated and Boost successfully builds, it is safe to delete those files.
 
 
 


### PR DESCRIPTION
This PR adds a new Troubleshooting section to the README and adds an entry to document the solution to a common build error in Boost that happens after upgrading your MSVC version.