### PR TITLE
Patch vtk8.2 gcc10

### DIFF
--- a/Patches/VTK/8.2/Patch.cmake
+++ b/Patches/VTK/8.2/Patch.cmake
@@ -6,3 +6,18 @@
 file(COPY ${VTK_PATCH_DIR}/ThirdParty/netcdf/vtknetcdf/CMakeLists.txt
   DESTINATION ${VTK_SOURCE_DIR}/ThirdParty/netcdf/vtknetcdf/
 )
+
+# Patch vtkExodusII build for gcc 10.
+# Bug report is posted here:
+# https://gitlab.kitware.com/vtk/vtk/-/issues/17774
+# Details of the patch are posted here:
+# https://discourse.slicer.org/t/build-fails-in-vtkexodus-on-linux/12018/5
+file(COPY ${VTK_PATCH_DIR}/ThirdParty/exodusII/update.sh
+  DESTINATION ${VTK_SOURCE_DIR}/ThirdParty/exodusII/
+  )
+file(COPY ${VTK_PATCH_DIR}/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+  DESTINATION ${VTK_SOURCE_DIR}/ThirdParty/exodusII/vtkexodusII/src
+)
+file(COPY ${VTK_PATCH_DIR}/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+  DESTINATION ${VTK_SOURCE_DIR}/ThirdParty/exodusII/vtkexodusII/src
+)

