### PR TITLE
Update to PROJ 5.2

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -102,10 +102,10 @@ else()
     set(_GDAL_ARGS_ZLIB "--with-libz=${ZLIB_ROOT}")
   endif()
 
-  if(fletch_ENABLE_PROJ4)
+  if(fletch_ENABLE_PROJ)
     #If we're building libproj, then use it.
-    list(APPEND _GDAL_DEPENDS PROJ4 )
-    set(_GDAL_ARGS_PROJ4 "--with-proj=${PROJ4_ROOT}")
+    list(APPEND _GDAL_DEPENDS PROJ )
+    set(_GDAL_ARGS_PROJ "--with-proj=${PROJ_ROOT}")
   endif()
 
   # For now, I don't see the need for postgresql support in GDAL. If it is required, just add
@@ -173,7 +173,7 @@ else()
   # Here is where you add any new package related args for tiff, so we don't keep repeating them below.
   set (GDAL_PKG_ARGS
     ${_GDAL_ARGS_PYTHON} ${_GDAL_PNG_ARGS} ${_GDAL_GEOTIFF_ARGS} ${_GDAL_ARGS_PG}
-    ${_GDAL_ARGS_PROJ4} ${_GDAL_ARGS_XML2} ${_GDAL_TIFF_ARGS} ${_GDAL_ARGS_SQLITE}
+    ${_GDAL_ARGS_PROJ} ${_GDAL_ARGS_XML2} ${_GDAL_TIFF_ARGS} ${_GDAL_ARGS_SQLITE}
     ${_GDAL_ARGS_ZLIB} ${_GDAL_ARGS_LTIDSDK} ${JPEG_ARG} ${_GDAL_ARGS_libKML}
     ${_GDAL_GEOS_ARGS} ${_GDAL_ARGS_UNSUPPORTED} --without-jasper
     )

--- a/CMake/External_PDAL.cmake
+++ b/CMake/External_PDAL.cmake
@@ -45,11 +45,11 @@ else()
 endif()
 
 # Set Proj.4 dependency
-if (fletch_ENABLE_PROJ4)
-  message(STATUS "PDAL depending on internal PROJ4")
-  list(APPEND PDAL_DEPENDS PROJ4)
+if (fletch_ENABLE_PROJ)
+  message(STATUS "PDAL depending on internal PROJ")
+  list(APPEND PDAL_DEPENDS PROJ)
 else()
-  message(FATAL_ERROR "PROJ4 is required for PDAL, please enable")
+  find_package(PROJ4 REQUIRED)
 endif()
 
 # Set libxml2 dependency

--- a/CMake/External_PROJ.cmake
+++ b/CMake/External_PROJ.cmake
@@ -1,7 +1,7 @@
 
