### PR TITLE
Disable GTest, GMock in PROJ

### DIFF
--- a/CMake/External_PROJ.cmake
+++ b/CMake/External_PROJ.cmake
@@ -13,6 +13,8 @@ ExternalProject_Add(PROJ
     -DBUILD_LIBPROJ_SHARED:BOOL=ON
     -DBUILD_TESTING:BOOL=OFF
     -DPROJ_TESTS:BOOL=OFF
+    -DBUILD_GMOCK:BOOL=OFF
+    -DBUILD_GTEST:BOOL=OFF
   )
 
 fletch_external_project_force_install(PACKAGE PROJ)


### PR DESCRIPTION
Explicitly tell PROJ to not build Google Test or Google Mock. There is some odd issue which I have not been able to track down with the compile flags being mangled during these builds that results in passing bogus compile flags and seems to be triggered by any `-Werror=something` flags.

For our purposes, we don't need PROJ's tests, so turning these off works around the issue and also makes for a leaner build.