--- a/Patches/VTK/8.2/ThirdParty/exodusII/update.sh
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+shopt -s dotglob
+
+readonly name="exodusII"
+readonly ownership="Seacas Upstream <kwrobot@kitware.com>"
+readonly subtree="ThirdParty/$name/vtk$name"
+readonly repo="https://gitlab.kitware.com/third-party/seacas.git"
+readonly tag="for/vtk-old"
+readonly paths="
+packages/seacas/libraries/exodus/CMakeLists.vtk.txt
+packages/seacas/libraries/exodus/cmake/exodus_config.h.in
+packages/seacas/libraries/exodus/include/exodusII.h
+packages/seacas/libraries/exodus/include/exodusII_cfg.h.in
+packages/seacas/libraries/exodus/include/exodusII_int.h
+packages/seacas/libraries/exodus/include/vtk_exodusII_mangle.h
+packages/seacas/libraries/exodus/src/*.c
+packages/seacas/libraries/exodus/src/deprecated/*.c
+
+packages/seacas/libraries/exodus/.gitattributes
+packages/seacas/libraries/exodus/COPYRIGHT
+packages/seacas/libraries/exodus/README
+packages/seacas/libraries/exodus/README.kitware.md
+"
+
+extract_source () {
+    git_archive
+    pushd "$extractdir/$name-reduced"
+    mv -v packages/seacas/libraries/exodus/* .
+    rm -rvf packages
+    mv -v CMakeLists.vtk.txt CMakeLists.txt
+    popd
+}
+
+. "${BASH_SOURCE%/*}/../update-common.sh"

--- a/Patches/VTK/8.2/ThirdParty/exodusII/update.sh
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/update.sh
@@ -8,7 +8,7 @@ readonly name="exodusII"
 readonly ownership="Seacas Upstream <kwrobot@kitware.com>"
 readonly subtree="ThirdParty/$name/vtk$name"
 readonly repo="https://gitlab.kitware.com/third-party/seacas.git"
-readonly tag="for/vtk-old"
+readonly tag="for/vtk-20200128-7.24f-v2019-12-18"
 readonly paths="
 packages/seacas/libraries/exodus/CMakeLists.vtk.txt
 packages/seacas/libraries/exodus/cmake/exodus_config.h.in

--- a/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
@@ -1,0 +1,618 @@
+/*
+ * Copyright (c) 2005-2017 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *
+ *     * Neither the name of NTESS nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*!
+
+\note The ex_create_par_int() is an internal function called by
+ex_create_par(). The user should call ex_create_par() and not ex_create_par_int().
+
+The function ex_create() creates a new exodus file and returns an ID
+that can subsequently be used to refer to the file.
+
+All floating point values in an exodus file are stored as either
+4-byte (float) or 8-byte (double) numbers; no mixing of 4- and
+8-byte numbers in a single file is allowed. An application code can
+compute either 4- or 8-byte values and can designate that the values
+be stored in the exodus file as either 4- or 8-byte numbers;
+conversion between the 4- and 8-byte values is performed automatically
+by the API routines. Thus, there are four possible combinations of
+compute word size and storage (or I/O) word size.
+
+\return In case of an error, ex_create() returns a negative number. Possible
+causes of errors include:
+  -  Passing a file name that includes a directory that does not
+ exist.
+  -  Specifying a file name of a file that exists and also
+ specifying a no clobber option.
+  -  Attempting to create a file in a directory without permission
+ to create files there.
+  -  Passing an invalid file clobber mode.
+
+
+\param path The file name of the new exodus file. This can be given as either an
+            absolute path name (from the root of the file system) or a relative
+            path name (from the current directory).
+
+\param cmode Mode. Use one of the following predefined constants:
+\arg EX_NOCLOBBER  To create the new file only if the given file name does
+not refer to a
+                      file that already exists.
+
+\arg EX_CLOBBER    To create the new file, regardless of whether a file with
+the same
+                      name already exists. If a file with the same name does
+exist, its
+                      contents will be erased.
+
+\arg EX_64BIT_OFFSET To create a model that can store individual datasets
+larger than
+                        2 gigabytes. This modifies the internal storage used by
+exodusII and
+                        also puts the underlying NetCDF file into the \e 64-bit
+offset'
+                        mode. See largemodel for more details on this
+                        mode. A large model file will also be created if the
+                        environment variable EXODUS_LARGE_MODEL is defined
+                        in the users environment. A message will be printed to
+standard output
+                        if this environment variable is found. EX_LARGE_MODEL is
+alias.
+
+\arg EX_NORMAL_MODEL Create a standard model.
+
+\arg EX_64BIT_DATA	To create a model using the CDF5 format which uses the
+                        classic model but has 64-bit dimensions and sizes.
+                        This type will also be created if the
+                        environment variable EXODUS_NETCDF5 is defined in the
+                        users environment. A message will be printed to standard
+                        output if
+                        this environment variable is found.
+
+\arg EX_NETCDF4	To create a model using the HDF5-based NetCDF-4
+                        output. An HDF5-based NetCDF-4 file will also be created
+if the
+                        environment variable EXODUS_NETCDF4 is defined in the
+                        users environment. A message will be printed to standard
+output if
+                        this environment variable is found.
+
+\arg EX_NOSHARE	Do not open the underlying NetCDF file in \e share
+mode. See the
+                        NetCDF documentation for more details.
+
+\arg EX_SHARE	Do open the underlying NetCDF file in \e share mode. See
+the NetCDF
+                        documentation for more details.
+
+\param[in,out] comp_ws  The word size in bytes (0, 4 or 8) of the floating point
+variables
+                        used in the application program. If 0 (zero) is passed,
+the default
+                        sizeof(float) will be used and returned in this
+variable. WARNING: all
+                        exodus functions requiring floats must be passed floats
+declared with
+                        this passed in or returned compute word size (4 or 8).}
+
+\param io_ws            The word size in bytes (4 or 8) of the floating point
+                        data as they are to be stored in the exodus file.
+
+\param run_version (internally generated) used to verify compatibility of library
+and include files.
+
+The following code segment creates an exodus file called \file{test.exo}:
+
+~~~{.c}
+#include "exodusII.h"
+int CPU_word_size, IO_word_size, exoid;
+CPU_word_size = sizeof(float);      \comment{use float or double}
+IO_word_size = 8;                   \comment{store variables as doubles}
+
+\comment{create exodus file}
+exoid = ex_create ("test.exo"       \comment{filename path}
+                    EX_CLOBBER,     \comment{create mode}
+                    &CPU_word_size, \comment{CPU float word size in bytes}
+                    &IO_word_size); \comment{I/O float word size in bytes}
+~~~
+
+*/
+
+/* Determine whether compiling against a parallel netcdf... */
+#include "exodusII.h"
+#if defined(PARALLEL_AWARE_EXODUS)
+
+#include "exodusII_int.h"
+#include <mpi.h>
+#include <stdlib.h>
+
+static int warning_output = 0;
+
+/* NOTE: Do *not* call `ex_create_par_int()` directly.  The public API
+ *       function name is `ex_create_par()` which is a wrapper that calls
+ *       `ex_create_par_int` with an additional argument to make sure
+ *       library and include file are consistent
+ */
+int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI_Comm comm,
+                      MPI_Info info, int run_version)
+{
+  int   exoid;
+  int   status;
+  int   dimid;
+  int   old_fill;
+  int   lio_ws;
+  int   filesiz = 1;
+  float vers;
+  char  errmsg[MAX_ERR_LENGTH];
+  char *mode_name;
+  int   nc_mode = 0;
+#if NC_HAS_HDF5
+  static int netcdf4_mode = -1;
+#endif /* NC_NETCDF4 */
+#if defined(NC_64BIT_DATA)
+  static int netcdf5_mode = -1;
+#endif
+
+  int int64_status;
+  int pariomode  = 0;
+  int is_mpiio   = 0;
+  int is_pnetcdf = 0;
+
+  unsigned int my_mode = cmode;
+
+  /* Contains a 1 in all bits corresponding to file modes */
+  static unsigned int all_modes = EX_NORMAL_MODEL | EX_64BIT_OFFSET | EX_64BIT_DATA | EX_NETCDF4;
+
+  EX_FUNC_ENTER();
+
+#if !NC_HAS_PARALLEL
+  /* Library does NOT support parallel output via netcdf-4 or pnetcdf */
+  snprintf(errmsg, MAX_ERR_LENGTH,
+           "EXODUS: ERROR: Parallel output requires the netcdf-4 and/or "
+           "pnetcdf library format, but this netcdf library does not "
+           "support either.\n");
+  ex_err(__func__, errmsg, EX_BADPARAM);
+  EX_FUNC_LEAVE(EX_FATAL);
+#endif
+
+  if (run_version != EX_API_VERS_NODOT && warning_output == 0) {
+    int run_version_major = run_version / 100;
+    int run_version_minor = run_version % 100;
+    int lib_version_major = EX_API_VERS_NODOT / 100;
+    int lib_version_minor = EX_API_VERS_NODOT % 100;
+    fprintf(stderr,
+            "EXODUS: Warning: This code was compiled with exodusII "
+            "version %d.%02d,\n          but was linked with exodusII "
+            "library version %d.%02d\n          This is probably an "
+            "error in the build process of this code.\n",
+            run_version_major, run_version_minor, lib_version_major, lib_version_minor);
+    warning_output = 1;
+  }
+
+/*
+ * See if specified mode is supported in the version of netcdf we
+ * are using
+ */
+#if !NC_HAS_HDF5
+  if (my_mode & EX_NETCDF4) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "EXODUS: ERROR: File format specified as netcdf-4, but the "
+             "NetCDF library being used was not configured to enable "
+             "this format\n");
+    ex_err(__func__, errmsg, EX_BADPARAM);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+#endif
+
+#if !defined(NC_64BIT_DATA)
+  if (my_mode & EX_64BIT_DATA) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "EXODUS: ERROR: File format specified as 64bit_data, but "
+             "the NetCDF library being used does not support this "
+             "format\n");
+    ex_err(__func__, errmsg, EX_BADPARAM);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+#endif
+
+  /* Check that one and only one format mode is specified... */
+  {
+    unsigned int set_modes = all_modes & my_mode;
+
+    if (set_modes == 0) {
+      my_mode |= EX_64BIT_OFFSET; /* Default if nothing specified */
+    }
+    else {
+      /* Checks that only a single bit is set */
+      set_modes = set_modes && !(set_modes & (set_modes - 1));
+      if (!set_modes) {
+        snprintf(errmsg, MAX_ERR_LENGTH,
+                 "EXODUS: ERROR: More than 1 file format "
+                 "(EX_NORMAL_MODEL, EX_LARGE_MODEL, EX_64BIT_OFFSET, "
+                 "EX_64BIT_DATA, or EX_NETCDF4)\nwas specified in the "
+                 "mode argument of the ex_create call. Only a single "
+                 "format can be specified.\n");
+        ex_err(__func__, errmsg, EX_BADPARAM);
+        EX_FUNC_LEAVE(EX_FATAL);
+      }
+    }
+  }
+
+  /*
+   * See if any integer data is to be stored as int64 (long long). If
+   * so, then need to set NC_NETCDF4 and unset NC_CLASSIC_MODEL (or
+   * set EX_NOCLASSIC.  Output meaningful error message if the library
+   * is not NetCDF-4 enabled...
+   *
+   * As of netcdf-4.4.0, can also use NC_64BIT_DATA (CDF5) mode for this...
+   */
+  int64_status = my_mode & (EX_ALL_INT64_DB | EX_ALL_INT64_API);
+
+  if ((int64_status & EX_ALL_INT64_DB) != 0) {
+#if NC_HAS_HDF5 || defined(NC_64BIT_DATA)
+    /* Library DOES support netcdf4 and/or cdf5 ... See if user
+     * specified either of these and use that one; if not, pick
+     * netcdf4, non-classic as default.
+     */
+    if (my_mode & EX_NETCDF4) {
+      my_mode |= EX_NOCLASSIC;
+    }
+#if defined(NC_64BIT_DATA)
+    else if (my_mode & EX_64BIT_DATA) {
+      ; /* Do nothing, already set */
+    }
+#endif
+    else {
+      /* Unset the current mode so we don't have multiples specified */
+      /* ~all_modes sets to 1 all bits not associated with file format */
+      my_mode &= ~all_modes;
+#if NC_HAS_HDF5
+      /* Pick netcdf4 as default mode for 64-bit integers */
+      my_mode |= EX_NOCLASSIC;
+      my_mode |= EX_NETCDF4;
+#else
+      /* Pick 64bit_data as default mode for 64-bit integers */
+      my_mode |= EX_64BIT_DATA;
+#endif
+    }
+#else
+    /* Library does NOT support netcdf4 or cdf5 */
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "EXODUS: ERROR: 64-bit integer storage requested, but the "
+             "netcdf library does not support the required netcdf-4 or "
+             "64BIT_DATA extensions.\n");
+    ex_err(__func__, errmsg, EX_BADPARAM);
+    EX_FUNC_LEAVE(EX_FATAL);
+#endif
+  }
+
+  /* Check parallel io mode.  Valid is NC_MPIPOSIX or NC_MPIIO or NC_PNETCDF
+   * Exodus uses different flag values; map to netcdf values
+   */
+  {
+    int tmp_mode = 0;
+    if (my_mode & EX_MPIPOSIX) {
+      pariomode = NC_MPIPOSIX;
+      tmp_mode  = EX_NETCDF4;
+#if !NC_HAS_HDF5
+      snprintf(errmsg, MAX_ERR_LENGTH,
+               "EXODUS: ERROR: EX_MPIPOSIX parallel output requested "
+               "which requires NetCDF-4 support, but the library does "
+               "not have that option enabled.\n");
+      ex_err(__func__, errmsg, EX_BADPARAM);
+      EX_FUNC_LEAVE(EX_FATAL);
+#endif
+    }
+    else if (my_mode & EX_MPIIO) {
+      pariomode = NC_MPIIO;
+      is_mpiio  = 1;
+      tmp_mode  = EX_NETCDF4;
+#if !NC_HAS_HDF5
+      snprintf(errmsg, MAX_ERR_LENGTH,
+               "EXODUS: ERROR: EX_MPIIO parallel output requested which "
+               "requires NetCDF-4 support, but the library does not "
+               "have that option enabled.\n");
+      ex_err(__func__, errmsg, EX_BADPARAM);
+      EX_FUNC_LEAVE(EX_FATAL);
+#endif
+    }
+    else if (my_mode & EX_PNETCDF) {
+      pariomode  = NC_PNETCDF;
+      is_pnetcdf = 1;
+      /* See if client specified 64-bit or not... */
+      if ((int64_status & EX_ALL_INT64_DB) != 0) {
+        tmp_mode = EX_64BIT_DATA;
+      }
+      else {
+        tmp_mode = EX_64BIT_OFFSET;
+      }
+#if !NC_HAS_PNETCDF
+      snprintf(errmsg, MAX_ERR_LENGTH,
+               "EXODUS: ERROR: EX_PNETCDF parallel output requested "
+               "which requires PNetCDF support, but the library does "
+               "not have that option enabled.\n");
+      ex_err(__func__, errmsg, EX_BADPARAM);
+      EX_FUNC_LEAVE(EX_FATAL);
+#endif
+    }
+
+    /* If tmp_mode was set here, then need to clear any other mode that
+       was potentially already set in my_mode... */
+    my_mode &= ~all_modes;
+    my_mode |= tmp_mode;
+  }
+
+  if (my_mode & EX_NETCDF4) {
+    nc_mode |= NC_NETCDF4;
+  }
+  else {
+    if (netcdf4_mode == -1) {
+      char *option = getenv("EXODUS_NETCDF4");
+      if (option != NULL) {
+        netcdf4_mode = NC_NETCDF4;
+        if (option[0] != 'q') {
+          fprintf(stderr, "EXODUS: Using netcdf version 4 selected via "
+                          "EXODUS_NETCDF4 environment variable\n");
+        }
+      }
+      else {
+        netcdf4_mode = 0;
+      }
+    }
+    nc_mode |= netcdf4_mode;
+  }
+
+  if (!(my_mode & EX_NOCLASSIC)) {
+    nc_mode |= NC_CLASSIC_MODEL;
+  }
+
+#if defined(NC_64BIT_DATA)
+  if (my_mode & EX_64BIT_DATA) {
+    nc_mode |= (NC_64BIT_DATA);
+  }
+  else {
+    if (netcdf5_mode == -1) {
+      char *option = getenv("EXODUS_NETCDF5");
+      if (option != NULL) {
+        netcdf5_mode = NC_64BIT_DATA;
+        if (option[0] != 'q') {
+          fprintf(stderr, "EXODUS: Using netcdf version 5 (CDF5) selected via "
+                          "EXODUS_NETCDF5 environment variable\n");
+        }
+      }
+      else {
+        netcdf5_mode = 0;
+      }
+    }
+    nc_mode |= netcdf5_mode;
+  }
+#endif
+
+  /*
+   * Hardwire filesiz to 1 for all created files. Reduce complexity in nodal output routines.
+   * has been default for a decade or so, but still support it on read...
+   */
+  if (
+#if NC_HAS_HDF5
+      !(nc_mode & NC_NETCDF4) &&
+#endif
+#if defined(NC_64BIT_DATA)
+      !(nc_mode & NC_64BIT_DATA) &&
+#endif
+      filesiz == 1) {
+    nc_mode |= NC_64BIT_OFFSET;
+  }
+
+  if (my_mode & EX_SHARE) {
+    nc_mode |= NC_SHARE;
+  }
+
+  /*
+   * set error handling mode to no messages, non-fatal errors
+   */
+  ex_opts(exoptval); /* call required to set ncopts first time through */
+
+  if (my_mode & EX_CLOBBER) {
+    nc_mode |= NC_CLOBBER;
+    mode_name = "CLOBBER";
+  }
+  else {
+    nc_mode |= NC_NOCLOBBER;
+    mode_name = "NOCLOBBER";
+  }
+
+  if ((status = nc_create_par(path, nc_mode | pariomode, comm, info, &exoid)) != NC_NOERR) {
+#if NC_HAS_HDF5
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: file create failed for %s, mode: %s", path, mode_name);
+#else
+    if (my_mode & EX_NETCDF4) {
+      snprintf(errmsg, MAX_ERR_LENGTH,
+               "ERROR: file create failed for %s in NETCDF4 and %s "
+               "mode.\n\tThis library does not support netcdf-4 files.",
+               path, mode_name);
+    }
+    else {
+      snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: file create failed for %s, mode: %s", path,
+               mode_name);
+    }
+#endif
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* turn off automatic filling of netCDF variables */
+
+  if ((status = nc_set_fill(exoid, NC_NOFILL, &old_fill)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to set nofill mode in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* Verify that there is not an existing file_item struct for this
+     exoid This could happen (and has) when application calls
+     ex_open(), but then closes file using nc_close() and then reopens
+     file.  NetCDF will possibly reuse the exoid which results in
+     internal corruption in exodus data structures since exodus does
+     not know that file was closed and possibly new file opened for
+     this exoid
+  */
+  if (ex_find_file_item(exoid) != NULL) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: There is an existing file already using the file "
+             "id %d which was also assigned to file %s.\n\tWas "
+             "nc_close() called instead of ex_close() on an open Exodus "
+             "file?\n",
+             exoid, path);
+    ex_err(__func__, errmsg, EX_BADFILEID);
+    nc_close(exoid);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* initialize floating point size conversion.  since creating new file,
+   * i/o wordsize attribute from file is zero.
+   */
+  if (ex_conv_ini(exoid, comp_ws, io_ws, 0, int64_status, 1, is_mpiio, is_pnetcdf) != EX_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to init conversion routines in file id %d",
+             exoid);
+    ex_err(__func__, errmsg, EX_LASTERR);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* put the EXODUS version number, and i/o floating point word size as
+   * netcdf global attributes
+   */
+
+  /* store Exodus API version # as an attribute */
+  vers = EX_API_VERS;
+  if ((status = nc_put_att_float(exoid, NC_GLOBAL, ATT_API_VERSION, NC_FLOAT, 1, &vers)) !=
+      NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to store Exodus II API version attribute in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* store Exodus file version # as an attribute */
+  vers = EX_VERS;
+  if ((status = nc_put_att_float(exoid, NC_GLOBAL, ATT_VERSION, NC_FLOAT, 1, &vers)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to store Exodus II file version attribute in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* store Exodus file float word size  as an attribute */
+  lio_ws = (int)(*io_ws);
+  if ((status = nc_put_att_int(exoid, NC_GLOBAL, ATT_FLT_WORDSIZE, NC_INT, 1, &lio_ws)) !=
+      NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to store Exodus II file float word size "
+             "attribute in file id %d",
+             exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* store Exodus file size (1=large, 0=normal) as an attribute */
+  if ((status = nc_put_att_int(exoid, NC_GLOBAL, ATT_FILESIZE, NC_INT, 1, &filesiz)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to store Exodus II file size attribute in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  {
+    int max_so_far = 32;
+    if ((status = nc_put_att_int(exoid, NC_GLOBAL, ATT_MAX_NAME_LENGTH, NC_INT, 1, &max_so_far)) !=
+        NC_NOERR) {
+      snprintf(errmsg, MAX_ERR_LENGTH,
+               "ERROR: failed to add maximum_name_length attribute in file id %d", exoid);
+      ex_err(__func__, errmsg, status);
+      EX_FUNC_LEAVE(EX_FATAL);
+    }
+  }
+
+  /* define some dimensions and variables */
+
+  /* create string length dimension */
+  if ((status = nc_def_dim(exoid, DIM_STR, (MAX_STR_LENGTH + 1), &dimid)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define string length in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* The name string length dimension is delayed until the ex_put_init function
+   */
+
+  /* create line length dimension */
+  if ((status = nc_def_dim(exoid, DIM_LIN, (MAX_LINE_LENGTH + 1), &dimid)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define line length in file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* create number "4" dimension; must be of type long */
+  if ((status = nc_def_dim(exoid, DIM_N4, 4L, &dimid)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define number \"4\" dimension in file id %d",
+             exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  {
+    int int64_db_status = int64_status & EX_ALL_INT64_DB;
+    if ((status = nc_put_att_int(exoid, NC_GLOBAL, ATT_INT64_STATUS, NC_INT, 1,
+                                 &int64_db_status)) != NC_NOERR) {
+      snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add int64_status attribute in file id %d",
+               exoid);
+      ex_err(__func__, errmsg, status);
+      EX_FUNC_LEAVE(EX_FATAL);
+    }
+  }
+
+  if ((status = nc_enddef(exoid)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to complete definition for file id %d", exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  EX_FUNC_LEAVE(exoid);
+}
+#else
+/*
+ * Prevent warning in some versions of ranlib(1) because the object
+ * file has no symbols.
+ */
+const char exodus_unused_symbol_dummy_1;
+#endif

--- a/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
@@ -614,5 +614,5 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_create_par;
 #endif

--- a/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) 2005-2017 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *
+ *     * Neither the name of NTESS nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/*****************************************************************************
+ *
+ * exopen - ex_open
+ *
+ * entry conditions -
+ *   input parameters:
+ *       char*   path                    exodus filename path
+ *       int     mode                    access mode w/r
+ *
+ * exit conditions -
+ *       int     exoid                   exodus file id
+ *       int*    comp_ws                 computer word size
+ *       int*    io_ws                   storage word size
+ *       float*  version                 EXODUS interface version number
+ *
+ * revision history -
+ *
+ *
+ *****************************************************************************/
+/* Determine whether compiling against a parallel netcdf... */
+#include "exodusII.h"
+#if defined(PARALLEL_AWARE_EXODUS)
+
+#include "exodusII.h"     // for ex_err, etc
+#include "exodusII_int.h" // for EX_FATAL, etc
+#include <mpi.h>          // for MPI_Comm, MPI_Info, etc
+#include <stddef.h>       // for size_t
+#include <stdio.h>
+#include <string.h>
+/*!
+
+\note The ex_open_par_int() is an internal function called by
+ex_open_par(). The user should call ex_open_par() and not ex_open_par_int().
+
+The function ex_open_par() opens an existing exodus file and returns
+an ID that can subsequently be used to refer to the file, the word
+size of the floating point values stored in the file, and the version
+of the exodus database (returned as a ``float'', regardless of the
+compute or I/O word size). Multiple files may be ``open'' simultaneously.
+
+\return In case of an error, ex_open_par() returns a negative
+number. Possible causes of errors include:
+  -  The specified file does not exist.
+  -  The mode specified is something other than the predefined constant
+\fparam{EX_READ} or \fparam{EX_WRITE}.
+  -  Database version is earlier than 2.0.
+
+\param path The file name of the exodus file. This can be given as either an
+            absolute path name (from the root of the file system) or a relative
+            path name (from the current directory).
+
+\param mode Access mode. Use one of the following predefined constants:
+        -  \fparam{EX_READ} To open the file just for reading.
+        -  \fparam{EX_WRITE} To open the file for writing and reading.
+
+\param[in,out] comp_ws The word size in bytes (0, 4 or 8) of the floating point
+variables
+               used in the application program. If 0 (zero) is passed, the
+default
+               size of floating point values for the machine will be used and
+               returned in this variable. WARNING: all exodus functions
+requiring
+               reals must be passed reals declared with this passed in or
+returned
+               compute word size (4 or 8).
+
+
+\param[in,out] io_ws The word size in bytes (0, 4 or 8) of the floating
+                    point data as they are stored in the exodus file. If the
+word
+                    size does not match the word size of data stored in the
+file,
+                    a fatal error is returned. If this argument is 0, the word
+size
+                    of the floating point data already stored in the file is
+returned.
+
+\param[out] version  Returned exodus database version number.
+
+The following opens an exodus file named \file{test.exo} for parallel
+read only, using default settings for compute and I/O word sizes:
+
+~~~{.c}
+int CPU_word_size,IO_word_size, exoid;
+float version;
+
+CPU_word_size = sizeof(float);   \co{float or double}
+IO_word_size = 0;                \co{use what is stored in file}
+
+\comment{open exodus files}
+exoid = ex_open_par ("test.exo",     \co{filename path}
+                     EX_READ,        \co{access mode = READ}
+                     &CPU_word_size, \co{CPU word size}
+                     &IO_word_size,  \co{IO word size}
+                     &version,       \co{ExodusII library version
+                     MPI_COMM_WORLD,
+                     MPI_INFO_NULL);}
+~~~
+ */
+
+static int warning_output = 0;
+
+struct ncvar /* variable */
+{
+  char    name[MAX_VAR_NAME_LENGTH];
+  nc_type type;
+  int     ndims;
+  int     dims[NC_MAX_VAR_DIMS];
+  int     natts;
+};
+
+/* NOTE: Do *not* call `ex_open_par_int()` directly.  The public API
+ *       function name is `ex_open_par()` which is a wrapper that
+ *       calls `ex_open_par_int` with an additional argument to make
+ *       sure library and include file are consistent
+ */
+int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float *version,
+                    MPI_Comm comm, MPI_Info info, int run_version)
+{
+  int     exoid;
+  int     status, stat_att, stat_dim;
+  nc_type att_type = NC_NAT;
+  size_t  att_len  = 0;
+  int     nc_mode  = 0;
+  int     old_fill;
+  int     file_wordsize;
+  int     dim_str_name;
+  int     int64_status = 0;
+  int     is_hdf5      = 0;
+  int     is_pnetcdf   = 0;
+  int     in_redef     = 0;
+
+  char errmsg[MAX_ERR_LENGTH];
+
+  EX_FUNC_ENTER();
+
+  /* set error handling mode to no messages, non-fatal errors */
+  ex_opts(exoptval); /* call required to set ncopts first time through */
+
+  if (run_version != EX_API_VERS_NODOT && warning_output == 0) {
+    int run_version_major = run_version / 100;
+    int run_version_minor = run_version % 100;
+    int lib_version_major = EX_API_VERS_NODOT / 100;
+    int lib_version_minor = EX_API_VERS_NODOT % 100;
+    fprintf(stderr,
+            "EXODUS: Warning: This code was compiled with exodus "
+            "version %d.%02d,\n          but was linked with exodus "
+            "library version %d.%02d\n          This is probably an "
+            "error in the build process of this code.\n",
+            run_version_major, run_version_minor, lib_version_major, lib_version_minor);
+    warning_output = 1;
+  }
+
+  if ((mode & EX_READ) && (mode & EX_WRITE)) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: Cannot specify both EX_READ and EX_WRITE");
+    ex_err(__func__, errmsg, EX_BADFILEMODE);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  if (mode & EX_WRITE) {
+    nc_mode = (NC_WRITE | NC_MPIIO);
+  }
+  else {
+    nc_mode = (NC_NOWRITE | NC_SHARE | NC_MPIIO);
+  }
+  if ((status = nc_open_par(path, nc_mode, comm, info, &exoid)) != NC_NOERR) {
+    /* It is possible that the user is trying to open a netcdf4
+       file, but the netcdf4 capabilities aren't available in the
+       netcdf linked to this library. Note that we can't just use a
+       compile-time define since we could be using a shareable
+       netcdf library, so the netcdf4 capabilities aren't known
+       until runtime...
+
+       Later versions of netcdf-4.X have a function that can be
+       queried to determine whether the library being used was
+       compiled with --enable-netcdf4, but not everyone is using that
+       version yet, so we may have to do some guessing...
+
+       At this time, query the beginning of the file and see if it
+       is an HDF-5 file and if it is assume that the open failure
+       is due to the netcdf library not enabling netcdf4 features unless
+       we have the define that shows it is enabled, then assume other error...
+    */
+    int type = 0;
+    ex_check_file_type(path, &type);
+
+    if (type == 5) {
+#if NC_HAS_HDF5
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the netcdf-4 "
+              "file:\n\t'%s'\n\t failed. The netcdf library supports "
+              "netcdf-4 so there must be a filesystem or some other "
+              "issue \n",
+              path);
+#else
+      /* This is an hdf5 (netcdf4) file. If NC_HAS_HDF5 is not defined,
+         then we either don't have hdf5 support in this netcdf version,
+         OR this is an older netcdf version that doesn't provide that define.
+
+         In either case, we don't have enough information, so we
+         assume that the netcdf doesn't have netcdf4 capabilities
+         enabled.  Tell the user...
+      */
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the netcdf-4 "
+              "file:\n\t'%s'\n\tEither the netcdf library does not "
+              "support netcdf-4 or there is a filesystem or some "
+              "other issue \n",
+              path);
+#endif
+    }
+    else if (type == 4) {
+#if defined(NC_64BIT_DATA)
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the CDF5 "
+              "file:\n\t'%s'\n\t failed. The netcdf library supports "
+              "CDF5-type files so there must be a filesystem or some other "
+              "issue \n",
+              path);
+#else
+      /* This is an cdf5 (64BIT_DATA) file. If NC_64BIT_DATA is not defined,
+         then we either don't have cdf5 support in this netcdf version,
+         OR this is an older netcdf version that doesn't provide that define.
+
+         In either case, we don't have enough information, so we
+         assume that the netcdf doesn't have cdf5 capabilities
+         enabled.  Tell the user...
+      */
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the CDF5 "
+              "file:\n\t'%s'\n\tEither the netcdf library does not "
+              "support CDF5 or there is a filesystem or some "
+              "other issue \n",
+              path);
+
+#endif
+    }
+    else if (type == 1 || type == 2) {
+#if NC_HAS_PNETCDF
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the classic NetCDF "
+              "file:\n\t'%s'\n\t failed. The netcdf library supports "
+              "PNetCDF files as required for parallel readinf of this "
+              "file type, so there must be a filesystem or some other "
+              "issue \n",
+              path);
+#else
+      /* This is an normal NetCDF format file, for parallel reading, the PNetCDF
+         library is required but that is not compiled into this version.
+      */
+      fprintf(stderr,
+              "EXODUS: ERROR: Attempting to open the NetCDF "
+              "file:\n\t'%s'\n\tThe NetCDF library was not "
+              "built with PNetCDF support as required for parallel access to this file.\n",
+              path);
+
+#endif
+    }
+
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to open %s of type %d for reading. Either the "
+             "file does not exist, or there is a permission or file format "
+             "issue.",
+             path, type);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* File opened correctly */
+  int type = 0;
+  ex_check_file_type(path, &type);
+  if (type == 5) {
+    is_hdf5 = 1;
+  }
+  else if (type == 1 || type == 2 || type == 4) {
+    is_pnetcdf = 1;
+  }
+
+  if (mode & EX_WRITE) { /* Appending */
+    /* turn off automatic filling of netCDF variables */
+    if (is_pnetcdf) {
+      if ((status = nc_redef(exoid)) != NC_NOERR) {
+        snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to put file id %d into define mode", exoid);
+        ex_err(__func__, errmsg, status);
+        EX_FUNC_LEAVE(EX_FATAL);
+      }
+      in_redef = 1;
+    }
+
+    if ((status = nc_set_fill(exoid, NC_NOFILL, &old_fill)) != NC_NOERR) {
+      snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to set nofill mode in file id %d", exoid);
+      ex_err(__func__, errmsg, status);
+      EX_FUNC_LEAVE(EX_FATAL);
+    }
+
+    stat_att = nc_inq_att(exoid, NC_GLOBAL, ATT_MAX_NAME_LENGTH, &att_type, &att_len);
+    stat_dim = nc_inq_dimid(exoid, DIM_STR_NAME, &dim_str_name);
+    if (stat_att != NC_NOERR || stat_dim != NC_NOERR) {
+      if (!in_redef) {
+        if ((status = nc_redef(exoid)) != NC_NOERR) {
+          snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to put file id %d into define mode",
+                   exoid);
+          ex_err(__func__, errmsg, status);
+          EX_FUNC_LEAVE(EX_FATAL);
+        }
+        in_redef = 1;
+      }
+      if (stat_att != NC_NOERR) {
+        int max_so_far = 32;
+        nc_put_att_int(exoid, NC_GLOBAL, ATT_MAX_NAME_LENGTH, NC_INT, 1, &max_so_far);
+      }
+
+      /* If the DIM_STR_NAME variable does not exist on the database, we need to
+       * add it now. */
+      if (stat_dim != NC_NOERR) {
+        /* Not found; set to default value of 32+1. */
+        int max_name = ex_default_max_name_length < 32 ? 32 : ex_default_max_name_length;
+        nc_def_dim(exoid, DIM_STR_NAME, max_name + 1, &dim_str_name);
+      }
+    }
+
+    if (in_redef) {
+      if ((status = nc_enddef(exoid)) != NC_NOERR) {
+        snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to complete definition in file id %d",
+                 exoid);
+        ex_err(__func__, errmsg, status);
+        EX_FUNC_LEAVE(EX_FATAL);
+      }
+      in_redef = 0;
+    }
+
+    /* If this is a parallel execution and we are appending, then we
+     * need to set the parallel access method for all transient variables to NC_COLLECTIVE since
+     * they will be being extended.
+     */
+    int ndims;    /* number of dimensions */
+    int nvars;    /* number of variables */
+    int ngatts;   /* number of global attributes */
+    int recdimid; /* id of unlimited dimension */
+
+    int varid;
+
+    /* Determine number of variables on the database... */
+    nc_inq(exoid, &ndims, &nvars, &ngatts, &recdimid);
+
+    for (varid = 0; varid < nvars; varid++) {
+      struct ncvar var;
+      nc_inq_var(exoid, varid, var.name, &var.type, &var.ndims, var.dims, &var.natts);
+
+      if ((strcmp(var.name, VAR_GLO_VAR) == 0) || (strncmp(var.name, "vals_elset_var", 14) == 0) ||
+          (strncmp(var.name, "vals_sset_var", 13) == 0) ||
+          (strncmp(var.name, "vals_fset_var", 13) == 0) ||
+          (strncmp(var.name, "vals_eset_var", 13) == 0) ||
+          (strncmp(var.name, "vals_nset_var", 13) == 0) ||
+          (strncmp(var.name, "vals_nod_var", 12) == 0) ||
+          (strncmp(var.name, "vals_edge_var", 13) == 0) ||
+          (strncmp(var.name, "vals_face_var", 13) == 0) ||
+          (strncmp(var.name, "vals_elem_var", 13) == 0) ||
+          (strcmp(var.name, VAR_WHOLE_TIME) == 0)) {
+        nc_var_par_access(exoid, varid, NC_COLLECTIVE);
+      }
+    }
+  } /* End of (mode & EX_WRITE) */
+
+  /* determine version of EXODUS file, and the word size of
+   * floating point and integer values stored in the file
+   */
+
+  if ((status = nc_get_att_float(exoid, NC_GLOBAL, ATT_VERSION, version)) != NC_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to get database version for file id: %d",
+             exoid);
+    ex_err(__func__, errmsg, status);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* check ExodusII file version - old version 1.x files are not supported */
+  if (*version < 2.0) {
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: Unsupported file version %.2f in file id: %d",
+             *version, exoid);
+    ex_err(__func__, errmsg, EX_BADPARAM);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  if (nc_get_att_int(exoid, NC_GLOBAL, ATT_FLT_WORDSIZE, &file_wordsize) !=
+      NC_NOERR) { /* try old (prior to db version 2.02) attribute name */
+    if ((status = nc_get_att_int(exoid, NC_GLOBAL, ATT_FLT_WORDSIZE_BLANK, &file_wordsize)) !=
+        NC_NOERR) {
+      snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to get file wordsize from file id: %d",
+               exoid);
+      ex_err(__func__, errmsg, status);
+      EX_FUNC_LEAVE(EX_FATAL);
+    }
+  }
+
+  /* See if int64 status attribute exists and if so, what data is stored as
+   * int64
+   * Older files don't have the attribute, so it is not an error if it is
+   * missing
+   */
+  if (nc_get_att_int(exoid, NC_GLOBAL, ATT_INT64_STATUS, &int64_status) != NC_NOERR) {
+    int64_status = 0; /* Just in case it gets munged by a failed get_att_int call */
+  }
+
+  /* Merge in API int64 status flags as specified by caller of function... */
+  int64_status |= (mode & EX_ALL_INT64_API);
+
+  /* Verify that there is not an existing file_item struct for this
+     exoid This could happen (and has) when application calls
+     ex_open(), but then closes file using nc_close() and then reopens
+     file.  NetCDF will possibly reuse the exoid which results in
+     internal corruption in exodus data structures since exodus does
+     not know that file was closed and possibly new file opened for
+     this exoid
+  */
+  if (ex_find_file_item(exoid) != NULL) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: There is an existing file already using the file "
+             "id %d which was also assigned to file %s.\n\tWas "
+             "nc_close() called instead of ex_close() on an open Exodus "
+             "file?\n",
+             exoid, path);
+    ex_err(__func__, errmsg, EX_BADFILEID);
+    nc_close(exoid);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  /* initialize floating point and integer size conversion. */
+  if (ex_conv_ini(exoid, comp_ws, io_ws, file_wordsize, int64_status, 1, is_hdf5, is_pnetcdf) !=
+      EX_NOERR) {
+    snprintf(errmsg, MAX_ERR_LENGTH,
+             "ERROR: failed to initialize conversion routines in file id %d", exoid);
+    ex_err(__func__, errmsg, EX_LASTERR);
+    EX_FUNC_LEAVE(EX_FATAL);
+  }
+
+  EX_FUNC_LEAVE(exoid);
+}
+#else
+/*
+ * Prevent warning in some versions of ranlib(1) because the object
+ * file has no symbols.
+ */
+const char exodus_unused_symbol_dummy_1;
+#endif

--- a/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+++ b/Patches/VTK/8.2/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
@@ -474,5 +474,5 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_open_par;
 #endif


### PR DESCRIPTION
Patch VTK 8.2 to fix a build issue when using gcc v10. vtkExodusII complains about "multiple definition of `exodus_unused_symbol_dummy_1'"

The VTK issue is written up here and is merged into master as of a year ago:
https://gitlab.kitware.com/vtk/vtk/-/issues/17774

This patch was taken from Slicer. Details posted here:
https://discourse.slicer.org/t/build-fails-in-vtkexodus-on-linux/12018/5