-ExternalProject_Add(PROJ4
-  URL ${PROJ4_file}
-  URL_MD5 ${PROJ4_md5}
+ExternalProject_Add(PROJ
+  URL ${PROJ_file}
+  URL_MD5 ${PROJ_md5}
   ${COMMON_EP_ARGS}
   ${COMMON_CMAKE_EP_ARGS}
   CMAKE_ARGS
@@ -12,12 +12,14 @@ ExternalProject_Add(PROJ4
     -DBUILD_SHARED_LIBS:BOOL=ON
     -DBUILD_LIBPROJ_SHARED:BOOL=ON
     -DBUILD_TESTING:BOOL=OFF
-    -DPROJ4_ENABLE_TESTS:BOOL=OFF
+    -DPROJ_TESTS:BOOL=OFF
   )
 
-fletch_external_project_force_install(PACKAGE PROJ4)
+fletch_external_project_force_install(PACKAGE PROJ)
 
+set(PROJ_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
 set(PROJ4_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)
+set(PROJ_INCLUDE_DIR "${PROJ4_ROOT}/include" CACHE PATH "")
 set(PROJ4_INCLUDE_DIR "${PROJ4_ROOT}/include" CACHE PATH "")
 
 file(APPEND ${fletch_CONFIG_INPUT} "
@@ -25,8 +27,9 @@ file(APPEND ${fletch_CONFIG_INPUT} "
 # PROJ4
 ########################################
 set(PROJ4_ROOT \${fletch_ROOT})
+set(PROJ_ROOT \${fletch_ROOT})
 set(PROJ4_INCLUDE_DIR \${fletch_ROOT}/include)
 set(PROJ_INCLUDE_DIR \${fletch_ROOT}/include)
 
-set(fletch_ENABLED_PROJ4 TRUE)
+set(fletch_ENABLED_PROJ TRUE)
 ")

--- a/CMake/External_PostGIS.cmake
+++ b/CMake/External_PostGIS.cmake
@@ -2,9 +2,9 @@ if(WIN32)
   message(FATAL_ERROR "PostGIS build is not currently support on Windows")
 endif()
 
-if(fletch_ENABLE_PROJ4)
-  set(_PostGIS_ARGS_PROJ4 --with-projdir=${PROJ4_ROOT})
-  list(APPEND _PostGIS_DEPENDS PROJ4)
+if(fletch_ENABLE_PROJ)
+  set(_PostGIS_ARGS_PROJ --with-projdir=${PROJ_ROOT})
+  list(APPEND _PostGIS_DEPENDS PROJ)
 else()
   find_package(PROJ4 REQUIRED)
 endif()
@@ -59,7 +59,7 @@ endif()
 set(_PostGIS_CONFIGURE_COMMAND
   ./configure
   --prefix=${fletch_BUILD_INSTALL_PREFIX}
-  ${_PostGIS_ARGS_PROJ4}
+  ${_PostGIS_ARGS_PROJ}
   ${_PostGIS_ARGS_GEOS}
   ${_PostGIS_ARGS_PostgreSQL}
   ${_PostGIS_ARGS_GDAL}

--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -131,11 +131,11 @@ if(VTK_WITH_PostgreSQL)
 endif()
 
 # Proj4
-# VTK doesn't accept PROJ4 that have include files that are called differently
+# VTK doesn't accept PROJ that have include files that are called differently
 # than lib_proj.h.
-if(fletch_ENABLE_PROJ4)
-  message(STATUS "VTK will not build against this project PROJ4. "
-    "VTK doesn't accept PROJ4 that have include files that are named differently "
+if(fletch_ENABLE_PROJ)
+  message(STATUS "VTK will not build against this project PROJ. "
+    "VTK doesn't accept PROJ that have include files that are named differently "
     "than lib_proj.h.")
 endif()
 set(vtk_cmake_args ${vtk_cmake_args}

--- a/CMake/External_libgeotiff.cmake
+++ b/CMake/External_libgeotiff.cmake
@@ -30,14 +30,14 @@ else()
   list(APPEND libgeotiff_pkg_args -DWITH_JPEG:BOOL=OFF)
 endif()
 
-if (NOT fletch_ENABLE_PROJ4)
-  message(FATAL " You must enable PROJ4 from fletch to build libgeotiff. There are issues with the system version")
+if (NOT fletch_ENABLE_PROJ)
+  message(FATAL "You must enable PROJ from fletch to build libgeotiff. There are issues with the system version.")
 endif()
 
 # Proj4
 add_package_dependency(
   PACKAGE libgeotiff
-  PACKAGE_DEPENDENCY PROJ4
+  PACKAGE_DEPENDENCY PROJ
   OPTIONAL
 )
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -341,11 +341,15 @@ else()
 endif()
 list(APPEND fletch_external_sources OpenCV)
 
-# PROJ.4
-set(PROJ4_version "4.9.3" )
-set(PROJ4_url "http://download.osgeo.org/proj/proj-${PROJ4_version}.tar.gz" )
-set(PROJ4_md5 "d598336ca834742735137c5674b214a1" )
-list(APPEND fletch_external_sources PROJ4 )
+# PROJ
+if (fletch_ENABLE_PROJ4)
+  message(WARNING "The package name PROJ4 is deprecated. Use PROJ instead.")
+  set(fletch_ENABLE_PROJ ON)
+endif()
+set(PROJ_version "5.2.0" )
+set(PROJ_url "http://download.osgeo.org/proj/proj-${PROJ_version}.tar.gz" )
+set(PROJ_md5 "ad285c7d03cbb138d9246e10e1f3191c" )
+list(APPEND fletch_external_sources PROJ )
 
 # libgeotiff
 set(libgeotiff_version "1.4.2")


### PR DESCRIPTION
Update PROJ to 5.2. Rename from PROJ4 to PROJ.

Note that, due to a major API change between PROJ 4 and later versions of PROJ, our find module, which looks for the PROJ 4 API, intentionally remains "PROJ4".