### PR TITLE
VTK 9 uses different CMake options for modules than VTK 8

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -91,16 +91,22 @@ else()
     -DVTK_QT_VERSION:STRING=5
   )
 endif()
-set(vtk_cmake_args ${vtk_cmake_args}
-  -DVTK_Group_Qt:BOOL=OFF
-  -DModule_vtkGUISupportQt:BOOL=ON
-  -DModule_vtkGUISupportQtOpenGL:BOOL=ON
-  -DModule_vtkGUISupportQtSQL:BOOL=ON
-  -DModule_vtkGUISupportQtWebkit:BOOL=${BUILD_QT_WEBKIT}
-  -DModule_vtkRenderingQt:BOOL=ON
-  -DModule_vtkViewsQt:BOOL=ON
-  -DVTK_QT_VERSION:STRING=${Qt_version_major}
-)
+if(VTK_SELECT_VERSION VERSION_LESS 9.0)
+  set(vtk_cmake_args ${vtk_cmake_args}
+    -DVTK_Group_Qt:BOOL=OFF
+    -DModule_vtkGUISupportQt:BOOL=ON
+    -DModule_vtkGUISupportQtOpenGL:BOOL=ON
+    -DModule_vtkGUISupportQtSQL:BOOL=ON
+    -DModule_vtkGUISupportQtWebkit:BOOL=${BUILD_QT_WEBKIT}
+    -DModule_vtkRenderingQt:BOOL=ON
+    -DModule_vtkViewsQt:BOOL=ON
+    -DVTK_QT_VERSION:STRING=${Qt_version_major}
+  )
+else()
+  set(vtk_cmake_args ${vtk_cmake_args}
+    -DVTK_GROUP_ENABLE_Qt:STRING=YES
+  )
+endif()
 
 # PostgreSQL
 add_package_dependency(


### PR DESCRIPTION
The CMake options for enabling modules have changed in VTK 9, so setting the old options was no longer enabling Qt support in VTK 9.  Note that QtWebKit is not longer a sub-option, so we can just turn the whole Qt group on. 