### PR TITLE
Disable FFmpeg assembler optimizations

### DIFF
--- a/CMake/External_FFmpeg.cmake
+++ b/CMake/External_FFmpeg.cmake
@@ -75,6 +75,7 @@ else ()
                            --enable-pic
                            --extra-cflags=-fPIC
                            --extra-cxxflags=-fPIC
+                           --disable-asm
        )
   endif()
   set(FFMPEG_CONFIGURE_COMMAND


### PR DESCRIPTION
Disable FFMPEG assembler optimizations on static build to allow libavcodec to build with fpic enabled. Necessary for Kwiver wheel building.