### PR TITLE
Conditionally update zlib name in get_system_library_name

### DIFF
--- a/CMake/External_PNG.cmake
+++ b/CMake/External_PNG.cmake
@@ -8,7 +8,11 @@ add_package_dependency(
 )
 if(NOT ZLIB_FOUND)
   set(ZLIB_INCLUDE_DIRS ${fletch_BUILD_INSTALL_PREFIX}/include)
-  get_system_library_name(zlib zlib_lib)
+  if (BUILD_SHARED_LIBS)
+    get_system_library_name(zlib zlib_lib)
+  else()
+    get_system_library_name(z zlib_lib)
+  endif()
   set(ZLIB_LIBRARIES ${fletch_BUILD_INSTALL_PREFIX}/lib/${zlib_lib})
 endif()
 set(png_cmake_args ${png_cmake_args}


### PR DESCRIPTION
The static build for zlib is called libz.a rather libzlib.a. Thus PR checks if the build is static or dynamic and provides the zlib name based on the type of build