### PR TITLE
Fix VTK Python bindings with MSVC

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -187,7 +187,7 @@ set(vtk_cmake_args ${vtk_cmake_args}
   )
 
 # PYTHON
-if(fletch_BUILD_WITH_PYTHON AND NOT MSVC14 )
+if(fletch_BUILD_WITH_PYTHON AND MSVC_VERSION VERSION_GREATER_EQUAL 1910)
   option(fletch_ENABLE_VTK_PYTHON "Enable Python wrappings for VTK" ON)
   mark_as_advanced(fletch_ENABLE_VTK_PYTHON)
 
@@ -203,8 +203,6 @@ if(fletch_BUILD_WITH_PYTHON AND NOT MSVC14 )
       message(WARNING "VTK building without python support. Python NOT found.")
     endif()
   endif()
-elseif(fletch_BUILD_WITH_PYTHON AND MSVC14)
-  message(WARNING "VTK Python will not build correctly on Visual Studio 2015. VTK 7.0 of higher is required.")
 endif()
 
 if(fletch_ENABLE_VTK AND VTK_WRAP_PYTHON AND VTK_SELECT_VERSION VERSION_LESS 7.0.0)

--- a/Doc/release-notes/release.txt
+++ b/Doc/release-notes/release.txt
@@ -15,3 +15,4 @@ Fixes since v1.4.0
  * Host Qt downloads on data.kitware.com. Location removed by Qt.
  * Add documentation regarding a Boost failure caused by MSVC version upgrades.
  * Fixed an issue with broken CUDA_HOST_COMPILER path in some projects using MSVC.
+ * Fixed an issue with enabling VTK Python bindings in MSVC.


### PR DESCRIPTION
I was still getting the warning message about using VS 2015 and VTK < 7 even when using more recent VTK and more recent VS.