### PR TITLE
Update fletch-tarballs.cmake

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -210,7 +210,7 @@ list(APPEND fletch_external_sources SuiteSparse)
 set(Ceres_version 1.14.0)
 set(Ceres_url "http://ceres-solver.org/ceres-solver-${Ceres_version}.tar.gz")
 set(Ceres_md5 "fd9b4eba8850f0f2ede416cd821aafa5")
-set(Ceres_dlname "ceres-${Ceres_version}.tar.gz")
+set(Ceres_dlname "ceres-solver-${Ceres_version}.tar.gz")
 list(APPEND fletch_external_sources Ceres)
 
 if(NOT WIN32)


### PR DESCRIPTION
The downloaded Ceres file name is actually ceres-solver-1.14.0.tar.gz not ceres-1.14.0.tar.gz
Typo first discover here: https://github.com/Kitware/TeleSculptor/issues/425#issuecomment-808448948