### PR TITLE
Patch boost implicit function errors

### DIFF
--- a/Patches/Boost/1.65.1/Patch.cmake
+++ b/Patches/Boost/1.65.1/Patch.cmake
@@ -20,3 +20,28 @@ file(COPY ${Boost_patch}/msvc.jam
 file(COPY ${Boost_patch}/visualc.hpp
   DESTINATION ${Boost_source}/boost/config/compiler/
   )
+
+# Patch to fix b2's missing headers
+# This problem manifests in darwin clang and results in
+# error: implicit declaration of function ...
+file(COPY ${Boost_patch}/debugger.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/execcmd.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/filesys.h
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/fileunix.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/jam.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/make.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/
+  )
+file(COPY ${Boost_patch}/path.c
+  DESTINATION ${Boost_source}/tools/build/src/engine/modules/
+  )

--- a/Patches/Boost/1.65.1/debugger.c
+++ b/Patches/Boost/1.65.1/debugger.c
@@ -1,0 +1,2739 @@
+/*
+ * Copyright 2015 Steven Watanabe
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include "debugger.h"
+#include "constants.h"
+#include "strings.h"
+#include "pathsys.h"
+#include "cwd.h"
+#include "function.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <signal.h>
+
+#ifdef NT
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#else
+#include <errno.h>
+#include <sys/wait.h>
+#endif
+
+#undef debug_on_enter_function
+#undef debug_on_exit_function
+
+struct breakpoint
+{
+    OBJECT * file;
+    OBJECT * bound_file;
+    int line;
+    int status;
+};
+
+#define BREAKPOINT_ENABLED 1
+#define BREAKPOINT_DISABLED 2
+#define BREAKPOINT_DELETED 3
+
+static struct breakpoint * breakpoints;
+static int num_breakpoints;
+static int breakpoints_capacity;
+
+#define DEBUG_NO_CHILD  0
+#define DEBUG_RUN       1
+#define DEBUG_STEP      2
+#define DEBUG_NEXT      3
+#define DEBUG_FINISH    4
+#define DEBUG_STOPPED   5
+
+#define DEBUG_MSG_BREAKPOINT   1
+#define DEBUG_MSG_END_STEPPING 2
+#define DEBUG_MSG_SETUP        3
+#define DEBUG_MSG_DONE         32
+
+static int debug_state;
+static int debug_depth;
+static OBJECT * debug_file;
+static int debug_line;
+static FRAME * debug_frame;
+LIST * debug_print_result;
+static int current_token;
+static int debug_selected_frame_number;
+
+/* Commands are read from this stream. */
+static FILE * command_input;
+/* Where to send output from commands. */
+static FILE * command_output;
+/* Only valid in the parent.  Reads command output from the child. */
+static FILE * command_child;
+
+struct command_elem
+{
+    const char * key;
+    void (*command)( int, const char * * );
+};
+
+static struct command_elem * command_array;
+
+static void debug_listen( void );
+static int read_command( void );
+static int is_same_file( OBJECT * file1, OBJECT * file2 );
+static void debug_mi_format_token( void );
+static OBJECT * make_absolute_path( OBJECT * filename );
+
+static void debug_string_write( FILE * out, const char * data )
+{
+    fprintf( out, "%s", data );
+    fputc( '\0', out );
+}
+
+static char * debug_string_read( FILE * in )
+{
+    string buf[ 1 ];
+    int ch;
+    char * result;
+    string_new( buf );
+    while( ( ch = fgetc( in ) ) > 0 )
+    {
+        string_push_back( buf, (char)ch );
+    }
+    result = strdup( buf->value );
+    string_free( buf );
+    return result;
+}
+
+static void debug_object_write( FILE * out, OBJECT * data )
+{
+    debug_string_write( out, object_str( data ) );
+}
+
+static OBJECT * debug_object_read( FILE * in )
+{
+    string buf[ 1 ];
+    int ch;
+    OBJECT * result;
+    string_new( buf );
+    while( ( ch = fgetc( in ) ) > 0 )
+    {
+        string_push_back( buf, (char)ch );
+    }
+    result = object_new( buf->value );
+    string_free( buf );
+    return result;
+}
+
+static void debug_int_write( FILE * out, int i )
+{
+    fprintf( out, "%d", i );
+    fputc( '\0', out );
+}
+
+static int debug_int_read( FILE * in )
+{
+    OBJECT * str = debug_object_read( in );
+    int result = atoi( object_str( str ) );
+    object_free( str );
+    return result;
+}
+
+static void debug_list_write( FILE * out, LIST * l )
+{
+    LISTITER iter = list_begin( l ), end = list_end( l );
+    fprintf( out, "%d\n", list_length( l ) );
+    for ( ; iter != end; iter = list_next( iter ) )
+    {
+        debug_object_write( out, list_item( iter ) );
+    }
+}
+
+static LIST * debug_list_read( FILE * in )
+{
+    int len;
+    int i;
+    int ch;
+    LIST * result = L0;
+    fscanf( in, "%d", &len );
+    ch = fgetc( in );
+    assert( ch == '\n' );
+    for ( i = 0; i < len; ++i )
+    {
+        result = list_push_back( result, debug_object_read( in ) );
+    }
+    return result;
+}
+
+static void debug_lol_write( FILE * out, LOL * lol )
+{
+    int i;
+    debug_int_write( out, lol->count );
+    for ( i = 0; i < lol->count; ++i )
+    {
+        debug_list_write( out, lol_get( lol, i ) );
+    }
+}
+
+static void debug_lol_read( FILE * in, LOL * lol )
+{
+    int count, i;
+    lol_init( lol );
+    count = debug_int_read( in );
+    for ( i = 0; i < count; ++i )
+    {
+        lol_add( lol, debug_list_read( in ) );
+    }
+}
+
+static void debug_frame_write( FILE * out, FRAME * frame )
+{
+    OBJECT * fullname = make_absolute_path( frame->file );
+    debug_object_write( out, frame->file );
+    debug_int_write( out, frame->line );
+    debug_object_write( out, fullname );
+    debug_lol_write( out, frame->args );
+    debug_string_write( out, frame->rulename );
+    object_free( fullname );
+}
+
+/*
+ * The information passed to the debugger for
+ * a frame is slightly different from the FRAME
+ * struct.
+ */
+typedef struct _frame_info
+{
+    OBJECT * file;
+    int line;
+    OBJECT * fullname;
+    LOL args[ 1 ];
+    char * rulename;
+} FRAME_INFO;
+
+static void debug_frame_info_free( FRAME_INFO * frame )
+{
+    object_free( frame->file );
+    object_free( frame->fullname );
+    lol_free( frame->args );
+    free( frame->rulename );
+}
+
+static void debug_frame_read( FILE * in, FRAME_INFO * frame )
+{
+    frame->file = debug_object_read( in );
+    frame->line = debug_int_read( in );
+    frame->fullname = debug_object_read( in );
+    debug_lol_read( in, frame->args );
+    frame->rulename = debug_string_read( in );
+}
+
+static int add_breakpoint( struct breakpoint elem )
+{
+    if ( num_breakpoints == breakpoints_capacity )
+    {
+        int new_capacity = breakpoints_capacity * 2;
+        if ( new_capacity == 0 ) new_capacity = 1;
+        breakpoints = ( struct breakpoint * )realloc( breakpoints, new_capacity * sizeof( struct breakpoint ) );
+        breakpoints_capacity = new_capacity;
+    }
+    breakpoints[ num_breakpoints++ ] = elem;
+    return num_breakpoints;
+}
+
+static int add_line_breakpoint( OBJECT * file, int line )
+{
+    struct breakpoint elem;
+    elem.file = file;
+    elem.bound_file = NULL;
+    elem.line = line;
+    elem.status = BREAKPOINT_ENABLED;
+    return add_breakpoint( elem );
+}
+
+static int add_function_breakpoint( OBJECT * name )
+{
+    struct breakpoint elem;
+    elem.file = name;
+    elem.bound_file = object_copy( name );
+    elem.line = -1;
+    elem.status = BREAKPOINT_ENABLED;
+    return add_breakpoint( elem );
+}
+
+/*
+ * Checks whether there is an active breakpoint at the
+ * specified location.  Returns the breakpoint id
+ * or -1 if none is found.
+ */
+static int handle_line_breakpoint( OBJECT * file, int line )
+{
+    int i;
+    if ( file == NULL ) return 0;
+    for ( i = 0; i < num_breakpoints; ++i )
+    {
+        if ( breakpoints[ i ].bound_file == NULL && is_same_file( breakpoints[ i ].file, file ) )
+        {
+            breakpoints[ i ].bound_file = object_copy( file );
+        }
+        if ( breakpoints[ i ].status == BREAKPOINT_ENABLED &&
+            breakpoints[ i ].bound_file != NULL &&
+            object_equal( breakpoints[ i ].bound_file, file ) &&
+            breakpoints[ i ].line == line )
+        {
+            return i + 1;
+        }
+    }
+    return 0;
+}
+
+static int handle_function_breakpoint( OBJECT * name )
+{
+    return handle_line_breakpoint( name, -1 );
+}
+
+static OBJECT * make_absolute_path( OBJECT * filename )
+{
+    PATHNAME path1[ 1 ];
+    string buf[ 1 ];
+    OBJECT * result;
+    const char * root = object_str( cwd() );
+    path_parse( object_str( filename ), path1 );
+    path1->f_root.ptr = root;
+    path1->f_root.len = strlen( root );
+    string_new( buf );
+    path_build( path1, buf );
+    result = object_new( buf->value );
+    string_free( buf );
+    return result;
+}
+
+static OBJECT * get_filename( OBJECT * path )
+{
+    PATHNAME path1[ 1 ];
+    string buf[ 1 ];
+    OBJECT * result;
+    const char * root = object_str( cwd() );
+    path_parse( object_str( path ), path1 );
+    path1->f_dir.ptr = NULL;
+    path1->f_dir.len = 0;
+    string_new( buf );
+    path_build( path1, buf );
+    result = object_new( buf->value );
+    string_free( buf );
+    return result;
+}
+
+static int is_same_file( OBJECT * file1, OBJECT * file2 )
+{
+    OBJECT * absolute1 = make_absolute_path( file1 );
+    OBJECT * absolute2 = make_absolute_path( file2 );
+    OBJECT * norm1 = path_as_key( absolute1 );
+    OBJECT * norm2 = path_as_key( absolute2 );
+    OBJECT * base1 = get_filename( file1 );
+    OBJECT * base2 = get_filename( file2 );
+    OBJECT * normbase1 = path_as_key( base1 );
+    OBJECT * normbase2 = path_as_key( base2 );
+    int result = object_equal( norm1, norm2 ) ||
+        ( object_equal( base1, file1 ) && object_equal( normbase1, normbase2 ) );
+    object_free( absolute1 );
+    object_free( absolute2 );
+    object_free( norm1 );
+    object_free( norm2 );
+    object_free( base1 );
+    object_free( base2 );
+    object_free( normbase1 );
+    object_free( normbase2 );
+    return result;
+}
+
+static void debug_print_source( OBJECT * filename, int line )
+{
+    FILE * file;
+
+    if ( filename == NULL || object_equal( filename, constant_builtin ) )
+        return;
+
+    file = fopen( object_str( filename ), "r" );
+    if ( file )
+    {
+        int ch;
+        int printing = 0;
+        int current_line = 1;
+        if ( line == 1 )
+        {
+            printing = 1;
+            printf( "%d\t", current_line );
+        }
+        while ( ( ch = fgetc( file ) ) != EOF )
+        {
+            if ( printing )
+                fputc( ch, stdout );
+
+            if ( ch == '\n' )
+            {
+                if ( printing )
+                    break;
+
+                ++current_line;
+                if ( current_line == line )
+                {
+                    printing = 1;
+                    printf( "%d\t", current_line );
+                }
+            }
+        }
+        fclose( file );
+    }
+}
+
+static void debug_print_frame( FRAME * frame )
+{
+    OBJECT * file = frame->file;
+    if ( file == NULL ) file = constant_builtin;
+    printf( "%s ", frame->rulename );
+    if ( strcmp( frame->rulename, "module scope" ) != 0 )
+    {
+        printf( "( ", frame->rulename );
+        if ( frame->args->count )
+        {
+            lol_print( frame->args );
+            printf( " " );
+        }
+        printf( ") " );
+    }
+    printf( "at %s:%d", object_str( file ), frame->line );
+}
+
+static void debug_mi_print_frame( FRAME * frame )
+{
+    OBJECT * fullname = make_absolute_path( frame->file );
+    printf( "frame={func=\"%s\",args=[],file=\"%s\",fullname=\"%s\",line=\"%d\"}",
+        frame->rulename,
+        object_str( frame->file ),
+        object_str( fullname ),
+        frame->line );
+    object_free( fullname );
+}
+
+static void debug_print_frame_info( FRAME_INFO * frame )
+{
+    OBJECT * file = frame->file;
+    if ( file == NULL ) file = constant_builtin;
+    printf( "%s ", frame->rulename );
+    if ( strcmp( frame->rulename, "module scope" ) != 0 )
+    {
+        printf( "( ", frame->rulename );
+        if ( frame->args->count )
+        {
+            lol_print( frame->args );
+            printf( " " );
+        }
+        printf( ") " );
+    }
+    printf( "at %s:%d", object_str( file ), frame->line );
+}
+
+static void debug_mi_print_frame_info( FRAME_INFO * frame )
+{
+    printf( "frame={func=\"%s\",args=[],file=\"%s\",fullname=\"%s\",line=\"%d\"}",
+        frame->rulename,
+        object_str( frame->file ),
+        object_str( frame->fullname ),
+        frame->line );
+}
+
+static void debug_on_breakpoint( int id )
+{
+    fputc( DEBUG_MSG_BREAKPOINT, command_output );
+    debug_int_write( command_output, id );
+    fflush( command_output );
+    debug_listen();
+}
+
+static void debug_end_stepping( void )
+{
+    fputc( DEBUG_MSG_END_STEPPING, command_output );
+    fflush( command_output );
+    debug_listen();
+}
+
+void debug_on_instruction( FRAME * frame, OBJECT * file, int line )
+{
+    int breakpoint_id;
+    assert( debug_is_debugging() );
+    if ( debug_state == DEBUG_NEXT && debug_depth <= 0 && debug_line != line )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_end_stepping();
+    }
+    else if ( debug_state == DEBUG_STEP && debug_line != line )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_end_stepping();
+    }
+    else if ( debug_state == DEBUG_FINISH && debug_depth <= 0 )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_end_stepping();
+    }
+    else if ( ( debug_file == NULL || ! object_equal( file, debug_file ) || line != debug_line ) &&
+        ( breakpoint_id = handle_line_breakpoint( file, line ) ) )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_on_breakpoint( breakpoint_id );
+    }
+}
+
+void debug_on_enter_function( FRAME * frame, OBJECT * name, OBJECT * file, int line )
+{
+    int breakpoint_id;
+    assert( debug_is_debugging() );
+    if ( debug_state == DEBUG_STEP && file )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_end_stepping();
+    }
+    else if ( ( breakpoint_id = handle_function_breakpoint( name ) ) ||
+        ( breakpoint_id = handle_line_breakpoint( file, line ) ) )
+    {
+        debug_file = file;
+        debug_line = line;
+        debug_frame = frame;
+        debug_on_breakpoint( breakpoint_id );
+    }
+    else if ( debug_state == DEBUG_NEXT || debug_state == DEBUG_FINISH )
+    {
+        ++debug_depth;
+    }
+}
+
+void debug_on_exit_function( OBJECT * name )
+{
+    assert( debug_is_debugging() );
+    if ( debug_state == DEBUG_NEXT || debug_state == DEBUG_FINISH )
+    {
+        --debug_depth;
+    }
+}
+
+#if NT
+static HANDLE child_handle;
+static DWORD child_pid;
+#else
+static int child_pid;
+#endif
+
+static void debug_child_continue( int argc, const char * * argv )
+{
+    debug_state = DEBUG_RUN;
+}
+
+static void debug_child_step( int argc, const char * * argv )
+{
+    debug_state = DEBUG_STEP;
+}
+
+static void debug_child_next( int argc, const char * * argv )
+{
+    debug_state = DEBUG_NEXT;
+    debug_depth = 0;
+}
+
+static void debug_child_finish( int argc, const char * * argv )
+{
+    debug_state = DEBUG_FINISH;
+    debug_depth = 1;
+}
+
+static void debug_child_kill( int argc, const char * * argv )
+{
+    exit( 0 );
+}
+
+static int debug_add_breakpoint( const char * name )
+{
+    const char * file_ptr = name;
+    const char * ptr = strrchr( file_ptr, ':' );
+    if ( ptr )
+    {
+        char * end;
+        long line = strtoul( ptr + 1, &end, 10 );
+        if ( line > 0 && line <= INT_MAX && end != ptr + 1 && *end == 0 )
+        {
+            OBJECT * file = object_new_range( file_ptr,  ptr - file_ptr );
+            return add_line_breakpoint( file, line );
+        }
+        else
+        {
+            OBJECT * name = object_new( file_ptr );
+            return add_function_breakpoint( name );
+        }
+    }
+    else
+    {
+        OBJECT * name = object_new( file_ptr );
+        return add_function_breakpoint( name );
+    }
+}
+
+static void debug_child_break( int argc, const char * * argv )
+{
+    if ( argc == 2 )
+    {
+        debug_add_breakpoint( argv[ 1 ] );
+    }
+}
+
+static int get_breakpoint_by_name( const char * name )
+{
+    int result;
+    const char * file_ptr = name;
+    const char * ptr = strrchr( file_ptr, ':' );
+    if ( ptr )
+    {
+        char * end;
+        long line = strtoul( ptr + 1, &end, 10 );
+        if ( line > 0 && line <= INT_MAX && end != ptr + 1 && *end == 0 )
+        {
+            OBJECT * file = object_new_range( file_ptr,  ptr - file_ptr );
+            result = handle_line_breakpoint( file, line );
+            object_free( file );
+        }
+        else
+        {
+            OBJECT * name = object_new( file_ptr );
+            result = handle_function_breakpoint( name );
+            object_free( name );
+        }
+    }
+    else
+    {
+        OBJECT * name = object_new( file_ptr );
+        result = handle_function_breakpoint( name );
+        object_free( name );
+    }
+    return result;
+}
+
+static void debug_child_disable( int argc, const char * * argv )
+{
+    if ( argc == 2 )
+    {
+        int id = atoi( argv[ 1 ] );
+        if ( id < 1 || id > num_breakpoints )
+            return;
+        --id;
+        if ( breakpoints[ id ].status == BREAKPOINT_DELETED )
+            return;
+        breakpoints[ id ].status = BREAKPOINT_DISABLED;
+    }
+}
+
+static void debug_child_enable( int argc, const char * * argv )
+{
+    if ( argc == 2 )
+    {
+        int id = atoi( argv[ 1 ] );
+        if ( id < 1 || id > num_breakpoints )
+            return;
+        --id;
+        if ( breakpoints[ id ].status == BREAKPOINT_DELETED )
+            return;
+        breakpoints[ id ].status = BREAKPOINT_ENABLED;
+    }
+}
+
+static void debug_child_delete( int argc, const char * * argv )
+{
+    if ( argc == 2 )
+    {
+        int id = atoi( argv[ 1 ] );
+        if ( id < 1 || id > num_breakpoints )
+            return;
+        --id;
+        breakpoints[ id ].status = BREAKPOINT_DELETED;
+    }
+}
+
+static void debug_child_print( int argc, const char * * argv )
+{
+    FRAME * saved_frame;
+    OBJECT * saved_file;
+    int saved_line;
+    string buf[ 1 ];
+    const char * lines[ 2 ];
+    int i;
+    FRAME new_frame = *debug_frame;
+    /* Save the current file/line, since running parse_string
+     * will likely change it.
+     */
+    saved_frame = debug_frame;
+    saved_file = debug_file;
+    saved_line = debug_line;
+    string_new( buf );
+    string_append( buf, "__DEBUG_PRINT_HELPER__" );
+    for ( i = 1; i < argc; ++i )
+    {
+        string_push_back( buf, ' ' );
+        string_append( buf, argv[ i ] );
+    }
+    string_append( buf, " ;\n" );
+    lines[ 0 ] = buf->value;
+    lines[ 1 ] = NULL;
+    parse_string( constant_builtin, lines, &new_frame );
+    string_free( buf );
+    debug_list_write( command_output, debug_print_result );
+    fflush( command_output );
+    debug_frame = saved_frame;
+    debug_file = saved_file;
+    debug_line = saved_line;
+}
+
+static void debug_child_frame( int argc, const char * * argv )
+{
+    if ( argc == 2 )
+    {
+        debug_selected_frame_number = atoi( argv[ 1 ] );
+    }
+    else
+    {
+        assert( !"Wrong number of arguments to frame." );
+    }
+}
+
+static void debug_child_info( int argc, const char * * argv )
+{
+    if ( strcmp( argv[ 1 ], "locals" ) == 0 )
+    {
+        LIST * locals = L0;
+        if ( debug_frame->function )
+        {
+            locals = function_get_variables( debug_frame->function );
+        }
+        debug_list_write( command_output, locals );
+        fflush( command_output );
+        list_free( locals );
+    }
+    else if ( strcmp( argv[ 1 ], "frame" ) == 0 )
+    {
+        int frame_number = debug_selected_frame_number;
+        int i;
+        OBJECT * fullname;
+        FRAME base = *debug_frame;
+        FRAME * frame = &base;
+        base.file = debug_file;
+        base.line = debug_line;
+        if ( argc == 3 ) frame_number = atoi( argv[ 2 ] );
+
+        for ( i = 0; i < frame_number; ++i ) frame = frame->prev;
+
+        debug_frame_write( command_output, frame );
+    }
+    else if ( strcmp( argv[ 1 ], "depth" ) == 0 )
+    {
+        int result = 0;
+        FRAME * frame = debug_frame;
+        while ( frame )
+        {
+            frame = frame->prev;
+            ++result;
+        }
+        fprintf( command_output, "%d", result );
+        fputc( '\0', command_output );
+        fflush( command_output );
+    }
+}
+
+/* Commands for the parent. */
+
+#ifdef NT
+
+static int get_module_filename( string * out )
+{
+    DWORD result;
+    string_reserve( out, 256 + 1 );
+    string_truncate( out, 256 );
+    while( ( result = GetModuleFileName( NULL, out->value, out->size ) ) == out->size )
+    {
+        string_reserve( out, out->size * 2 + 1);
+        string_truncate( out, out->size * 2 );
+    }
+    if ( result != 0 )
+    {
+        string_truncate( out, result );
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+#endif
+
+static struct command_elem child_commands[] =
+{
+    { "continue", &debug_child_continue },
+    { "kill", &debug_child_kill },
+    { "step", &debug_child_step },
+    { "next", &debug_child_next },
+    { "finish", &debug_child_finish },
+    { "break", &debug_child_break },
+    { "disable", &debug_child_disable },
+    { "enable", &debug_child_enable },
+    { "delete", &debug_child_delete },
+    { "print", &debug_child_print },
+    { "frame", &debug_child_frame },
+    { "info", &debug_child_info },
+    { NULL, NULL }
+};
+
+static void debug_mi_error( const char * message )
+{
+    debug_mi_format_token();
+    printf( "^error,msg=\"%s\"\n(gdb) \n", message );
+}
+
+static void debug_error_( const char * message )
+{
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "%s\n", message );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_error( message );
+    }
+}
+
+static const char * debug_format_message( const char * format, va_list vargs )
+{
+    char * buf;
+    int result;
+    int sz = 80;
+    for ( ; ; )
+    {
+        va_list args;
+        buf = malloc( sz );
+        if ( !buf )
+            return 0;
+        va_copy( args, vargs );
+        result = vsnprintf( buf, sz, format, args );
+        va_end( args );
+        if ( result < 0 )
+            return 0;
+        if ( result < sz ) return buf;
+        free( buf );
+        sz = result + 1;
+    }
+}
+
+static void debug_error( const char * format, ... )
+{
+    va_list args;
+    const char * msg;
+    va_start( args, format );
+    msg = debug_format_message( format, args );
+    va_end( args );
+    if ( !msg )
+    {
+        debug_error_( "Failed formatting error message." );
+        return;
+    }
+    debug_error_( msg );
+    free( ( void * )msg );
+}
+
+static void debug_parent_child_exited( int pid, int exit_code )
+{
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "Child %d exited with status %d\n", (int)child_pid, (int)exit_code );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        if ( exit_code == 0 )
+            printf( "*stopped,reason=\"exited-normally\"\n(gdb) \n" );
+        else
+            printf( "*stopped,reason=\"exited\",exit-code=\"%d\"\n(gdb) \n", exit_code );
+    }
+    else
+    {
+        assert( !"Wrong value of debug_interface." );
+    }
+}
+
+static void debug_parent_child_signalled( int pid, int sigid )
+{
+    
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "Child %d exited on signal %d\n", child_pid, sigid );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        const char * name = "unknown";
+        const char * meaning = "unknown";
+        switch( sigid )
+        {
+        case SIGINT: name = "SIGINT"; meaning = "Interrupt"; break;
+        }
+        printf("*stopped,reason=\"exited-signalled\",signal-name=\"%s\",signal-meaning=\"%s\"\n(gdb) \n", name, meaning);
+    }
+    else
+    {
+        assert( !"Wrong value of debug_interface." );
+    }
+}
+
+static void debug_parent_on_breakpoint( void )
+{
+    FRAME_INFO base;
+    int id;
+    id = debug_int_read( command_child );
+    fprintf( command_output, "info frame\n" );
+    fflush( command_output );
+    debug_frame_read( command_child, &base );
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "Breakpoint %d, ", id );
+        debug_print_frame_info( &base );
+        printf( "\n" );
+        debug_print_source( base.file, base.line );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        printf( "*stopped,reason=\"breakpoint-hit\",bkptno=\"%d\",disp=\"keep\",", id );
+        debug_mi_print_frame_info( &base );
+        printf( ",thread-id=\"1\",stopped-threads=\"all\"" );
+        printf( "\n(gdb) \n" );
+    }
+    else
+    {
+        assert( !"Wrong value if debug_interface" );
+    }
+    fflush( stdout );
+}
+
+static void debug_parent_on_end_stepping( void )
+{
+    FRAME_INFO base;
+    fprintf( command_output, "info frame\n" );
+    fflush( command_output );
+    debug_frame_read( command_child, &base );
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        debug_print_source( base.file, base.line );
+    }
+    else
+    {
+        printf( "*stopped,reason=\"end-stepping-range\"," );
+        debug_mi_print_frame_info( &base );
+        printf( ",thread-id=\"1\"" );
+        printf( "\n(gdb) \n" );
+    }
+    fflush( stdout );
+}
+
+/* Waits for events from the child. */
+static void debug_parent_wait( int print_message )
+{
+    char ch = fgetc( command_child );
+    if ( ch == DEBUG_MSG_BREAKPOINT )
+    {
+        debug_parent_on_breakpoint();
+    }
+    else if ( ch == DEBUG_MSG_END_STEPPING )
+    {
+        debug_parent_on_end_stepping();
+    }
+    else if ( ch == DEBUG_MSG_SETUP )
+    {
+        /* FIXME: This is handled in the caller, but it would make
+           more sense to handle it here. */
+        return;
+    }
+    else if ( ch == EOF )
+    {
+#if NT
+        WaitForSingleObject( child_handle, INFINITE );
+        if ( print_message )
+        {
+            DWORD exit_code;
+            GetExitCodeProcess( child_handle, &exit_code );
+            debug_parent_child_exited( (int)child_pid, (int)exit_code );
+        }
+        CloseHandle( child_handle );
+#else
+        int status;
+        int pid;
+        while ( ( pid = waitpid( child_pid, &status, 0 ) ) == -1 )
+            if ( errno != EINTR )
+                break;
+        if ( print_message )
+        {
+            if ( WIFEXITED( status ) )
+                debug_parent_child_exited( child_pid, WEXITSTATUS( status ) );
+            else if ( WIFSIGNALED( status ) )
+                debug_parent_child_signalled( child_pid, WTERMSIG( status ) );
+        }
+#endif
+        fclose( command_child );
+        fclose( command_output );
+        debug_state = DEBUG_NO_CHILD;
+    }
+}
+
+/* Prints the message for starting the child. */
+static void debug_parent_run_print( int argc, const char * * argv )
+{
+    int i;
+    extern char const * saved_argv0;
+    char * name = executable_path( saved_argv0 );
+    printf( "Starting program: %s", name );
+    free( name );
+    for ( i = 1; i < argc; ++i )
+    {
+        printf( " %s", argv[ i ] );
+    }
+    printf( "\n" );
+    fflush( stdout );
+}
+
+#if NT
+
+void debug_init_handles( const char * in, const char * out )
+{
+    HANDLE read_handle;
+    int read_fd;
+    HANDLE write_handle;
+    int write_fd;
+
+    sscanf( in, "%p", &read_handle );
+    read_fd = _open_osfhandle( (intptr_t)read_handle, _O_RDONLY );
+    command_input = _fdopen( read_fd, "r" );
+    
+    sscanf( out, "%p", &write_handle );
+    write_fd = _open_osfhandle( (intptr_t)write_handle, _O_WRONLY );
+    command_output = _fdopen( write_fd, "w" );
+
+    command_array = child_commands;
+
+    /* Handle the initial setup */
+    /* wake up the parent */
+    fputc( DEBUG_MSG_SETUP, command_output );
+    debug_listen();
+}
+
+static void init_parent_handles( HANDLE out, HANDLE in )
+{
+    int read_fd, write_fd;
+
+    command_child = _fdopen( _open_osfhandle( (intptr_t)in, _O_RDONLY ), "r" );
+    command_output = _fdopen( _open_osfhandle( (intptr_t)out, _O_WRONLY ), "w" );
+}
+
+static void debug_parent_copy_breakpoints( void )
+{
+    int i;
+    for ( i = 0; i < num_breakpoints; ++i )
+    {
+        fprintf( command_output, "break %s", object_str( breakpoints[ i ].file ) );
+        if ( breakpoints[ i ].line != -1 )
+        {
+            fprintf( command_output, ":%d", breakpoints[ i ].line );
+        }
+        fprintf( command_output, "\n" );
+
+        switch ( breakpoints[ i ].status )
+        {
+        case BREAKPOINT_ENABLED:
+            break;
+        case BREAKPOINT_DISABLED:
+            fprintf( command_output, "disable %d\n", i + 1 );
+            break;
+        case BREAKPOINT_DELETED:
+            fprintf( command_output, "delete %d\n", i + 1 );
+            break;
+        default:
+            assert( !"Wrong breakpoint status." );
+        }
+    }
+    fflush( command_output );
+}
+
+#endif
+
+static void debug_start_child( int argc, const char * * argv )
+{
+#if NT
+    char buf[ 80 ];
+    HANDLE pipe1[ 2 ];
+    HANDLE pipe2[ 2 ];
+    string self[ 1 ];
+    string command_line[ 1 ];
+    SECURITY_ATTRIBUTES sa = { sizeof( SECURITY_ATTRIBUTES ), NULL, TRUE };
+    PROCESS_INFORMATION pi = { NULL, NULL, 0, 0 };
+    STARTUPINFO si = { sizeof( STARTUPINFO ), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0 };
+    assert( DEBUG_STATE == DEBUG_NO_CHILD );
+    if ( ! CreatePipe( &pipe1[ 0 ], &pipe1[ 1 ], &sa, 0 ) )
+    {
+        printf("internal error\n");
+        return;
+    }
+    if ( ! CreatePipe( &pipe2[ 0 ], &pipe2[ 1 ], &sa, 0 ) )
+    {
+        printf("internal error\n");
+        CloseHandle( pipe1[ 0 ] );
+        CloseHandle( pipe1[ 1 ] );
+        return;
+    }
+    string_new( self );
+    if ( ! get_module_filename( self ) )
+    {
+        printf("internal error\n");
+        CloseHandle( pipe1[ 0 ] );
+        CloseHandle( pipe1[ 1 ] );
+        CloseHandle( pipe2[ 0 ] );
+        CloseHandle( pipe2[ 1 ] );
+        return;
+    }
+    string_copy( command_line, "b2 " );
+    /* Pass the handles as the first and second arguments. */
+    string_append( command_line, debugger_opt );
+    sprintf( buf, "%p", pipe1[ 0 ] );
+    string_append( command_line, buf );
+    string_push_back( command_line, ' ' );
+    string_append( command_line, debugger_opt );
+    sprintf( buf, "%p", pipe2[ 1 ] );
+    string_append( command_line, buf );
+    /* Pass the rest of the command line. */
+    for ( int i = 1; i < argc; ++i )
+    {
+        string_push_back( command_line, ' ' );
+        string_append( command_line, argv[ i ] );
+    }
+    SetHandleInformation( pipe1[ 1 ], HANDLE_FLAG_INHERIT, 0 );
+    SetHandleInformation( pipe2[ 0 ], HANDLE_FLAG_INHERIT, 0 );
+    if ( ! CreateProcess(
+        self->value,
+        command_line->value,
+        NULL,
+        NULL,
+        TRUE,
+        0,
+        NULL,
+        NULL,
+        &si,
+        &pi
+        ) )
+    {
+        printf("internal error\n");
+        CloseHandle( pipe1[ 0 ] );
+        CloseHandle( pipe1[ 1 ] );
+        CloseHandle( pipe2[ 0 ] );
+        CloseHandle( pipe2[ 1 ] );
+        string_free( self );
+        string_free( command_line );
+        return;
+    }
+    child_pid = pi.dwProcessId;
+    child_handle = pi.hProcess;
+    CloseHandle( pi.hThread );
+    CloseHandle( pipe1[ 0 ] );
+    CloseHandle( pipe2[ 1 ] );
+    string_free( self );
+    string_free( command_line );
+
+    debug_state = DEBUG_RUN;
+
+    init_parent_handles( pipe1[ 1 ], pipe2[ 0 ] );
+    debug_parent_wait( 1 );
+    debug_parent_copy_breakpoints();
+    fprintf( command_output, "continue\n" );
+    fflush( command_output );
+#else
+    int pipe1[2];
+    int pipe2[2];
+    int write_fd;
+    int read_fd;
+    int pid;
+    int i;
+    assert( DEBUG_STATE == DEBUG_NO_CHILD );
+    pipe(pipe1);
+    pipe(pipe2);
+    pid = fork();
+    if ( pid == -1 )
+    {
+        /* error */
+        close( pipe1[ 0 ] );
+        close( pipe1[ 1 ] );
+        close( pipe2[ 0 ] );
+        close( pipe1[ 1 ] );
+    }
+    else if ( pid == 0 )
+    {
+        /* child */
+        extern const char * saved_argv0;
+        read_fd = pipe1[ 0 ];
+        write_fd = pipe2[ 1 ];
+        close( pipe2[ 0 ] );
+        close( pipe1[ 1 ] );
+        command_array = child_commands;
+        argv[ 0 ] = executable_path( saved_argv0 );
+        debug_child_data.argc = argc;
+        debug_child_data.argv = argv;
+        command_input = fdopen( read_fd, "r" );
+        command_output = fdopen( write_fd, "w" );
+        longjmp( debug_child_data.jmp, 1 );
+    }
+    else
+    {
+        /* parent */
+        read_fd = pipe2[ 0 ];
+        write_fd = pipe1[ 1 ];
+        close( pipe1[ 0 ] );
+        close( pipe2[ 1 ] );
+        command_output = fdopen( write_fd, "w" );
+        command_child = fdopen( read_fd, "r" );
+        child_pid = pid;
+    }
+    debug_state = DEBUG_RUN;
+#endif
+}
+
+static void debug_parent_run( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_RUN )
+    {
+        fprintf( command_output, "kill\n" );
+        fflush( command_output );
+        debug_parent_wait( 1 );
+    }
+    debug_parent_run_print( argc, argv );
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        printf( "=thread-created,id=\"1\",group-id=\"i1\"\n" );
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+    }
+    debug_start_child( argc, argv );
+    debug_parent_wait( 1 );
+}
+
+static int debug_parent_forward_nowait( int argc, const char * * argv, int print_message, int require_child )
+{
+    int i;
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        if ( require_child )
+            printf( "The program is not being run.\n" );
+        return 1;
+    }
+    fputs( argv[ 0 ], command_output );
+    for( i = 1; i < argc; ++i )
+    {
+        fputc( ' ', command_output );
+        fputs( argv[ i ], command_output );
+    }
+    fputc( '\n', command_output );
+    fflush( command_output );
+    return 0;
+}
+
+/* FIXME: This function should be eliminated when I finish all stdout to the parent. */
+static void debug_parent_forward( int argc, const char * * argv, int print_message, int require_child )
+{
+    if ( debug_parent_forward_nowait( argc, argv, print_message, require_child ) != 0 )
+    {
+        return;
+    }
+    debug_parent_wait( print_message );
+}
+
+static void debug_parent_continue( int argc, const char * * argv )
+{
+    if ( argc > 1 )
+    {
+        debug_error( "Too many arguments to continue." );
+        return;
+    }
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+    }
+    debug_parent_forward( 1, argv, 1, 1 );
+}
+
+static void debug_parent_kill( int argc, const char * * argv )
+{
+    if ( argc > 1 )
+    {
+        debug_error( "Too many arguments to kill." );
+        return;
+    }
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+        fflush( stdout );
+    }
+    debug_parent_forward( 1, argv, 0, 1 );
+}
+
+static void debug_parent_step( int argc, const char * * argv )
+{
+    if ( argc > 1 )
+    {
+        debug_error( "Too many arguments to step." );
+        return;
+    }
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+    }
+    debug_parent_forward( 1, argv, 1, 1 );
+}
+
+static void debug_parent_next( int argc, const char * * argv )
+{
+    if ( argc > 1 )
+    {
+        debug_error( "Too many arguments to next." );
+        return;
+    }
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+    }
+    debug_parent_forward( 1, argv, 1, 1 );
+}
+
+static void debug_parent_finish( int argc, const char * * argv )
+{
+    if ( argc > 1 )
+    {
+        debug_error( "Too many arguments to finish." );
+        return;
+    }
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+    }
+    debug_parent_forward( 1, argv, 1, 1 );
+}
+
+static void debug_parent_break( int argc, const char * * argv )
+{
+    int id;
+    if ( argc < 2 )
+    {
+        debug_error( "Missing argument to break." );
+        return;
+    }
+    else if ( argc > 2 )
+    {
+        debug_error( "Too many arguments to break." );
+        return;
+    }
+    id = debug_add_breakpoint( argv[ 1 ] );
+    debug_parent_forward_nowait( argc, argv, 1, 0 );
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "Breakpoint %d set at %s\n", id, argv[ 1 ] );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+    else
+    {
+        assert( !"wrong value of debug_interface." );
+    }
+}
+
+int check_breakpoint_fn_args( int argc, const char * * argv )
+{
+    if ( argc < 2 )
+    {
+        debug_error( "Missing argument to %s.", argv[ 0 ] );
+        return 0;
+    }
+    else if ( argc > 2 )
+    {
+        debug_error( "Too many arguments to %s.", argv[ 0 ] );
+        return 0;
+    }
+    else
+    {
+        char * end;
+        long x = strtol( argv[ 1 ], &end, 10 );
+        if ( *end )
+        {
+            debug_error( "Invalid breakpoint number %s.", argv[ 1 ] );
+            return 0;
+        }
+        if ( x < 1 || x > num_breakpoints || breakpoints[ x - 1 ].status == BREAKPOINT_DELETED )
+        {
+            debug_error( "Unknown breakpoint %s.", argv[ 1 ] );
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void debug_parent_disable( int argc, const char * * argv )
+{
+    if ( ! check_breakpoint_fn_args( argc, argv ) )
+    {
+        return;
+    }
+    debug_child_disable( argc, argv );
+    debug_parent_forward_nowait( 2, argv, 1, 0 );
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+}
+
+static void debug_parent_enable( int argc, const char * * argv )
+{
+    if ( ! check_breakpoint_fn_args( argc, argv ) )
+    {
+        return;
+    }
+    debug_child_enable( argc, argv );
+    debug_parent_forward_nowait( 2, argv, 1, 0 );
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+}
+
+static void debug_parent_delete( int argc, const char * * argv )
+{
+    if ( ! check_breakpoint_fn_args( argc, argv ) )
+    {
+        return;
+    }
+    debug_child_delete( argc, argv );
+    debug_parent_forward_nowait( 2, argv, 1, 0 );
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+}
+
+static void debug_parent_clear( int argc, const char * * argv )
+{
+    char buf[ 16 ];
+    const char * new_args[ 2 ];
+    int id;
+    if ( argc < 2 )
+    {
+        debug_error( "Missing argument to clear." );
+        return;
+    }
+    else if ( argc > 2 )
+    {
+        debug_error( "Too many arguments to clear." );
+        return;
+    }
+    id = get_breakpoint_by_name( argv[ 1 ] );
+    if ( id == 0 )
+    {
+        debug_error( "No breakpoint at %s.", argv[ 1 ] );
+        return;
+    }
+
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        printf( "Deleted breakpoint %d\n", id );
+    }
+    
+    sprintf( buf, "%d", id );
+    new_args[ 0 ] = "delete";
+    new_args[ 1 ] = buf;
+    debug_parent_delete( 2, new_args );
+}
+
+static void debug_parent_print( int argc, const char * * argv )
+{
+    LIST * result;
+    if ( debug_parent_forward_nowait( argc, argv, 1, 1 ) != 0 )
+    {
+        return;
+    }
+    result = debug_list_read( command_child );
+
+    if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+    {
+        list_print( result );
+        printf( "\n" );
+    }
+    else if ( debug_interface == DEBUG_INTERFACE_MI )
+    {
+        printf( "~\"$1 = " );
+        list_print( result );
+        printf( "\"\n~\"\\n\"\n" );
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+}
+
+static void debug_parent_backtrace( int argc, const char * * argv )
+{
+    const char * new_args[ 3 ];
+    OBJECT * depth_str;
+    int depth;
+    int i;
+    FRAME_INFO frame;
+    
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_error( "The program is not being run." );
+        return;
+    }
+
+    new_args[ 0 ] = "info";
+    new_args[ 1 ] = "frame";
+
+    fprintf( command_output, "info depth\n" );
+    fflush( command_output );
+    depth_str = debug_object_read( command_child );
+    depth = atoi( object_str( depth_str ) );
+    object_free( depth_str );
+
+    for ( i = 0; i < depth; ++i )
+    {
+        char buf[ 16 ];
+        sprintf( buf, "%d", i );
+        new_args[ 2 ] = buf;
+        debug_parent_forward_nowait( 3, new_args, 0, 0 );
+        debug_frame_read( command_child, &frame );
+        printf( "#%d  in ", i );
+        debug_print_frame_info( &frame );
+        printf( "\n" );
+    }
+    fflush( stdout );
+}
+
+static void debug_parent_quit( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_RUN )
+    {
+        fprintf( command_output, "kill\n" );
+        fflush( command_output );
+        debug_parent_wait( 0 );
+    }
+    exit( 0 );
+}
+
+static const char * const help_text[][2] =
+{
+    {
+        "run", 
+        "run <args>\n"
+        "Creates a new b2 child process passing <args> on the command line."
+        "  Terminates\nthe current child (if any).\n"
+    },
+    {
+        "continue",
+        "continue\nContinue debugging\n"
+    },
+    {
+        "step",
+        "step\nContinue to the next statement\n"
+    },
+    {
+        "next",
+        "next\nContinue to the next line in the current frame\n"
+    },
+    {
+        "finish",
+        "finish\nContinue to the end of the current frame\n"
+    },
+    {
+        "break",
+        "break <location>\n"
+        "Sets a breakpoint at <location>.  <location> can be either a the name of a\nfunction or <filename>:<lineno>\n"
+    },
+    {
+        "disable",
+        "disable <breakpoint>\nDisable a breakpoint\n"
+    },
+    {
+        "enable",
+        "enable <breakpoint>\nEnable a breakpoint\n"
+    },
+    {
+        "delete",
+        "delete <breakpoint>\nDelete a breakpoint\n"
+    },
+    {
+        "clear",
+        "clear <location>\nDelete the breakpoint at <location>\n"
+    },
+    {
+        "print",
+        "print <expression>\nDisplay the value of <expression>\n"
+    },
+    {
+        "backtrace",
+        "backtrace\nDisplay the call stack\n"
+    },
+    {
+        "kill",
+        "kill\nTerminate the child\n"
+    },
+    {
+        "quit",
+        "quit\nExit the debugger\n"
+    },
+    {
+        "help",
+        "help\nhelp <command>\nShow help for debugger commands.\n"
+    },
+    { 0, 0 }
+};
+
+static void debug_parent_help( int argc, const char * * argv )
+{
+    if ( argc == 1 )
+    {
+        printf(
+            "run       - Start debugging\n"
+            "continue  - Continue debugging\n"
+            "step      - Continue to the next statement\n"
+            "next      - Continue to the next line in the current frame\n"
+            "finish    - Continue to the end of the current frame\n"
+            "break     - Set a breakpoint\n"
+            "disable   - Disable a breakpoint\n"
+            "enable    - Enable a breakpoint\n"
+            "delete    - Delete a breakpoint\n"
+            "clear     - Delete a breakpoint by location\n"
+            );
+        printf(
+            "print     - Display an expression\n"
+            "backtrace - Display the call stack\n"
+            "kill      - Terminate the child\n"
+            "quit      - Exit the debugger\n"
+            "help      - Debugger help\n"
+            );
+    }
+    else if ( argc == 2 )
+    {
+        int i;
+        for ( i = 0; help_text[ i ][ 0 ]; ++i )
+        {
+            if ( strcmp( argv[ 1 ], help_text[ i ][ 0 ] ) == 0 )
+            {
+                printf( "%s", help_text[ i ][ 1 ] );
+                return;
+            }
+        }
+        printf( "No command named %s\n", argv[ 1 ] );
+    }
+}
+
+static void debug_mi_break_insert( int argc, const char * * argv );
+static void debug_mi_break_delete( int argc, const char * * argv );
+static void debug_mi_break_disable( int argc, const char * * argv );
+static void debug_mi_break_enable( int argc, const char * * argv );
+static void debug_mi_break_info( int argc, const char * * argv );
+static void debug_mi_break_list( int argc, const char * * argv );
+static void debug_mi_inferior_tty_set( int argc, const char * * argv );
+static void debug_mi_gdb_exit( int argc, const char * * argv );
+static void debug_mi_gdb_set( int argc, const char * * argv );
+static void debug_mi_gdb_show( int argc, const char * * argv );
+static void debug_mi_not_implemented( int argc, const char * * argv );
+static void debug_mi_file_list_exec_source_files( int argc, const char * * argv );
+static void debug_mi_file_list_exec_source_file( int argc, const char * * argv );
+static void debug_mi_thread_info( int argc, const char * * argv );
+static void debug_mi_thread_select( int argc, const char * * argv );
+static void debug_mi_stack_info_frame( int argc, const char * * argv );
+static void debug_mi_stack_select_frame( int argc, const char * * argv );
+static void debug_mi_stack_list_variables( int argc, const char * * argv );
+static void debug_mi_stack_list_locals( int argc, const char * * argv );
+static void debug_mi_stack_list_frames( int argc, const char * * argv );
+static void debug_mi_list_target_features( int argc, const char * * argv );
+static void debug_mi_exec_run( int argc, const char * * argv );
+static void debug_mi_exec_continue( int argc, const char * * argv );
+static void debug_mi_exec_step( int argc, const char * * argv );
+static void debug_mi_exec_next( int argc, const char * * argv );
+static void debug_mi_exec_finish( int argc, const char * * argv );
+static void debug_mi_data_list_register_names( int argc, const char * * argv );
+static void debug_mi_data_evaluate_expression( int argc, const char * * argv );
+static void debug_mi_interpreter_exec( int argc, const char * * argv );
+
+static struct command_elem parent_commands[] =
+{
+    { "run", &debug_parent_run },
+    { "continue", &debug_parent_continue },
+    { "kill", &debug_parent_kill },
+    { "step", &debug_parent_step },
+    { "next", &debug_parent_next },
+    { "finish", &debug_parent_finish },
+    { "break", &debug_parent_break },
+    { "disable", &debug_parent_disable },
+    { "enable", &debug_parent_enable },
+    { "delete", &debug_parent_delete },
+    { "clear", &debug_parent_clear },
+    { "print", &debug_parent_print },
+    { "backtrace", &debug_parent_backtrace },
+    { "quit", &debug_parent_quit },
+    { "help", &debug_parent_help },
+    { "-break-insert", &debug_mi_break_insert },
+    { "-break-delete", &debug_mi_break_delete },
+    { "-break-disable", &debug_mi_break_disable },
+    { "-break-enable", &debug_mi_break_enable },
+    { "-break-info", &debug_mi_break_info },
+    { "-break-list", &debug_mi_break_list },
+    { "-inferior-tty-set", &debug_mi_inferior_tty_set },
+    { "-gdb-exit", &debug_mi_gdb_exit },
+    { "-gdb-set", &debug_mi_gdb_set },
+    { "-gdb-show", &debug_mi_gdb_show },
+    { "-enable-pretty-printing", &debug_mi_not_implemented },
+    { "-file-list-exec-source-files", &debug_mi_file_list_exec_source_files },
+    { "-file-list-exec-source-file", &debug_mi_file_list_exec_source_file },
+    { "-thread-info", &debug_mi_thread_info },
+    { "-thread-select", &debug_mi_thread_select },
+    { "-stack-info-frame", &debug_mi_stack_info_frame },
+    { "-stack-select-frame", &debug_mi_stack_select_frame },
+    { "-stack-list-variables", &debug_mi_stack_list_variables },
+    { "-stack-list-locals", &debug_mi_stack_list_locals },
+    { "-stack-list-frames", &debug_mi_stack_list_frames },
+    { "-list-target-features", &debug_mi_list_target_features },
+    { "-exec-run", &debug_mi_exec_run },
+    { "-exec-continue", &debug_mi_exec_continue },
+    { "-exec-step", &debug_mi_exec_step },
+    { "-exec-next", &debug_mi_exec_next },
+    { "-exec-finish", &debug_mi_exec_finish },
+    { "-data-list-register-names", &debug_mi_data_list_register_names },
+    { "-data-evaluate-expression", &debug_mi_data_evaluate_expression },
+    { "-interpreter-exec", &debug_mi_interpreter_exec },
+    { NULL, NULL }
+};
+
+static void debug_mi_format_token( void )
+{
+    if ( current_token != 0 )
+    {
+        printf( "%d", current_token );
+    }
+}
+
+static void debug_mi_format_breakpoint( int id )
+{
+    struct breakpoint * ptr = &breakpoints[ id - 1 ];
+    printf( "bkpt={" );
+    printf( "number=\"%d\"", id );
+    printf( ",type=\"breakpoint\"" );
+    printf( ",disp=\"keep\"" ); /* FIXME: support temporary breakpoints. */
+    printf( ",enabled=\"%s\"", ptr->status == BREAKPOINT_ENABLED ? "y" : "n" );
+    /* addr */
+    if ( ptr->line == -1 )
+    {
+        printf( ",func=\"%s\"", object_str( ptr->file ) );
+    }
+    else
+    {
+        printf( ",file=\"%s\"", object_str( ptr->file ) );
+        printf( ",line=\"%d\"", ptr->line );
+        printf( ",fullname=\"%s\"", object_str( ptr->file ) );
+    }
+    /* fullname */
+    /* times */
+    printf( "" );
+    printf( "}" );
+}
+
+static int breakpoint_id_parse( const char * name )
+{
+    int id = atoi( name );
+    if ( id > num_breakpoints || id < 1 || breakpoints[ id ].status == BREAKPOINT_DELETED )
+        return -1;
+    return id;
+}
+
+static void debug_mi_break_after( int argc, const char * * argv )
+{
+    int id;
+    int count;
+    --argc;
+    ++argv;
+    if ( argc > 0 && strcmp( argv[ 0 ], "--" ) == 0 )
+    {
+        ++argv;
+        --argc;
+    }
+    if ( argc < 2 )
+    {
+        debug_mi_error( "not enough arguments for -break-after." );
+        return;
+    }
+    else if ( argc > 2 )
+    {
+        debug_mi_error( "too many arguments for -break-after." );
+        return;
+    }
+    id = atoi( argv[ 0 ] );
+    count = atoi( argv[ 1 ] );
+    /* FIXME: set ignore count */
+}
+
+static void debug_mi_break_insert( int argc, const char * * argv )
+{
+    const char * inner_argv[ 2 ];
+    int temporary = 0; /* FIXME: not supported yet */
+    int hardware = 0; /* unsupported */
+    int force = 1; /* We don't have global debug information... */
+    int disabled = 0;
+    int tracepoint = 0; /* unsupported */
+    int thread_id = 0;
+    int ignore_count = 0;
+    const char * condition; /* FIXME: not supported yet */
+    const char * location;
+    int id;
+    for ( --argc, ++argv; argc; --argc, ++argv )
+    {
+        if ( strcmp( *argv, "-t" ) == 0 )
+        {
+            temporary = 1;
+        }
+        else if ( strcmp( *argv, "-h" ) == 0 )
+        {
+            hardware = 1;
+        }
+        else if ( strcmp( *argv, "-f" ) == 0 )
+        {
+            force = 1;
+        }
+        else if ( strcmp( *argv, "-d" ) == 0 )
+        {
+            disabled = 1;
+        }
+        else if ( strcmp( *argv, "-a" ) == 0 )
+        {
+            tracepoint = 1;
+        }
+        else if ( strcmp( *argv, "-c" ) == 0 )
+        {
+            if ( argc < 2 )
+            {
+                debug_mi_error( "Missing argument for -c." );
+                return;
+            }
+
+            condition = argv[ 1 ];
+            --argc;
+            ++argv;
+        }
+        else if ( strcmp( *argv, "-i" ) == 0 )
+        {
+            if ( argc < 2 )
+            {
+                debug_mi_error( "Missing argument for -i." );
+                return;
+            }
+
+            ignore_count = atoi( argv[ 1 ] );
+            --argc;
+            ++argv;
+        }
+        else if ( strcmp( *argv, "-p" ) == 0 )
+        {
+            if ( argc < 2 )
+            {
+                debug_mi_error( "Missing argument for -p." );
+                return;
+            }
+
+            thread_id = atoi( argv[ 1 ] );
+            --argc;
+            ++argv;
+        }
+        else if ( strcmp( *argv, "--" ) == 0 )
+        {
+            --argc;
+            ++argv;
+            break;
+        }
+        else if ( **argv != '-' )
+        {
+            break;
+        }
+        else
+        {
+            debug_mi_error( "Unknown argument." );
+            return;
+        }
+    }
+    if ( argc > 1 )
+    {
+        debug_mi_error( "Too many arguments for -break-insert." );
+        return;
+    }
+
+    if ( argc == 1 )
+    {
+        location = *argv;
+    }
+    else
+    {
+        debug_mi_error( "Not implemented: -break-insert with no location." );
+        return;
+    }
+    inner_argv[ 0 ] = "break";
+    inner_argv[ 1 ] = location;
+
+    id = debug_add_breakpoint( location );
+    debug_parent_forward_nowait( 2, inner_argv, 1, 0 );
+
+    if ( disabled )
+    {
+        char buf[ 80 ];
+        sprintf( buf, "%d", num_breakpoints );
+        inner_argv[ 0 ] = "disable";
+        inner_argv[ 1 ] = buf;
+        debug_child_disable( 2, inner_argv );
+        debug_parent_forward_nowait( 2, inner_argv, 1, 0 );
+    }
+
+    debug_mi_format_token();
+    printf( "^done," );
+    debug_mi_format_breakpoint( id );
+    printf( "\n(gdb) \n" );
+}
+
+static void debug_mi_break_delete( int argc, const char * * argv )
+{
+    if ( argc < 2 )
+    {
+        debug_mi_error( "Not enough arguments for -break-delete" );
+        return;
+    }
+    for ( --argc, ++argv; argc; --argc, ++argv )
+    {
+        const char * inner_argv[ 2 ];
+        int id = breakpoint_id_parse( *argv );
+        if ( id == -1 )
+        {
+            debug_mi_error( "Not a valid breakpoint" );
+            return;
+        }
+        inner_argv[ 0 ] = "delete";
+        inner_argv[ 1 ] = *argv;
+        debug_parent_delete( 2, inner_argv );
+    }
+}
+
+static void debug_mi_break_enable( int argc, const char * * argv )
+{
+    if ( argc < 2 )
+    {
+        debug_mi_error( "Not enough arguments for -break-enable" );
+        return;
+    }
+    for ( --argc, ++argv; argc; --argc, ++argv )
+    {
+        const char * inner_argv[ 2 ];
+        int id = breakpoint_id_parse( *argv );
+        if ( id == -1 )
+        {
+            debug_mi_error( "Not a valid breakpoint" );
+            return;
+        }
+        inner_argv[ 0 ] = "enable";
+        inner_argv[ 1 ] = *argv;
+        debug_parent_enable( 2, inner_argv );
+    }
+}
+
+static void debug_mi_break_disable( int argc, const char * * argv )
+{
+    if ( argc < 2 )
+    {
+        debug_mi_error( "Not enough arguments for -break-disable" );
+        return;
+    }
+    for ( --argc, ++argv; argc; --argc, ++argv )
+    {
+        const char * inner_argv[ 2 ];
+        int id = breakpoint_id_parse( *argv );
+        if ( id == -1 )
+        {
+            debug_mi_error( "Not a valid breakpoint" );
+            return;
+        }
+        inner_argv[ 0 ] = "disable";
+        inner_argv[ 1 ] = *argv;
+        debug_parent_disable( 2, inner_argv );
+    }
+}
+
+static void debug_mi_format_breakpoint_header_col( int width, int alignment, const char * col_name, const char * colhdr )
+{
+    printf( "{width=\"%d\",alignment=\"%d\",col_name=\"%s\",colhdr=\"%s\"}", width, alignment, col_name, colhdr );
+}
+
+static void debug_mi_format_breakpoint_hdr( void )
+{
+    printf( "hdr=[" );
+    debug_mi_format_breakpoint_header_col( 7, -1, "number", "Num" );
+    printf( "," );
+    debug_mi_format_breakpoint_header_col( 14, -1, "type", "Type" );
+    printf( "," );
+    debug_mi_format_breakpoint_header_col( 4, -1, "disp", "Disp" );
+    printf( "," );
+    debug_mi_format_breakpoint_header_col( 3, -1, "enabled", "Enb" );
+    printf( "," );
+    debug_mi_format_breakpoint_header_col( 10, -1, "addr", "Address" );
+    printf( "," );
+    debug_mi_format_breakpoint_header_col( 40, 2, "what", "What" );
+    printf( "]" );
+}
+
+static void debug_mi_break_info( int argc, const char * * argv )
+{
+    int id;
+    --argc;
+    ++argv;
+    if ( strcmp( *argv, "--" ) == 0 )
+    {
+        --argc;
+        ++argv;
+    }
+    if ( argc < 1 )
+    {
+        debug_mi_error( "Not enough arguments for -break-info" );
+        return;
+    }
+    if ( argc > 1 )
+    {
+        debug_mi_error( "Too many arguments for -break-info" );
+    }
+
+    id = breakpoint_id_parse( *argv );
+    if ( id == -1 )
+    {
+        debug_mi_error( "No such breakpoint." );
+        return;
+    }
+
+    printf( "^done,BreakpointTable={"
+        "nr_rows=\"%d\",nr_cols=\"6\",", 1 );
+    debug_mi_format_breakpoint_hdr();
+    printf( ",body=[" );
+    debug_mi_format_breakpoint( id );
+    printf( "]}" );
+    printf("\n(gdb) \n");
+}
+
+static void debug_mi_break_list( int argc, const char * * argv )
+{
+    int number;
+    int i;
+    int first;
+    if ( argc > 2 || argc == 2 && strcmp( argv[ 1 ], "--" ) )
+    {
+        debug_mi_error( "Too many arguments for -break-list" );
+        return;
+    }
+    
+    number = 0;
+    for ( i = 0; i < num_breakpoints; ++i )
+        if ( breakpoints[ i ].status != BREAKPOINT_DELETED )
+            ++number;
+    debug_mi_format_token();
+    printf( "^done,BreakpointTable={"
+        "nr_rows=\"%d\",nr_cols=\"6\",", number );
+    debug_mi_format_breakpoint_hdr();
+    printf( ",body=[" );
+    first = 1;
+    for ( i = 0; i < num_breakpoints; ++i )
+        if ( breakpoints[ i ].status != BREAKPOINT_DELETED )
+        {
+            if ( first ) first = 0;
+            else printf( "," );
+            debug_mi_format_breakpoint( i + 1 );
+        }
+    printf( "]}" );
+    printf("\n(gdb) \n");
+}
+
+static void debug_mi_inferior_tty_set( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^done\n(gdb) \n" );
+}
+
+static void debug_mi_gdb_exit( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_RUN )
+    {
+        fprintf( command_output, "kill\n" );
+        fflush( command_output );
+        debug_parent_wait( 0 );
+    }
+    debug_mi_format_token();
+    printf( "^exit\n" );
+    exit( EXIT_SUCCESS );
+}
+
+static void debug_mi_gdb_set( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^done\n(gdb) \n" );
+}
+
+static void debug_mi_gdb_show( int argc, const char * * argv )
+{
+    const char * value = "";
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    value = "(gdb) ";
+    printf( "^done,value=\"%s\"\n(gdb) \n", value );
+}
+
+static void debug_mi_not_implemented( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^done\n(gdb) \n" );
+}
+
+void debug_mi_file_list_exec_source_files( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^done,files=[]\n(gdb) \n" );
+}
+
+static void debug_mi_file_list_exec_source_file( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^error,msg=\"Don't know how to handle this yet\"\n(gdb) \n" );
+}
+
+static void debug_mi_thread_info( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^done,threads=[]\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "info", "frame" };
+        FRAME_INFO info;
+        debug_parent_forward_nowait( 2, new_args, 0, 0 );
+        debug_frame_read( command_child, &info );
+
+        debug_mi_format_token();
+        printf( "^done,threads=[{id=\"1\"," );
+        debug_mi_print_frame_info( &info );
+        debug_frame_info_free( &info );
+        printf( "}],current-thread-id=\"1\"\n(gdb) \n" );
+    }
+}
+
+static void debug_mi_thread_select( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        /* FIXME: better error handling*/
+        debug_mi_format_token();
+        printf( "^error,msg=\"Thread ID 1 not known\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "info", "frame" };
+        FRAME_INFO info;
+        debug_parent_forward_nowait( 2, new_args, 0, 0 );
+        debug_frame_read( command_child, &info );
+
+        debug_mi_format_token();
+        printf( "^done,new-thread-id=\"1\"," );
+        debug_mi_print_frame_info( &info );
+        debug_frame_info_free( &info );
+        printf( "\n(gdb) \n" );
+    }
+}
+
+static void debug_mi_stack_select_frame( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[ 2 ];
+        new_args[ 0 ] = "frame";
+        new_args[ 1 ] = argv[ 1 ];
+        debug_parent_forward_nowait( 2, new_args, 0, 0 );
+        debug_mi_format_token();
+        printf( "^done\n(gdb) \n" );
+    }
+}
+
+static void debug_mi_stack_info_frame( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        FRAME_INFO info;
+        fprintf( command_output, "info frame\n" );
+        fflush( command_output );
+        debug_frame_read( command_child, &info );
+        debug_mi_format_token();
+        printf( "^done," );
+        debug_mi_print_frame_info( &info );
+        debug_frame_info_free( &info );
+        printf( "\n(gdb) \n" );
+    }
+}
+
+static void debug_mi_stack_list_variables( int argc, const char * * argv )
+{
+    int print_values = 0;
+#define DEBUG_PRINT_VARIABLES_NO_VALUES     1
+#define DEBUG_PRINT_VARIABLES_ALL_VALUES    2
+#define DEBUG_PRINT_VARIABLES_SIMPLE_VALUES 3
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+        return;
+    }
+    --argc;
+    ++argv;
+    for ( ; argc; --argc, ++argv )
+    {
+        if ( strcmp( *argv, "--thread" ) == 0 )
+        {
+            /* Only one thread. */
+            --argc;
+            ++argv;
+        }
+        else if ( strcmp( *argv, "--no-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_NO_VALUES;
+        }
+        else if ( strcmp( *argv, "--all-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_ALL_VALUES;
+        }
+        else if ( strcmp( *argv, "--simple-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_SIMPLE_VALUES;
+        }
+        else if ( strcmp( *argv, "--" ) == 0 )
+        {
+            --argc;
+            ++argv;
+            break;
+        }
+        else if ( argv[ 0 ][ 0 ] == '-' )
+        {
+            debug_mi_format_token();
+            printf( "^error,msg=\"Unknown argument %s\"\n(gdb) \n", *argv );
+            return;
+        }
+        else
+        {
+            break;
+        }
+    }
+    if ( argc != 0 )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"Too many arguments for -stack-list-variables\"\n(gdb) \n" );
+        return;
+    }
+    
+    {
+        LIST * vars;
+        LISTITER iter, end;
+        int first = 1;
+        fprintf( command_output, "info locals\n" );
+        fflush( command_output );
+        vars = debug_list_read( command_child );
+        debug_parent_wait( 0 );
+        debug_mi_format_token();
+        printf( "^done,variables=[" );
+        for ( iter = list_begin( vars ), end = list_end( vars ); iter != end; iter = list_next( iter ) )
+        {
+            OBJECT * varname = list_item( iter );
+            string varbuf[1];
+            const char * new_args[2];
+            if ( first )
+            {
+                first = 0;
+            }
+            else
+            {
+                printf( "," );
+            }
+            printf( "{name=\"%s\",value=\"", object_str( varname ) );
+            fflush( stdout );
+            string_new( varbuf );
+            string_append( varbuf, "$(" );
+            string_append( varbuf, object_str( varname ) );
+            string_append( varbuf, ")" );
+            new_args[ 0 ] = "print";
+            new_args[ 1 ] = varbuf->value;
+            debug_parent_forward( 2, new_args, 0, 0 );
+            string_free( varbuf );
+            printf( "\"}" );
+        }
+        printf( "]\n(gdb) \n" );
+        fflush( stdout );
+        list_free( vars );
+    }
+}
+
+static void debug_mi_stack_list_locals( int argc, const char * * argv )
+{
+    int print_values = 0;
+#define DEBUG_PRINT_VARIABLES_NO_VALUES     1
+#define DEBUG_PRINT_VARIABLES_ALL_VALUES    2
+#define DEBUG_PRINT_VARIABLES_SIMPLE_VALUES 3
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+        return;
+    }
+    --argc;
+    ++argv;
+    for ( ; argc; --argc, ++argv )
+    {
+        if ( strcmp( *argv, "--thread" ) == 0 )
+        {
+            /* Only one thread. */
+            --argc;
+            ++argv;
+            if ( argc == 0 )
+            {
+                debug_mi_format_token();
+                printf( "^error,msg=\"Argument required for --thread.\"" );
+                return;
+            }
+        }
+        else if ( strcmp( *argv, "--no-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_NO_VALUES;
+        }
+        else if ( strcmp( *argv, "--all-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_ALL_VALUES;
+        }
+        else if ( strcmp( *argv, "--simple-values" ) == 0 )
+        {
+            print_values = DEBUG_PRINT_VARIABLES_SIMPLE_VALUES;
+        }
+        else if ( strcmp( *argv, "--" ) == 0 )
+        {
+            --argc;
+            ++argv;
+            break;
+        }
+        else if ( argv[ 0 ][ 0 ] == '-' )
+        {
+            debug_mi_format_token();
+            printf( "^error,msg=\"Unknown argument %s\"\n(gdb) \n", *argv );
+            return;
+        }
+        else
+        {
+            break;
+        }
+    }
+    if ( argc != 0 )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"Too many arguments for -stack-list-variables\"\n(gdb) \n" );
+        return;
+    }
+    
+    {
+        LIST * vars;
+        LISTITER iter, end;
+        int first = 1;
+        fprintf( command_output, "info locals\n" );
+        fflush( command_output );
+        vars = debug_list_read( command_child );
+        debug_parent_wait( 0 );
+        debug_mi_format_token();
+        printf( "^done,locals=[" );
+        for ( iter = list_begin( vars ), end = list_end( vars ); iter != end; iter = list_next( iter ) )
+        {
+            OBJECT * varname = list_item( iter );
+            string varbuf[1];
+            const char * new_args[2];
+            if ( first )
+            {
+                first = 0;
+            }
+            else
+            {
+                printf( "," );
+            }
+            printf( "{name=\"%s\",type=\"list\",value=\"", object_str( varname ) );
+            fflush( stdout );
+            string_new( varbuf );
+            string_append( varbuf, "$(" );
+            string_append( varbuf, object_str( varname ) );
+            string_append( varbuf, ")" );
+            new_args[ 0 ] = "print";
+            new_args[ 1 ] = varbuf->value;
+            debug_parent_forward( 2, new_args, 0, 0 );
+            string_free( varbuf );
+            printf( "\"}" );
+        }
+        printf( "]\n(gdb) \n" );
+        fflush( stdout );
+        list_free( vars );
+    }
+}
+
+static void debug_mi_stack_list_frames( int argc, const char * * argv )
+{
+    const char * new_args[ 3 ];
+    int depth;
+    int i;
+    
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        debug_mi_format_token();
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+        return;
+    }
+
+    new_args[ 0 ] = "info";
+    new_args[ 1 ] = "frame";
+
+    fprintf( command_output, "info depth\n" );
+    fflush( command_output );
+    depth = debug_int_read( command_child );
+
+    debug_mi_format_token();
+    printf( "^done,stack=[" );
+    for ( i = 0; i < depth; ++i )
+    {
+        FRAME_INFO frame;
+        fprintf( command_output, "info frame %d\n", i );
+        fflush( command_output );
+        if ( i != 0 )
+        {
+            printf( "," );
+        }
+        debug_frame_read( command_child, &frame );
+        debug_mi_print_frame_info( &frame );
+    }
+    printf( "]\n(gdb) \n" );
+    fflush( stdout );
+}
+
+static void debug_mi_list_target_features( int argc, const char * * argv )
+{
+    /* FIXME: implement this for real */
+    debug_mi_format_token();
+    printf( "^done,features=[\"async\"]\n(gdb) \n" );
+}
+
+static void debug_mi_exec_run( int argc, const char * * argv )
+{
+    printf( "=thread-created,id=\"1\",group-id=\"i1\"\n" );
+    debug_mi_format_token();
+    printf( "^running\n(gdb) \n" );
+    fflush( stdout );
+    debug_start_child( argc, argv );
+    debug_parent_wait( 1 );
+}
+
+static void debug_mi_exec_continue( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "continue" };
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+        debug_parent_forward( 1, new_args, 1, 0 );
+    }
+}
+
+static void debug_mi_exec_step( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "step" };
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+        debug_parent_forward( 1, new_args, 1, 0 );
+    }
+}
+
+static void debug_mi_exec_next( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "next" };
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+        debug_parent_forward( 1, new_args, 1, 0 );
+    }
+}
+
+static void debug_mi_exec_finish( int argc, const char * * argv )
+{
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[] = { "finish" };
+        debug_mi_format_token();
+        printf( "^running\n(gdb) \n" );
+        fflush( stdout );
+        debug_parent_forward( 1, new_args, 1, 0 );
+    }
+}
+
+static void debug_mi_data_list_register_names( int argc, const char * * argv )
+{
+    debug_mi_format_token();
+    printf( "^done,register-names=[]\n(gdb) \n" );
+}
+
+static void debug_mi_data_evaluate_expression( int argc, const char * * argv )
+{
+    if ( argc < 2 )
+    {
+        printf( "^error,msg=\"Not enough arguments for -data-evaluate-expression\"\n(gdb) \n" );
+    }
+    if ( debug_state == DEBUG_NO_CHILD )
+    {
+        printf( "^error,msg=\"No child\"\n(gdb) \n" );
+    }
+    else
+    {
+        const char * new_args[ 2 ];
+        debug_mi_format_token();
+        printf( "^done,value=\"" );
+        fflush( stdout );
+        new_args[ 0 ] = "print";
+        new_args[ 1 ] = argv[ 1 ];
+        debug_parent_forward( 2, new_args, 1, 0 );
+        printf( "\"\n(gdb) \n" );
+    }
+}
+
+static int process_command( char * command );
+
+static void debug_mi_interpreter_exec( int argc, const char * * argv )
+{
+    if ( argc < 3 )
+    {
+        debug_mi_error( "Not enough arguments for -interpreter-exec" );
+    }
+    process_command( (char *)argv[ 2 ] );
+}
+
+/* The debugger's main loop. */
+int debugger( void )
+{
+    command_array = parent_commands;
+    command_input = stdin;
+    if ( debug_interface == DEBUG_INTERFACE_MI )
+        printf( "=thread-group-added,id=\"i1\"\n(gdb) \n" );
+    while ( 1 )
+    {
+        if ( debug_interface == DEBUG_INTERFACE_CONSOLE )
+            printf("(b2db) ");
+        fflush( stdout );
+        read_command();
+    }
+    return 0;
+}
+
+
+/* Runs the matching command in the current command_array. */
+static int run_command( int argc, const char * * argv )
+{
+    struct command_elem * command;
+    const char * command_name;
+    if ( argc == 0 )
+    {
+        return 1;
+    }
+    command_name = argv[ 0 ];
+    /* Skip the GDB/MI token when choosing the command to run. */
+    while( isdigit( *command_name ) ) ++command_name;
+    current_token = atoi( argv[ 0 ] );
+    for( command = command_array; command->key; ++command )
+    {
+        if ( strcmp( command->key, command_name ) == 0 )
+        {
+            ( *command->command )( argc, argv );
+            return 1;
+        }
+    }
+    debug_error( "Unknown command: %s", command_name );
+    return 0;
+}
+
+/* Parses a single command into whitespace separated tokens, and runs it. */
+static int process_command( char * line )
+{
+    int result;
+    size_t capacity = 8;
+    const char * * buffer = malloc( capacity * sizeof( const char * ) );
+    const char * * current = buffer;
+    char * iter = line;
+    const char * saved = iter;
+    *current = iter;
+    for ( ; ; )
+    {
+        /* skip spaces */
+        while ( *iter && isspace( *iter ) )
+        {
+            ++iter;
+        }
+        if ( ! *iter )
+        {
+            break;
+        }
+        /* Find the next token */
+        saved = iter;
+        if ( *iter == '\"' )
+        {
+            saved = ++iter;
+            /* FIXME: handle escaping */
+            while ( *iter && *iter != '\"' )
+            {
+                ++iter;
+            }
+        }
+        else
+        {
+            while ( *iter && ! isspace( *iter ) )
+            {
+                ++iter;
+            }
+        }
+        /* resize the buffer if necessary */
+        if ( current == buffer + capacity )
+        {
+            buffer = realloc( (void *)buffer, capacity * 2 * sizeof( const char * ) );
+            current = buffer + capacity;
+        }
+        /* append the token to the buffer */
+        *current++ = saved;
+        /* null terminate the token */
+        if ( *iter )
+        {
+            *iter++ = '\0';
+        }
+    }
+    result = run_command( current - buffer, buffer );
+    free( (void *)buffer );
+    return result;
+}
+
+static int read_command( void )
+{
+    int result;
+    int ch;
+    string line[ 1 ];
+    string_new( line );
+    /* HACK: force line to be on the heap. */
+    string_reserve( line, 64 );
+    while( ( ch = fgetc( command_input ) )  != EOF )
+    {
+        if ( ch == '\n' )
+        {
+            break;
+        }
+        else
+        {
+            string_push_back( line, (char)ch );
+        }
+    }
+    result = process_command( line->value );
+    string_free( line );
+    return result;
+}
+
+static void debug_listen( void )
+{
+    debug_state = DEBUG_STOPPED;
+    while ( debug_state == DEBUG_STOPPED )
+    {
+        if ( feof( command_input ) )
+            exit( 1 );
+        fflush(stdout);
+        fflush( command_output );
+        read_command();
+    }
+    debug_selected_frame_number = 0;
+}
+
+struct debug_child_data_t debug_child_data;
+const char debugger_opt[] = "--b2db-internal-debug-handle=";
+int debug_interface;

--- a/Patches/Boost/1.65.1/debugger.c
+++ b/Patches/Boost/1.65.1/debugger.c
@@ -12,6 +12,7 @@
 #include "cwd.h"
 #include "function.h"
 #include <assert.h>
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -26,6 +27,7 @@
 #else
 #include <errno.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
 
 #undef debug_on_enter_function

--- a/Patches/Boost/1.65.1/execcmd.c
+++ b/Patches/Boost/1.65.1/execcmd.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright 1993, 1995 Christopher Seiwald.
+ * Copyright 2007 Noel Belcourt.
+ *
+ *   Utility functions shared between different exec*.c platform specific
+ * implementation modules.
+ *
+ * This file is part of Jam - see jam.c for Copyright information.
+ */
+
+#include "jam.h"
+#include "execcmd.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+
+/* Internal interrupt counter. */
+static int intr;
+
+
+/* Constructs a list of command-line elements using the format specified by the
+ * given shell list.
+ *
+ * Given argv array should have at least MAXARGC + 1 elements.
+ * Slot numbers may be between 0 and 998 (inclusive).
+ *
+ * Constructed argv list will be zero terminated. Character arrays referenced by
+ * the argv structure elements will be either elements from the give shell list,
+ * internal static buffers or the given command string and should thus not
+ * considered owned by or released via the argv structure and should be
+ * considered invalidated by the next argv_from_shell() call.
+ *
+ * Shell list elements:
+ *   - Starting with '%' - represent the command string.
+ *   - Starting with '!' - represent the slot number (increased by one).
+ *   - Anything else - used as a literal.
+ *   - If no '%' element is found, the command string is appended as an extra.
+ */
+
+void argv_from_shell( char const * * argv, LIST * shell, char const * command,
+    int const slot )
+{
+    static char jobno[ 4 ];
+
+    int i;
+    int gotpercent = 0;
+    LISTITER iter = list_begin( shell );
+    LISTITER end = list_end( shell );
+
+    assert( 0 <= slot );
+    assert( slot < 999 );
+    sprintf( jobno, "%d", slot + 1 );
+
+    for ( i = 0; iter != end && i < MAXARGC; ++i, iter = list_next( iter ) )
+    {
+        switch ( object_str( list_item( iter ) )[ 0 ] )
+        {
+            case '%': argv[ i ] = command; ++gotpercent; break;
+            case '!': argv[ i ] = jobno; break;
+            default : argv[ i ] = object_str( list_item( iter ) );
+        }
+    }
+
+    if ( !gotpercent )
+        argv[ i++ ] = command;
+
+    argv[ i ] = NULL;
+}
+
+
+/* Returns whether the given command string contains lines longer than the given
+ * maximum.
+ */
+int check_cmd_for_too_long_lines( char const * command, int const max,
+    int * const error_length, int * const error_max_length )
+{
+    while ( *command )
+    {
+        size_t const l = strcspn( command, "\n" );
+        if ( l > max )
+        {
+            *error_length = l;
+            *error_max_length = max;
+            return EXEC_CHECK_LINE_TOO_LONG;
+        }
+        command += l;
+        if ( *command )
+            ++command;
+    }
+    return EXEC_CHECK_OK;
+}
+
+
+/* Checks whether the given shell list is actually a request to execute raw
+ * commands without an external shell.
+ */
+int is_raw_command_request( LIST * shell )
+{
+    return !list_empty( shell ) &&
+        !strcmp( object_str( list_front( shell ) ), "%" ) &&
+        list_next( list_begin( shell ) ) == list_end( shell );
+}
+
+
+/* Returns whether an interrupt has been detected so far. */
+
+int interrupted( void )
+{
+    return intr != 0;
+}
+
+
+/* Internal interrupt handler. */
+
+void onintr( int disp )
+{
+    ++intr;
+    out_printf( "...interrupted\n" );
+}

--- a/Patches/Boost/1.65.1/execcmd.c
+++ b/Patches/Boost/1.65.1/execcmd.c
@@ -10,6 +10,7 @@
 
 #include "jam.h"
 #include "execcmd.h"
+#include "output.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/Patches/Boost/1.65.1/filesys.h
+++ b/Patches/Boost/1.65.1/filesys.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1993-2002 Christopher Seiwald and Perforce Software, Inc.
+ *
+ * This file is part of Jam - see jam.c for Copyright information.
+ */
+
+/*  This file is ALSO:
+ *  Copyright 2001-2004 David Abrahams.
+ *  Distributed under the Boost Software License, Version 1.0.
+ *  (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+/*
+ * filesys.h - OS specific file routines
+ */
+
+#ifndef FILESYS_DWA20011025_H
+#define FILESYS_DWA20011025_H
+
+#include "hash.h"
+#include "lists.h"
+#include "object.h"
+#include "pathsys.h"
+#include "timestamp.h"
+
+
+typedef struct file_info_t
+{
+    OBJECT * name;
+    char is_file;
+    char is_dir;
+    char exists;
+    timestamp time;
+    LIST * files;
+} file_info_t;
+
+typedef struct file_item FILEITEM;
+struct file_item
+{
+    file_info_t * value;  /* expected to be equvalent with &FILEITEM */
+    FILEITEM * next;
+};
+
+typedef struct file_list
+{
+    FILEITEM * head;
+    FILEITEM * tail;
+    int size;
+} FILELIST;
+
+typedef file_info_t * * FILELISTITER;  /*  also &FILEITEM equivalent */
+
+
+typedef struct file_archive_info_t
+{
+    file_info_t * file;
+    FILELIST * members;
+} file_archive_info_t;
+
+
+typedef void (*archive_scanback)( void * closure, OBJECT * path, LIST * symbols,
+    int found, timestamp const * const );
+typedef void (*scanback)( void * closure, OBJECT * path, int found,
+    timestamp const * const );
+
+
+void file_archscan( char const * arch, scanback func, void * closure );
+void file_archivescan( OBJECT * path, archive_scanback func, void * closure );
+void file_build1( PATHNAME * const f, string * file ) ;
+void file_dirscan( OBJECT * dir, scanback func, void * closure );
+file_info_t * file_info( OBJECT * const path, int * found );
+int file_is_file( OBJECT * const path );
+int file_mkdir( char const * const path );
+file_info_t * file_query( OBJECT * const path );
+void file_remove_atexit( OBJECT * const path );
+void file_supported_fmt_resolution( timestamp * const );
+int file_time( OBJECT * const path, timestamp * const );
+
+
+/*  Archive/library file support */
+file_archive_info_t * file_archive_info( OBJECT * const path, int * found );
+file_archive_info_t * file_archive_query( OBJECT * const path );
+
+/* FILELIST linked-list */
+FILELIST * filelist_new( OBJECT * path );
+FILELIST * filelist_push_back( FILELIST * list, OBJECT * path );
+FILELIST * filelist_push_front( FILELIST * list, OBJECT * path );
+FILELIST * filelist_pop_front( FILELIST * list );
+int filelist_length( FILELIST * list );
+void filelist_free( FILELIST * list );
+
+FILELISTITER filelist_begin( FILELIST * list );
+FILELISTITER filelist_end( FILELIST * list );
+FILELISTITER filelist_next( FILELISTITER it );
+file_info_t * filelist_item( FILELISTITER it );
+file_info_t * filelist_front(  FILELIST * list );
+file_info_t * filelist_back(  FILELIST * list );
+
+#define FL0 ((FILELIST *)0)
+
+
+/* Internal utility worker functions. */
+void file_query_posix_( file_info_t * const );
+
+void file_done();
+
+#endif

--- a/Patches/Boost/1.65.1/filesys.h
+++ b/Patches/Boost/1.65.1/filesys.h
@@ -64,6 +64,7 @@ typedef void (*scanback)( void * closure, OBJECT * path, int found,
     timestamp const * const );
 
 
+int filelist_empty( FILELIST * list );
 void file_archscan( char const * arch, scanback func, void * closure );
 void file_archivescan( OBJECT * path, archive_scanback func, void * closure );
 void file_build1( PATHNAME * const f, string * file ) ;

--- a/Patches/Boost/1.65.1/fileunix.c
+++ b/Patches/Boost/1.65.1/fileunix.c
@@ -1,0 +1,547 @@
+/*
+ * Copyright 1993-2002 Christopher Seiwald and Perforce Software, Inc.
+ *
+ * This file is part of Jam - see jam.c for Copyright information.
+ */
+
+/*  This file is ALSO:
+ *  Copyright 2001-2004 David Abrahams.
+ *  Copyright 2005 Rene Rivera.
+ *  Distributed under the Boost Software License, Version 1.0.
+ *  (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+/*
+ * fileunix.c - manipulate file names and scan directories on UNIX/AmigaOS
+ *
+ * External routines:
+ *  file_archscan()                 - scan an archive for files
+ *  file_mkdir()                    - create a directory
+ *  file_supported_fmt_resolution() - file modification timestamp resolution
+ *
+ * External routines called only via routines in filesys.c:
+ *  file_collect_dir_content_() - collects directory content information
+ *  file_dirscan_()             - OS specific file_dirscan() implementation
+ *  file_query_()               - query information about a path from the OS
+ *  file_collect_archive_content_() - collects information about archive members
+ *  file_archivescan_()         - OS specific file_archivescan() implementation
+ */
+
+#include "jam.h"
+#ifdef USE_FILEUNIX
+#include "filesys.h"
+
+#include "object.h"
+#include "pathsys.h"
+#include "strings.h"
+#include "output.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <sys/stat.h>  /* needed for mkdir() */
+
+#if defined( sun ) || defined( __sun ) || defined( linux )
+# include <unistd.h>  /* needed for read and close prototype */
+#endif
+
+#if defined( OS_SEQUENT ) || \
+    defined( OS_DGUX ) || \
+    defined( OS_SCO ) || \
+    defined( OS_ISC )
+# define PORTAR 1
+#endif
+
+#if defined( OS_RHAPSODY ) || defined( OS_MACOSX ) || defined( OS_NEXT )
+# include <sys/dir.h>
+# include <unistd.h>  /* need unistd for rhapsody's proper lseek */
+# define STRUCT_DIRENT struct direct
+#else
+# include <dirent.h>
+# define STRUCT_DIRENT struct dirent
+#endif
+
+#ifdef OS_COHERENT
+# include <arcoff.h>
+# define HAVE_AR
+#endif
+
+#if defined( OS_MVS ) || defined( OS_INTERIX )
+#define ARMAG  "!<arch>\n"
+#define SARMAG  8
+#define ARFMAG  "`\n"
+#define HAVE_AR
+
+struct ar_hdr  /* archive file member header - printable ascii */
+{
+    char ar_name[ 16 ];  /* file member name - `/' terminated */
+    char ar_date[ 12 ];  /* file member date - decimal */
+    char ar_uid[ 6 ];    /* file member user id - decimal */
+    char ar_gid[ 6 ];    /* file member group id - decimal */
+    char ar_mode[ 8 ];   /* file member mode - octal */
+    char ar_size[ 10 ];  /* file member size - decimal */
+    char ar_fmag[ 2 ];   /* ARFMAG - string to end header */
+};
+#endif
+
+#if defined( OS_QNX ) || \
+    defined( OS_BEOS ) || \
+    defined( OS_HAIKU ) || \
+    defined( OS_MPEIX )
+# define NO_AR
+# define HAVE_AR
+#endif
+
+#ifndef HAVE_AR
+# ifdef OS_AIX
+/* Define these for AIX to get the definitions for both small and big archive
+ * file format variants.
+ */
+#  define __AR_SMALL__
+#  define __AR_BIG__
+# endif
+# include <ar.h>
+#endif
+
+
+/*
+ * file_collect_dir_content_() - collects directory content information
+ */
+
+int file_collect_dir_content_( file_info_t * const d )
+{
+    LIST * files = L0;
+    PATHNAME f;
+    int n;
+    STRUCT_DIRENT ** namelist;
+    STRUCT_DIRENT * dirent;
+    string path[ 1 ];
+    char const * dirstr;
+
+    assert( d );
+    assert( d->is_dir );
+    assert( list_empty( d->files ) );
+
+    dirstr = object_str( d->name );
+
+    memset( (char *)&f, '\0', sizeof( f ) );
+    f.f_dir.ptr = dirstr;
+    f.f_dir.len = strlen( dirstr );
+
+    if ( !*dirstr ) dirstr = ".";
+
+    if ( -1 == ( n = scandir( dirstr, &namelist, NULL, alphasort ) ) )
+        return -1;
+
+    string_new( path );
+    while ( n-- )
+    {
+        OBJECT * name;
+        dirent = namelist[ n ];
+        f.f_base.ptr = dirent->d_name
+        #ifdef old_sinix
+            - 2  /* Broken structure definition on sinix. */
+        #endif
+            ;
+        f.f_base.len = strlen( f.f_base.ptr );
+
+        string_truncate( path, 0 );
+        path_build( &f, path );
+        name = object_new( path->value );
+        /* Immediately stat the file to preserve invariants. */
+        if ( file_query( name ) )
+            files = list_push_back( files, name );
+        else
+            object_free( name );
+        free( dirent );
+    }
+    string_free( path );
+
+    free( namelist );
+
+    d->files = files;
+    return 0;
+}
+
+
+/*
+ * file_dirscan_() - OS specific file_dirscan() implementation
+ */
+
+void file_dirscan_( file_info_t * const d, scanback func, void * closure )
+{
+    assert( d );
+    assert( d->is_dir );
+
+    /* Special case / : enter it */
+    if ( !strcmp( object_str( d->name ), "/" ) )
+        (*func)( closure, d->name, 1 /* stat()'ed */, &d->time );
+}
+
+
+/*
+ * file_mkdir() - create a directory
+ */
+
+int file_mkdir( char const * const path )
+{
+    /* Explicit cast to remove const modifiers and avoid related compiler
+     * warnings displayed when using the intel compiler.
+     */
+    return mkdir( (char *)path, 0777 );
+}
+
+
+/*
+ * file_query_() - query information about a path from the OS
+ */
+
+void file_query_( file_info_t * const info )
+{
+    file_query_posix_( info );
+}
+
+
+/*
+ * file_supported_fmt_resolution() - file modification timestamp resolution
+ *
+ * Returns the minimum file modification timestamp resolution supported by this
+ * Boost Jam implementation. File modification timestamp changes of less than
+ * the returned value might not be recognized.
+ *
+ * Does not take into consideration any OS or file system related restrictions.
+ *
+ * Return value 0 indicates that any value supported by the OS is also supported
+ * here.
+ */
+
+void file_supported_fmt_resolution( timestamp * const t )
+{
+    /* The current implementation does not support file modification timestamp
+     * resolution of less than one second.
+     */
+    timestamp_init( t, 1, 0 );
+}
+
+
+/*
+ * file_archscan() - scan an archive for files
+ */
+void file_archscan( char const * arch, scanback func, void * closure )
+{
+    OBJECT * path = object_new( arch );
+    file_archive_info_t * archive = file_archive_query( path );
+
+    object_free( path );
+
+    if ( filelist_empty( archive->members ) )
+    {
+        if ( file_collect_archive_content_( archive ) < 0 )
+            return;
+    }
+
+    /* Report the collected archive content. */
+    {
+        FILELISTITER iter = filelist_begin( archive->members );
+        FILELISTITER const end = filelist_end( archive->members );
+        char buf[ MAXJPATH ];
+
+        for ( ; iter != end ; iter = filelist_next( iter ) )
+        {
+            file_info_t * member_file = filelist_item( iter );
+            LIST * symbols = member_file->files;
+
+            /* Construct member path: 'archive-path(member-name)'
+             */
+            sprintf( buf, "%s(%s)",
+                object_str( archive->file->name ),
+                object_str( member_file->name ) );
+            {
+                OBJECT * const member = object_new( buf );
+                (*func)( closure, member, 1 /* time valid */, &member_file->time );
+                object_free( member );
+            }
+        }
+    }
+}
+
+
+/*
+ *  file_archivescan_()         - OS specific file_archivescan() implementation
+ */
+
+void file_archivescan_( file_archive_info_t * const archive, archive_scanback func,
+                        void * closure )
+{
+}
+
+
+/*
+ *  file_collect_archive_content_() - collects information about archive members
+ */
+
+#ifndef AIAMAG  /* God-fearing UNIX */
+
+#define SARFMAG  2
+#define SARHDR  sizeof( struct ar_hdr )
+
+int file_collect_archive_content_( file_archive_info_t * const archive )
+{
+#ifndef NO_AR
+    struct ar_hdr ar_hdr;
+    char * string_table = 0;
+    char buf[ MAXJPATH ];
+    long offset;
+    int fd;
+    const char * path = object_str( archive->file->name );
+
+    if ( ! filelist_empty( archive->members ) ) filelist_free( archive->members );
+
+    if ( ( fd = open( path, O_RDONLY, 0 ) ) < 0 )
+        return -1;
+
+    if ( read( fd, buf, SARMAG ) != SARMAG ||
+        strncmp( ARMAG, buf, SARMAG ) )
+    {
+        close( fd );
+        return -1;
+    }
+
+    offset = SARMAG;
+
+    if ( DEBUG_BINDSCAN )
+        out_printf( "scan archive %s\n", path );
+
+    while ( ( read( fd, &ar_hdr, SARHDR ) == SARHDR ) &&
+        !( memcmp( ar_hdr.ar_fmag, ARFMAG, SARFMAG )
+#ifdef ARFZMAG
+            /* OSF also has a compressed format */
+            && memcmp( ar_hdr.ar_fmag, ARFZMAG, SARFMAG )
+#endif
+        ) )
+    {
+        char   lar_name_[ 257 ];
+        char * lar_name = lar_name_ + 1;
+        long   lar_date;
+        long   lar_size;
+        long   lar_offset;
+        char * c;
+        char * src;
+        char * dest;
+
+        strncpy( lar_name, ar_hdr.ar_name, sizeof( ar_hdr.ar_name ) );
+
+        sscanf( ar_hdr.ar_date, "%ld", &lar_date );
+        sscanf( ar_hdr.ar_size, "%ld", &lar_size );
+
+        if ( ar_hdr.ar_name[ 0 ] == '/' )
+        {
+            if ( ar_hdr.ar_name[ 1 ] == '/' )
+            {
+                /* This is the "string table" entry of the symbol table, holding
+                 * filename strings longer than 15 characters, i.e. those that
+                 * do not fit into ar_name.
+                 */
+                string_table = (char *)BJAM_MALLOC_ATOMIC( lar_size );
+                lseek( fd, offset + SARHDR, 0 );
+                if ( read( fd, string_table, lar_size ) != lar_size )
+                    out_printf("error reading string table\n");
+            }
+            else if ( string_table && ar_hdr.ar_name[ 1 ] != ' ' )
+            {
+                /* Long filenames are recognized by "/nnnn" where nnnn is the
+                 * offset of the string in the string table represented in ASCII
+                 * decimals.
+                 */
+                dest = lar_name;
+                lar_offset = atoi( lar_name + 1 );
+                src = &string_table[ lar_offset ];
+                while ( *src != '/' )
+                    *dest++ = *src++;
+                *dest = '/';
+            }
+        }
+
+        c = lar_name - 1;
+        while ( ( *++c != ' ' ) && ( *c != '/' ) );
+        *c = '\0';
+
+        if ( DEBUG_BINDSCAN )
+            out_printf( "archive name %s found\n", lar_name );
+
+        sprintf( buf, "%s", lar_name );
+
+        if ( strcmp( buf, "") != 0 )
+        {
+            file_info_t * member = 0;
+
+            archive->members = filelist_push_back( archive->members, object_new( buf ) );
+            member = filelist_back( archive->members );
+            member->is_file = 1;
+            member->is_dir = 0;
+            member->exists = 0;
+            timestamp_init( &member->time, (time_t)lar_date, 0 );
+        }
+
+        offset += SARHDR + ( ( lar_size + 1 ) & ~1 );
+        lseek( fd, offset, 0 );
+    }
+
+    if ( string_table )
+        BJAM_FREE( string_table );
+
+    close( fd );
+#endif  /* NO_AR */
+
+    return 0;
+}
+
+#else  /* AIAMAG - RS6000 AIX */
+
+static void collect_archive_content_small( int fd, file_archive_info_t * const archive )
+{
+    struct fl_hdr fl_hdr;
+
+    struct {
+        struct ar_hdr hdr;
+        char pad[ 256 ];
+    } ar_hdr ;
+
+    char buf[ MAXJPATH ];
+    long offset;
+    const char * path = object_str( archive->file->name );
+
+    if ( read( fd, (char *)&fl_hdr, FL_HSZ ) != FL_HSZ )
+        return;
+
+    sscanf( fl_hdr.fl_fstmoff, "%ld", &offset );
+
+    if ( DEBUG_BINDSCAN )
+        out_printf( "scan archive %s\n", path );
+
+    while ( offset > 0 && lseek( fd, offset, 0 ) >= 0 &&
+        read( fd, &ar_hdr, sizeof( ar_hdr ) ) >= (int)sizeof( ar_hdr.hdr ) )
+    {
+        long lar_date;
+        int lar_namlen;
+
+        sscanf( ar_hdr.hdr.ar_namlen, "%d" , &lar_namlen );
+        sscanf( ar_hdr.hdr.ar_date  , "%ld", &lar_date   );
+        sscanf( ar_hdr.hdr.ar_nxtmem, "%ld", &offset     );
+
+        if ( !lar_namlen )
+            continue;
+
+        ar_hdr.hdr._ar_name.ar_name[ lar_namlen ] = '\0';
+
+        sprintf( buf, "%s", ar_hdr.hdr._ar_name.ar_name );
+
+        if ( strcmp( buf, "") != 0 )
+        {
+            file_info_t * member = 0;
+
+            archive->members = filelist_push_back( archive->members, object_new( buf ) );
+            member = filelist_back( archive->members );
+            member->is_file = 1;
+            member->is_dir = 0;
+            member->exists = 0;
+            timestamp_init( &member->time, (time_t)lar_date, 0 );
+        }
+    }
+}
+
+/* Check for OS versions supporting the big variant. */
+#ifdef AR_HSZ_BIG
+
+static void collect_archive_content_big( int fd, file_archive_info_t * const archive )
+{
+    struct fl_hdr_big fl_hdr;
+
+    struct {
+        struct ar_hdr_big hdr;
+        char pad[ 256 ];
+    } ar_hdr ;
+
+    char buf[ MAXJPATH ];
+    long long offset;
+    const char * path = object_str( archive->file->name );
+
+    if ( read( fd, (char *)&fl_hdr, FL_HSZ_BIG ) != FL_HSZ_BIG )
+        return;
+
+    sscanf( fl_hdr.fl_fstmoff, "%lld", &offset );
+
+    if ( DEBUG_BINDSCAN )
+        out_printf( "scan archive %s\n", path );
+
+    while ( offset > 0 && lseek( fd, offset, 0 ) >= 0 &&
+        read( fd, &ar_hdr, sizeof( ar_hdr ) ) >= sizeof( ar_hdr.hdr ) )
+    {
+        long lar_date;
+        int lar_namlen;
+
+        sscanf( ar_hdr.hdr.ar_namlen, "%d"  , &lar_namlen );
+        sscanf( ar_hdr.hdr.ar_date  , "%ld" , &lar_date   );
+        sscanf( ar_hdr.hdr.ar_nxtmem, "%lld", &offset     );
+
+        if ( !lar_namlen )
+            continue;
+
+        ar_hdr.hdr._ar_name.ar_name[ lar_namlen ] = '\0';
+
+        sprintf( buf, "%s", ar_hdr.hdr._ar_name.ar_name );
+
+        if ( strcmp( buf, "") != 0 )
+        {
+            file_info_t * member = 0;
+
+            archive->members = filelist_push_back( archive->members, object_new( buf ) );
+            member = filelist_back( archive->members );
+            member->is_file = 1;
+            member->is_dir = 0;
+            member->exists = 0;
+            timestamp_init( &member->time, (time_t)lar_date, 0 );
+        }
+    }
+}
+
+#endif  /* AR_HSZ_BIG */
+
+int file_collect_archive_content_( file_archive_info_t * const archive )
+{
+    int fd;
+    char fl_magic[ SAIAMAG ];
+    const char * path = object_str( archive->file->name );
+
+    if ( ! filelist_empty( archive->members ) ) filelist_free( archive->members );
+
+    if ( ( fd = open( path, O_RDONLY, 0 ) ) < 0 )
+        return -1;
+
+    if ( read( fd, fl_magic, SAIAMAG ) != SAIAMAG ||
+        lseek( fd, 0, SEEK_SET ) == -1 )
+    {
+        close( fd );
+        return -1;
+    }
+
+    if ( !strncmp( AIAMAG, fl_magic, SAIAMAG ) )
+    {
+        /* read small variant */
+        collect_archive_content_small( fd, archive );
+    }
+#ifdef AR_HSZ_BIG
+    else if ( !strncmp( AIAMAGBIG, fl_magic, SAIAMAG ) )
+    {
+        /* read big variant */
+        collect_archive_content_big( fd, archive );
+    }
+#endif
+
+    close( fd );
+
+    return 0;
+}
+
+#endif  /* AIAMAG - RS6000 AIX */
+
+#endif  /* USE_FILEUNIX */

--- a/Patches/Boost/1.65.1/fileunix.c
+++ b/Patches/Boost/1.65.1/fileunix.c
@@ -40,6 +40,8 @@
 #include <stdio.h>
 #include <sys/stat.h>  /* needed for mkdir() */
 
+int file_collect_archive_content_( file_archive_info_t * const archive );
+
 #if defined( sun ) || defined( __sun ) || defined( linux )
 # include <unistd.h>  /* needed for read and close prototype */
 #endif

--- a/Patches/Boost/1.65.1/jam.c
+++ b/Patches/Boost/1.65.1/jam.c
@@ -1,0 +1,768 @@
+/*
+ * /+\
+ * +\   Copyright 1993-2002 Christopher Seiwald and Perforce Software, Inc.
+ * \+/
+ *
+ * This file is part of jam.
+ *
+ * License is hereby granted to use this software and distribute it freely, as
+ * long as this copyright notice is retained and modifications are clearly
+ * marked.
+ *
+ * ALL WARRANTIES ARE HEREBY DISCLAIMED.
+ */
+
+/* This file is ALSO:
+ * Copyright 2001-2004 David Abrahams.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+/*
+ * jam.c - make redux
+ *
+ * See Jam.html for usage information.
+ *
+ * These comments document the code.
+ *
+ * The top half of the code is structured such:
+ *
+ *                       jam
+ *                      / | \
+ *                 +---+  |  \
+ *                /       |   \
+ *         jamgram     option  \
+ *        /  |   \              \
+ *       /   |    \              \
+ *      /    |     \             |
+ *  scan     |     compile      make
+ *   |       |    /  | \       / |  \
+ *   |       |   /   |  \     /  |   \
+ *   |       |  /    |   \   /   |    \
+ * jambase parse     |   rules  search make1
+ *                   |           |      |   \
+ *                   |           |      |    \
+ *                   |           |      |     \
+ *               builtins    timestamp command execute
+ *                               |
+ *                               |
+ *                               |
+ *                             filesys
+ *
+ *
+ * The support routines are called by all of the above, but themselves are
+ * layered thus:
+ *
+ *                     variable|expand
+ *                      /      |   |
+ *                     /       |   |
+ *                    /        |   |
+ *                 lists       |   pathsys
+ *                    \        |
+ *                     \      hash
+ *                      \      |
+ *                       \     |
+ *                        \    |
+ *                         \   |
+ *                          \  |
+ *                         object
+ *
+ * Roughly, the modules are:
+ *
+ *  builtins.c - jam's built-in rules
+ *  command.c - maintain lists of commands
+ *  compile.c - compile parsed jam statements
+ *  exec*.c - execute a shell script on a specific OS
+ *  file*.c - scan directories and archives on a specific OS
+ *  hash.c - simple in-memory hashing routines
+ *  hdrmacro.c - handle header file parsing for filename macro definitions
+ *  headers.c - handle #includes in source files
+ *  jambase.c - compilable copy of Jambase
+ *  jamgram.y - jam grammar
+ *  lists.c - maintain lists of strings
+ *  make.c - bring a target up to date, once rules are in place
+ *  make1.c - execute command to bring targets up to date
+ *  object.c - string manipulation routines
+ *  option.c - command line option processing
+ *  parse.c - make and destroy parse trees as driven by the parser
+ *  path*.c - manipulate file names on a specific OS
+ *  hash.c - simple in-memory hashing routines
+ *  regexp.c - Henry Spencer's regexp
+ *  rules.c - access to RULEs, TARGETs, and ACTIONs
+ *  scan.c - the jam yacc scanner
+ *  search.c - find a target along $(SEARCH) or $(LOCATE)
+ *  timestamp.c - get the timestamp of a file or archive member
+ *  variable.c - handle jam multi-element variables
+ */
+
+
+#include "jam.h"
+#include "patchlevel.h"
+
+#include "builtins.h"
+#include "class.h"
+#include "compile.h"
+#include "constants.h"
+#include "debugger.h"
+#include "filesys.h"
+#include "function.h"
+#include "hcache.h"
+#include "lists.h"
+#include "make.h"
+#include "object.h"
+#include "option.h"
+#include "output.h"
+#include "parse.h"
+#include "cwd.h"
+#include "rules.h"
+#include "scan.h"
+#include "search.h"
+#include "strings.h"
+#include "timestamp.h"
+#include "variable.h"
+
+/* Macintosh is "special" */
+#ifdef OS_MAC
+# include <QuickDraw.h>
+#endif
+
+/* And UNIX for this. */
+#ifdef unix
+# include <sys/utsname.h>
+# include <signal.h>
+#endif
+
+struct globs globs =
+{
+    0,          /* noexec */
+    1,          /* jobs */
+    0,          /* quitquick */
+    0,          /* newestfirst */
+    0,          /* pipes action stdout and stderr merged to action output */
+#ifdef OS_MAC
+    { 0, 0 },   /* debug - suppress tracing output */
+#else
+    { 0, 1 },   /* debug ... */
+#endif
+    0,          /* output commands, not run them */
+    0,          /* action timeout */
+    0           /* maximum buffer size zero is all output */
+};
+
+/* Symbols to be defined as true for use in Jambase. */
+static char * othersyms[] = { OSMAJOR, OSMINOR, OSPLAT, JAMVERSYM, 0 };
+
+
+/* Known for sure:
+ *  mac needs arg_enviro
+ *  OS2 needs extern environ
+ */
+
+#ifdef OS_MAC
+# define use_environ arg_environ
+# ifdef MPW
+    QDGlobals qd;
+# endif
+#endif
+
+
+#ifdef OS_VMS
+# define use_environ arg_environ
+#endif
+
+
+/* on Win32-LCC */
+#if defined( OS_NT ) && defined( __LCC__ )
+# define use_environ _environ
+#endif
+
+#if defined( __MWERKS__)
+# define use_environ _environ
+    extern char * * _environ;
+#endif
+
+#ifndef use_environ
+# define use_environ environ
+# if !defined( __WATCOM__ ) && !defined( OS_OS2 ) && !defined( OS_NT )
+    extern char **environ;
+# endif
+#endif
+
+#if YYDEBUG != 0
+    extern int yydebug;
+#endif
+
+#ifndef NDEBUG
+static void run_unit_tests()
+{
+# if defined( USE_EXECNT )
+    extern void execnt_unit_test();
+    execnt_unit_test();
+# endif
+    string_unit_test();
+}
+#endif
+
+int anyhow = 0;
+
+#ifdef HAVE_PYTHON
+    extern PyObject * bjam_call         ( PyObject * self, PyObject * args );
+    extern PyObject * bjam_import_rule  ( PyObject * self, PyObject * args );
+    extern PyObject * bjam_define_action( PyObject * self, PyObject * args );
+    extern PyObject * bjam_variable     ( PyObject * self, PyObject * args );
+    extern PyObject * bjam_backtrace    ( PyObject * self, PyObject * args );
+    extern PyObject * bjam_caller       ( PyObject * self, PyObject * args );
+    int python_optimize = 1;  /* Set Python optimzation on by default */
+#endif
+
+void regex_done();
+
+char const * saved_argv0;
+
+static void usage( const char * progname )
+{
+	err_printf("\nusage: %s [ options ] targets...\n\n", progname);
+
+	err_printf("-a      Build all targets, even if they are current.\n");
+	err_printf("-dx     Set the debug level to x (0-13,console,mi).\n");
+	err_printf("-fx     Read x instead of Jambase.\n");
+	/* err_printf( "-g      Build from newest sources first.\n" ); */
+	err_printf("-jx     Run up to x shell commands concurrently.\n");
+	err_printf("-lx     Limit actions to x number of seconds after which they are stopped.\n");
+	err_printf("-mx     Maximum target output saved (kb), default is to save all output.\n");
+	err_printf("-n      Don't actually execute the updating actions.\n");
+	err_printf("-ox     Mirror all output to file x.\n");
+	err_printf("-px     x=0, pipes action stdout and stderr merged into action output.\n");
+	err_printf("-q      Quit quickly as soon as a target fails.\n");
+	err_printf("-sx=y   Set variable x=y, overriding environment.\n");
+	err_printf("-tx     Rebuild x, even if it is up-to-date.\n");
+	err_printf("-v      Print the version of jam and exit.\n");
+#ifdef HAVE_PYTHON
+	err_printf("-z      Disable Python Optimization and enable asserts\n");
+#endif
+	err_printf("--x     Option is ignored.\n\n");
+
+    exit( EXITBAD );
+}
+
+int main( int argc, char * * argv, char * * arg_environ )
+{
+    int                     n;
+    char                  * s;
+    struct bjam_option      optv[ N_OPTS ];
+    char            const * all = "all";
+    int                     status;
+    int                     arg_c = argc;
+    char          *       * arg_v = argv;
+    char            const * progname = argv[ 0 ];
+    module_t              * environ_module;
+    int                     is_debugger;
+
+    saved_argv0 = argv[ 0 ];
+
+    BJAM_MEM_INIT();
+
+#ifdef OS_MAC
+    InitGraf( &qd.thePort );
+#endif
+
+    cwd_init();
+
+#ifdef JAM_DEBUGGER
+
+    is_debugger = 0;
+    
+    if ( getoptions( argc - 1, argv + 1, "-:l:m:d:j:p:f:gs:t:ano:qv", optv ) < 0 )
+        usage( progname );
+
+    if ( s = getoptval( optv, 'd', 0 ) )
+    {
+        if ( strcmp( s, "mi" ) == 0 )
+        {
+            debug_interface = DEBUG_INTERFACE_MI;
+            is_debugger = 1;
+        }
+        else if ( strcmp( s, "console" ) == 0 )
+        {
+            debug_interface = DEBUG_INTERFACE_CONSOLE;
+            is_debugger = 1;
+        }
+    }
+
+#if NT
+
+    if ( argc >= 3 )
+    {
+        /* Check whether this instance is being run by the debugger. */
+        size_t opt_len = strlen( debugger_opt );
+        if ( strncmp( argv[ 1 ], debugger_opt, opt_len ) == 0 &&
+            strncmp( argv[ 2 ], debugger_opt, opt_len ) == 0 )
+        {
+            debug_init_handles( argv[ 1 ] + opt_len, argv[ 2 ] + opt_len );
+            /* Fix up argc/argv to hide the internal options */
+            arg_c = argc = (argc - 2);
+            argv[ 2 ] = argv[ 0 ];
+            arg_v = argv = (argv + 2);
+            debug_interface = DEBUG_INTERFACE_CHILD;
+        }
+    }
+
+    if ( is_debugger )
+    {
+        return debugger();
+    }
+
+#else
+
+    if ( is_debugger )
+    {
+        if ( setjmp( debug_child_data.jmp ) != 0 )
+        {
+            arg_c = argc = debug_child_data.argc;
+            arg_v = argv = (char * *)debug_child_data.argv;
+            debug_interface = DEBUG_INTERFACE_CHILD;
+        }
+        else
+        {
+            return debugger();
+        }
+    }
+
+#endif
+
+#endif
+
+    --argc;
+    ++argv;
+
+    #ifdef HAVE_PYTHON
+    #define OPTSTRING "-:l:m:d:j:p:f:gs:t:ano:qvz"
+    #else
+    #define OPTSTRING "-:l:m:d:j:p:f:gs:t:ano:qv"
+    #endif
+
+    if ( getoptions( argc, argv, OPTSTRING, optv ) < 0 )
+    {
+        usage( progname );
+    }
+
+    /* Version info. */
+    if ( ( s = getoptval( optv, 'v', 0 ) ) )
+    {
+        out_printf( "Boost.Jam  Version %s. %s.\n", VERSION, OSMINOR );
+        out_printf( "   Copyright 1993-2002 Christopher Seiwald and Perforce "
+            "Software, Inc.\n" );
+        out_printf( "   Copyright 2001 David Turner.\n" );
+        out_printf( "   Copyright 2001-2004 David Abrahams.\n" );
+        out_printf( "   Copyright 2002-2015 Rene Rivera.\n" );
+        out_printf( "   Copyright 2003-2015 Vladimir Prus.\n" );
+        return EXITOK;
+    }
+
+    /* Pick up interesting options. */
+    if ( ( s = getoptval( optv, 'n', 0 ) ) )
+    {
+        ++globs.noexec;
+        globs.debug[ 2 ] = 1;
+    }
+
+    if ( ( s = getoptval( optv, 'p', 0 ) ) )
+    {
+        /* Undocumented -p3 (acts like both -p1 -p2) means separate pipe action
+         * stdout and stderr.
+         */
+        globs.pipe_action = atoi( s );
+        if ( globs.pipe_action < 0 || 3 < globs.pipe_action )
+        {
+            err_printf( "Invalid pipe descriptor '%d', valid values are -p[0..3]."
+                "\n", globs.pipe_action );
+            exit( EXITBAD );
+        }
+    }
+
+    if ( ( s = getoptval( optv, 'q', 0 ) ) )
+        globs.quitquick = 1;
+
+    if ( ( s = getoptval( optv, 'a', 0 ) ) )
+        anyhow++;
+
+    if ( ( s = getoptval( optv, 'j', 0 ) ) )
+    {
+        globs.jobs = atoi( s );
+        if ( globs.jobs < 1 )
+        {
+            err_printf( "Invalid value for the '-j' option.\n" );
+            exit( EXITBAD );
+        }
+    }
+
+    if ( ( s = getoptval( optv, 'g', 0 ) ) )
+        globs.newestfirst = 1;
+
+    if ( ( s = getoptval( optv, 'l', 0 ) ) )
+        globs.timeout = atoi( s );
+
+    if ( ( s = getoptval( optv, 'm', 0 ) ) )
+        globs.max_buf = atoi( s ) * 1024;  /* convert to kb */
+
+    #ifdef HAVE_PYTHON
+    if ( ( s = getoptval( optv, 'z', 0 ) ) )
+        python_optimize = 0;  /* disable python optimization */
+    #endif
+
+    /* Turn on/off debugging */
+    for ( n = 0; ( s = getoptval( optv, 'd', n ) ); ++n )
+    {
+        int i;
+
+        /* First -d, turn off defaults. */
+        if ( !n )
+            for ( i = 0; i < DEBUG_MAX; ++i )
+                globs.debug[i] = 0;
+
+        i = atoi( s );
+
+        if ( ( i < 0 ) || ( i >= DEBUG_MAX ) )
+        {
+            out_printf( "Invalid debug level '%s'.\n", s );
+            continue;
+        }
+
+        /* n turns on levels 1-n. */
+        /* +n turns on level n. */
+        if ( *s == '+' )
+            globs.debug[ i ] = 1;
+        else while ( i )
+            globs.debug[ i-- ] = 1;
+    }
+
+    /* If an output file is specified, set globs.out to that. */
+    if ( ( s = getoptval( optv, 'o', 0 ) ) )
+    {
+        if ( !( globs.out = fopen( s, "w" ) ) )
+        {
+            err_printf( "Failed to write to '%s'\n", s );
+            exit( EXITBAD );
+        }
+        /* ++globs.noexec; */
+    }
+
+    constants_init();
+
+    {
+        PROFILE_ENTER( MAIN );
+
+#ifdef HAVE_PYTHON
+        {
+            PROFILE_ENTER( MAIN_PYTHON );
+            Py_OptimizeFlag = python_optimize;
+            Py_Initialize();
+            {
+                static PyMethodDef BjamMethods[] = {
+                    {"call", bjam_call, METH_VARARGS,
+                     "Call the specified bjam rule."},
+                    {"import_rule", bjam_import_rule, METH_VARARGS,
+                     "Imports Python callable to bjam."},
+                    {"define_action", bjam_define_action, METH_VARARGS,
+                     "Defines a command line action."},
+                    {"variable", bjam_variable, METH_VARARGS,
+                     "Obtains a variable from bjam's global module."},
+                    {"backtrace", bjam_backtrace, METH_VARARGS,
+                     "Returns bjam backtrace from the last call into Python."},
+                    {"caller", bjam_caller, METH_VARARGS,
+                     "Returns the module from which the last call into Python is made."},
+                    {NULL, NULL, 0, NULL}
+                };
+
+                Py_InitModule( "bjam", BjamMethods );
+            }
+            PROFILE_EXIT( MAIN_PYTHON );
+        }
+#endif
+
+#ifndef NDEBUG
+        run_unit_tests();
+#endif
+#if YYDEBUG != 0
+        if ( DEBUG_PARSE )
+            yydebug = 1;
+#endif
+
+        /* Set JAMDATE. */
+        {
+            timestamp current;
+            timestamp_current( &current );
+            var_set( root_module(), constant_JAMDATE, list_new( outf_time(
+                &current ) ), VAR_SET );
+        }
+
+        /* Set JAM_VERSION. */
+        var_set( root_module(), constant_JAM_VERSION,
+                 list_push_back( list_push_back( list_new(
+                   object_new( VERSION_MAJOR_SYM ) ),
+                   object_new( VERSION_MINOR_SYM ) ),
+                   object_new( VERSION_PATCH_SYM ) ),
+                   VAR_SET );
+
+        /* Set JAMUNAME. */
+#ifdef unix
+        {
+            struct utsname u;
+
+            if ( uname( &u ) >= 0 )
+            {
+                var_set( root_module(), constant_JAMUNAME,
+                         list_push_back(
+                             list_push_back(
+                                 list_push_back(
+                                     list_push_back(
+                                         list_new(
+                                            object_new( u.sysname ) ),
+                                         object_new( u.nodename ) ),
+                                     object_new( u.release ) ),
+                                 object_new( u.version ) ),
+                             object_new( u.machine ) ), VAR_SET );
+            }
+        }
+#endif  /* unix */
+
+        /* Set JAM_TIMESTAMP_RESOLUTION. */
+        {
+            timestamp fmt_resolution[ 1 ];
+            file_supported_fmt_resolution( fmt_resolution );
+            var_set( root_module(), constant_JAM_TIMESTAMP_RESOLUTION, list_new(
+                object_new( timestamp_timestr( fmt_resolution ) ) ), VAR_SET );
+        }
+
+        /* Load up environment variables. */
+
+        /* First into the global module, with splitting, for backward
+         * compatibility.
+         */
+        var_defines( root_module(), use_environ, 1 );
+
+        environ_module = bindmodule( constant_ENVIRON );
+        /* Then into .ENVIRON, without splitting. */
+        var_defines( environ_module, use_environ, 0 );
+
+        /*
+         * Jam defined variables OS & OSPLAT. We load them after environment, so
+         * that setting OS in environment does not change Jam's notion of the
+         * current platform.
+         */
+        var_defines( root_module(), othersyms, 1 );
+
+        /* Load up variables set on command line. */
+        for ( n = 0; ( s = getoptval( optv, 's', n ) ); ++n )
+        {
+            char * symv[ 2 ];
+            symv[ 0 ] = s;
+            symv[ 1 ] = 0;
+            var_defines( root_module(), symv, 1 );
+            var_defines( environ_module, symv, 0 );
+        }
+
+        /* Set the ARGV to reflect the complete list of arguments of invocation.
+         */
+        for ( n = 0; n < arg_c; ++n )
+            var_set( root_module(), constant_ARGV, list_new( object_new(
+                arg_v[ n ] ) ), VAR_APPEND );
+
+        /* Initialize built-in rules. */
+        load_builtins();
+
+        /* Add the targets in the command line to the update list. */
+        for ( n = 1; n < arg_c; ++n )
+        {
+            if ( arg_v[ n ][ 0 ] == '-' )
+            {
+                char * f = "-:l:d:j:f:gs:t:ano:qv";
+                for ( ; *f; ++f ) if ( *f == arg_v[ n ][ 1 ] ) break;
+                if ( ( f[ 1 ] == ':' ) && ( arg_v[ n ][ 2 ] == '\0' ) ) ++n;
+            }
+            else
+            {
+                OBJECT * const target = object_new( arg_v[ n ] );
+                mark_target_for_updating( target );
+                object_free( target );
+            }
+        }
+
+        if ( list_empty( targets_to_update() ) )
+            mark_target_for_updating( constant_all );
+
+        /* Parse ruleset. */
+        {
+            FRAME frame[ 1 ];
+            frame_init( frame );
+            for ( n = 0; ( s = getoptval( optv, 'f', n ) ); ++n )
+            {
+                OBJECT * const filename = object_new( s );
+                parse_file( filename, frame );
+                object_free( filename );
+            }
+
+            if ( !n )
+                parse_file( constant_plus, frame );
+        }
+
+        status = yyanyerrors();
+
+        /* Manually touch -t targets. */
+        for ( n = 0; ( s = getoptval( optv, 't', n ) ); ++n )
+        {
+            OBJECT * const target = object_new( s );
+            touch_target( target );
+            object_free( target );
+        }
+
+        /* The build system may set the PARALLELISM variable to override -j
+         * options.
+         */
+        {
+            LIST * const p = var_get( root_module(), constant_PARALLELISM );
+            if ( !list_empty( p ) )
+            {
+                int const j = atoi( object_str( list_front( p ) ) );
+                if ( j < 1 )
+                    out_printf( "Invalid value of PARALLELISM: %s.\n",
+                        object_str( list_front( p ) ) );
+                else
+                    globs.jobs = j;
+            }
+        }
+
+        /* KEEP_GOING overrides -q option. */
+        {
+            LIST * const p = var_get( root_module(), constant_KEEP_GOING );
+            if ( !list_empty( p ) )
+                globs.quitquick = atoi( object_str( list_front( p ) ) ) ? 0 : 1;
+        }
+
+        /* Now make target. */
+        {
+            PROFILE_ENTER( MAIN_MAKE );
+            LIST * const targets = targets_to_update();
+            if ( !list_empty( targets ) )
+                status |= make( targets, anyhow );
+            else
+                status = last_update_now_status;
+            PROFILE_EXIT( MAIN_MAKE );
+        }
+
+        PROFILE_EXIT( MAIN );
+    }
+
+    if ( DEBUG_PROFILE )
+        profile_dump();
+
+
+#ifdef OPT_HEADER_CACHE_EXT
+    hcache_done();
+#endif
+
+    clear_targets_to_update();
+
+    /* Widely scattered cleanup. */
+    property_set_done();
+    exec_done();
+    file_done();
+    rules_done();
+    timestamp_done();
+    search_done();
+    class_done();
+    modules_done();
+    regex_done();
+    cwd_done();
+    path_done();
+    function_done();
+    list_done();
+    constants_done();
+    object_done();
+
+    /* Close log out. */
+    if ( globs.out )
+        fclose( globs.out );
+
+#ifdef HAVE_PYTHON
+    Py_Finalize();
+#endif
+
+    BJAM_MEM_CLOSE();
+
+    return status ? EXITBAD : EXITOK;
+}
+
+
+/*
+ * executable_path()
+ */
+
+#if defined(_WIN32)
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+char * executable_path( char const * argv0 )
+{
+    char buf[ 1024 ];
+    DWORD const ret = GetModuleFileName( NULL, buf, sizeof( buf ) );
+    return ( !ret || ret == sizeof( buf ) ) ? NULL : strdup( buf );
+}
+#elif defined(__APPLE__)  /* Not tested */
+# include <mach-o/dyld.h>
+char *executable_path( char const * argv0 )
+{
+    char buf[ 1024 ];
+    uint32_t size = sizeof( buf );
+    return _NSGetExecutablePath( buf, &size ) ? NULL : strdup( buf );
+}
+#elif defined(sun) || defined(__sun)  /* Not tested */
+# include <stdlib.h>
+char * executable_path( char const * argv0 )
+{
+    const char * execname = getexecname();
+    return execname ? strdup( execname ) : NULL;
+}
+#elif defined(__FreeBSD__)
+# include <sys/sysctl.h>
+char * executable_path( char const * argv0 )
+{
+    int mib[ 4 ] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+    char buf[ 1024 ];
+    size_t size = sizeof( buf );
+    sysctl( mib, 4, buf, &size, NULL, 0 );
+    return ( !size || size == sizeof( buf ) ) ? NULL : strndup( buf, size );
+}
+#elif defined(__linux__)
+# include <unistd.h>
+char * executable_path( char const * argv0 )
+{
+    char buf[ 1024 ];
+    ssize_t const ret = readlink( "/proc/self/exe", buf, sizeof( buf ) );
+    return ( !ret || ret == sizeof( buf ) ) ? NULL : strndup( buf, ret );
+}
+#elif defined(OS_VMS)
+# include <unixlib.h>
+char * executable_path( char const * argv0 )
+{
+    char * vms_path = NULL;
+    char * posix_path = NULL;
+    char * p;
+
+    /* On VMS argv[0] shows absolute path to the image file.
+     * So, just remove VMS file version and translate path to POSIX-style.
+     */
+    vms_path = strdup( argv0 );
+    if ( vms_path && ( p = strchr( vms_path, ';') ) ) *p = '\0';
+    posix_path = decc$translate_vms( vms_path );
+    if ( vms_path ) free( vms_path );
+
+    return posix_path > 0 ? strdup( posix_path ) : NULL;
+}
+#else
+char * executable_path( char const * argv0 )
+{
+    /* If argv0 is an absolute path, assume it is the right absolute path. */
+    return argv0[ 0 ] == '/' ? strdup( argv0 ) : NULL;
+}
+#endif

--- a/Patches/Boost/1.65.1/jam.c
+++ b/Patches/Boost/1.65.1/jam.c
@@ -105,6 +105,7 @@
 #include "compile.h"
 #include "constants.h"
 #include "debugger.h"
+#include "execcmd.h"
 #include "filesys.h"
 #include "function.h"
 #include "hcache.h"

--- a/Patches/Boost/1.65.1/make.c
+++ b/Patches/Boost/1.65.1/make.c
@@ -1,0 +1,939 @@
+/*
+ * Copyright 1993, 1995 Christopher Seiwald.
+ *
+ * This file is part of Jam - see jam.c for Copyright information.
+ */
+
+/*  This file is ALSO:
+ *  Copyright 2001-2004 David Abrahams.
+ *  Distributed under the Boost Software License, Version 1.0.
+ *  (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+/*
+ * make.c - bring a target up to date, once rules are in place.
+ *
+ * This modules controls the execution of rules to bring a target and its
+ * dependencies up to date. It is invoked after the targets, rules, et. al.
+ * described in rules.h are created by the interpreting jam files.
+ *
+ * This file contains the main make() entry point and the first pass make0().
+ * The second pass, make1(), which actually does the command execution, is in
+ * make1.c.
+ *
+ * External routines:
+ *  make() - make a target, given its name
+ *
+ * Internal routines:
+ *  make0() - bind and scan everything to make a TARGET
+ *  make0sort() - reorder TARGETS chain by their time (newest to oldest)
+ */
+
+#include "jam.h"
+#include "make.h"
+
+#include "command.h"
+#ifdef OPT_HEADER_CACHE_EXT
+# include "hcache.h"
+#endif
+#include "headers.h"
+#include "lists.h"
+#include "object.h"
+#include "parse.h"
+#include "rules.h"
+#include "search.h"
+#include "timestamp.h"
+#include "variable.h"
+
+#include <assert.h>
+
+#ifndef max
+# define max(a,b) ((a)>(b)?(a):(b))
+#endif
+
+static TARGETS * make0sort( TARGETS * c );
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+    static void dependGraphOutput( TARGET * t, int depth );
+#endif
+
+static char const * target_fate[] =
+{
+    "init",     /* T_FATE_INIT     */
+    "making",   /* T_FATE_MAKING   */
+    "stable",   /* T_FATE_STABLE   */
+    "newer",    /* T_FATE_NEWER    */
+    "temp",     /* T_FATE_ISTMP    */
+    "touched",  /* T_FATE_TOUCHED  */
+    "rebuild",  /* T_FATE_REBUILD  */
+    "missing",  /* T_FATE_MISSING  */
+    "needtmp",  /* T_FATE_NEEDTMP  */
+    "old",      /* T_FATE_OUTDATED */
+    "update",   /* T_FATE_UPDATE   */
+    "nofind",   /* T_FATE_CANTFIND */
+    "nomake"    /* T_FATE_CANTMAKE */
+};
+
+static char const * target_bind[] =
+{
+    "unbound",
+    "missing",
+    "parents",
+    "exists",
+};
+
+#define spaces(x) ( "                    " + ( x > 20 ? 0 : 20-x ) )
+
+
+/*
+ * make() - make a target, given its name.
+ */
+
+int make( LIST * targets, int anyhow )
+{
+    COUNTS counts[ 1 ];
+    int status = 0;  /* 1 if anything fails */
+
+#ifdef OPT_HEADER_CACHE_EXT
+    hcache_init();
+#endif
+
+    memset( (char *)counts, 0, sizeof( *counts ) );
+
+    /* Make sure that the tables are set up correctly.
+     */
+    exec_init();
+
+    /* First bind all targets with LOCATE_TARGET setting. This is needed to
+     * correctly handle dependencies to generated headers.
+     */
+    bind_explicitly_located_targets();
+
+    {
+        LISTITER iter, end;
+        PROFILE_ENTER( MAKE_MAKE0 );
+        for ( iter = list_begin( targets ), end = list_end( targets ); iter != end; iter = list_next( iter ) )
+        {
+            TARGET * t = bindtarget( list_item( iter ) );
+            if ( t->fate == T_FATE_INIT )
+                make0( t, 0, 0, counts, anyhow, 0 );
+        }
+        PROFILE_EXIT( MAKE_MAKE0 );
+    }
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+    if ( DEBUG_GRAPH )
+    {
+        LISTITER iter, end;
+        for ( iter = list_begin( targets ), end = list_end( targets ); iter != end; iter = list_next( iter ) )
+           dependGraphOutput( bindtarget( list_item( iter ) ), 0 );
+    }
+#endif
+
+    if ( DEBUG_MAKE )
+    {
+        if ( counts->targets )
+            out_printf( "...found %d target%s...\n", counts->targets,
+                counts->targets > 1 ? "s" : "" );
+        if ( counts->temp )
+            out_printf( "...using %d temp target%s...\n", counts->temp,
+                counts->temp > 1 ? "s" : "" );
+        if ( counts->updating )
+            out_printf( "...updating %d target%s...\n", counts->updating,
+                counts->updating > 1 ? "s" : "" );
+        if ( counts->cantfind )
+            out_printf( "...can't find %d target%s...\n", counts->cantfind,
+                counts->cantfind > 1 ? "s" : "" );
+        if ( counts->cantmake )
+            out_printf( "...can't make %d target%s...\n", counts->cantmake,
+                counts->cantmake > 1 ? "s" : "" );
+    }
+
+    status = counts->cantfind || counts->cantmake;
+
+    {
+        PROFILE_ENTER( MAKE_MAKE1 );
+        status |= make1( targets );
+        PROFILE_EXIT( MAKE_MAKE1 );
+    }
+
+    return status;
+}
+
+
+/* Force any dependants of t that have already at least begun being visited by
+ * make0() to be updated.
+ */
+
+static void force_rebuilds( TARGET * t );
+
+static void update_dependants( TARGET * t )
+{
+    TARGETS * q;
+
+    for ( q = t->dependants; q; q = q->next )
+    {
+        TARGET * p = q->target;
+        char fate0 = p->fate;
+
+        /* If we have already at least begun visiting it and we are not already
+         * rebuilding it for other reasons.
+         */
+        if ( ( fate0 != T_FATE_INIT ) && ( fate0 < T_FATE_BUILD ) )
+        {
+            p->fate = T_FATE_UPDATE;
+
+            if ( DEBUG_FATE )
+            {
+                out_printf( "fate change  %s from %s to %s (as dependant of %s)\n",
+                        object_str( p->name ), target_fate[ (int) fate0 ], target_fate[ (int) p->fate ], object_str( t->name ) );
+            }
+
+            /* If we are done visiting it, go back and make sure its dependants
+             * get rebuilt.
+             */
+            if ( fate0 > T_FATE_MAKING )
+                update_dependants( p );
+        }
+    }
+    /* Make sure that rebuilds can be chained. */
+    force_rebuilds( t );
+}
+
+
+/*
+ * Make sure that all of t's rebuilds get rebuilt.
+ */
+
+static void force_rebuilds( TARGET * t )
+{
+    TARGETS * d;
+    for ( d = t->rebuilds; d; d = d->next )
+    {
+        TARGET * r = d->target;
+
+        /* If it is not already being rebuilt for other reasons. */
+        if ( r->fate < T_FATE_BUILD )
+        {
+            if ( DEBUG_FATE )
+                out_printf( "fate change  %s from %s to %s (by rebuild)\n",
+                        object_str( r->name ), target_fate[ (int) r->fate ], target_fate[ T_FATE_REBUILD ] );
+
+            /* Force rebuild it. */
+            r->fate = T_FATE_REBUILD;
+
+            /* And make sure its dependants are updated too. */
+            update_dependants( r );
+        }
+    }
+}
+
+
+int make0rescan( TARGET * t, TARGET * rescanning )
+{
+    int result = 0;
+    TARGETS * c;
+
+    /* Check whether we have already found a cycle. */
+    if ( target_scc( t ) == rescanning )
+        return 1;
+
+    /* If we have already visited this node, ignore it. */
+    if ( t->rescanning == rescanning )
+        return 0;
+
+    /* If t is already updated, ignore it. */
+    if ( t->scc_root == NULL && t->progress > T_MAKE_ACTIVE )
+        return 0;
+
+    t->rescanning = rescanning;
+    for ( c = t->depends; c; c = c->next )
+    {
+        TARGET * dependency = c->target;
+        /* Always start at the root of each new strongly connected component. */
+        if ( target_scc( dependency ) != target_scc( t ) )
+            dependency = target_scc( dependency );
+        result |= make0rescan( dependency, rescanning );
+
+        /* Make sure that we pick up the new include node. */
+        if ( c->target->includes == rescanning )
+            result = 1;
+    }
+    if ( result && t->scc_root == NULL )
+    {
+        t->scc_root = rescanning;
+        rescanning->depends = targetentry( rescanning->depends, t );
+    }
+    return result;
+}
+
+
+/*
+ * make0() - bind and scan everything to make a TARGET.
+ *
+ * Recursively binds a target, searches for #included headers, calls itself on
+ * those headers and any dependencies.
+ */
+
+void make0
+(
+    TARGET * t,
+    TARGET * p,       /* parent */
+    int      depth,   /* for display purposes */
+    COUNTS * counts,  /* for reporting */
+    int      anyhow,
+    TARGET * rescanning
+)  /* forcibly touch all (real) targets */
+{
+    TARGETS    * c;
+    TARGET     * ptime = t;
+    TARGET     * located_target = 0;
+    timestamp    last;
+    timestamp    leaf;
+    timestamp    hlast;
+    int          fate;
+    char const * flag = "";
+    SETTINGS   * s;
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+    int savedFate;
+    int oldTimeStamp;
+#endif
+
+    if ( DEBUG_MAKEPROG )
+        out_printf( "make\t--\t%s%s\n", spaces( depth ), object_str( t->name ) );
+
+    /*
+     * Step 1: Initialize.
+     */
+
+    if ( DEBUG_MAKEPROG )
+        out_printf( "make\t--\t%s%s\n", spaces( depth ), object_str( t->name ) );
+
+    t->fate = T_FATE_MAKING;
+    t->depth = depth;
+
+    /*
+     * Step 2: Under the influence of "on target" variables, bind the target and
+     * search for headers.
+     */
+
+    /* Step 2a: Set "on target" variables. */
+    s = copysettings( t->settings );
+    pushsettings( root_module(), s );
+
+    /* Step 2b: Find and timestamp the target file (if it is a file). */
+    if ( ( t->binding == T_BIND_UNBOUND ) && !( t->flags & T_FLAG_NOTFILE ) )
+    {
+        OBJECT * another_target;
+        object_free( t->boundname );
+        t->boundname = search( t->name, &t->time, &another_target,
+            t->flags & T_FLAG_ISFILE );
+        /* If it was detected that this target refers to an already existing and
+         * bound target, we add a dependency so that every target depending on
+         * us will depend on that other target as well.
+         */
+        if ( another_target )
+            located_target = bindtarget( another_target );
+
+        t->binding = timestamp_empty( &t->time )
+            ? T_BIND_MISSING
+            : T_BIND_EXISTS;
+    }
+
+    /* INTERNAL, NOTFILE header nodes have the time of their parents. */
+    if ( p && ( t->flags & T_FLAG_INTERNAL ) )
+        ptime = p;
+
+    /* If temp file does not exist but parent does, use parent. */
+    if ( p && ( t->flags & T_FLAG_TEMP ) &&
+        ( t->binding == T_BIND_MISSING ) &&
+        ( p->binding != T_BIND_MISSING ) )
+    {
+        t->binding = T_BIND_PARENTS;
+        ptime = p;
+    }
+
+#ifdef OPT_SEMAPHORE
+    {
+        LIST * var = var_get( root_module(), constant_JAM_SEMAPHORE );
+        if ( !list_empty( var ) )
+        {
+            TARGET * const semaphore = bindtarget( list_front( var ) );
+            semaphore->progress = T_MAKE_SEMAPHORE;
+            t->semaphore = semaphore;
+        }
+    }
+#endif
+
+    /* Step 2c: If its a file, search for headers. */
+    if ( t->binding == T_BIND_EXISTS )
+        headers( t );
+
+    /* Step 2d: reset "on target" variables. */
+    popsettings( root_module(), s );
+    freesettings( s );
+
+    /*
+     * Pause for a little progress reporting.
+     */
+
+    if ( DEBUG_BIND )
+    {
+        if ( !object_equal( t->name, t->boundname ) )
+            out_printf( "bind\t--\t%s%s: %s\n", spaces( depth ),
+                object_str( t->name ), object_str( t->boundname ) );
+
+        switch ( t->binding )
+        {
+        case T_BIND_UNBOUND:
+        case T_BIND_MISSING:
+        case T_BIND_PARENTS:
+            out_printf( "time\t--\t%s%s: %s\n", spaces( depth ),
+                object_str( t->name ), target_bind[ (int)t->binding ] );
+            break;
+
+        case T_BIND_EXISTS:
+            out_printf( "time\t--\t%s%s: %s\n", spaces( depth ),
+                object_str( t->name ), timestamp_str( &t->time ) );
+            break;
+        }
+    }
+
+    /*
+     * Step 3: Recursively make0() dependencies & headers.
+     */
+
+    /* Step 3a: Recursively make0() dependencies. */
+    for ( c = t->depends; c; c = c->next )
+    {
+        int const internal = t->flags & T_FLAG_INTERNAL;
+
+        /* Warn about circular deps, except for includes, which include each
+         * other alot.
+         */
+        if ( c->target->fate == T_FATE_INIT )
+            make0( c->target, ptime, depth + 1, counts, anyhow, rescanning );
+        else if ( c->target->fate == T_FATE_MAKING && !internal )
+            out_printf( "warning: %s depends on itself\n", object_str(
+                c->target->name ) );
+        else if ( c->target->fate != T_FATE_MAKING && rescanning )
+            make0rescan( c->target, rescanning );
+        if ( rescanning && c->target->includes && c->target->includes->fate !=
+            T_FATE_MAKING )
+            make0rescan( target_scc( c->target->includes ), rescanning );
+    }
+
+    if ( located_target )
+    {
+        if ( located_target->fate == T_FATE_INIT )
+            make0( located_target, ptime, depth + 1, counts, anyhow, rescanning
+                );
+        else if ( located_target->fate != T_FATE_MAKING && rescanning )
+            make0rescan( located_target, rescanning );
+    }
+
+    /* Step 3b: Recursively make0() internal includes node. */
+    if ( t->includes )
+        make0( t->includes, p, depth + 1, counts, anyhow, rescanning );
+
+    /* Step 3c: Add dependencies' includes to our direct dependencies. */
+    {
+        TARGETS * incs = 0;
+        for ( c = t->depends; c; c = c->next )
+            if ( c->target->includes )
+                incs = targetentry( incs, c->target->includes );
+        t->depends = targetchain( t->depends, incs );
+    }
+
+    if ( located_target )
+        t->depends = targetentry( t->depends, located_target );
+
+    /* Step 3d: Detect cycles. */
+    {
+        int cycle_depth = depth;
+        for ( c = t->depends; c; c = c->next )
+        {
+            TARGET * scc_root = target_scc( c->target );
+            if ( scc_root->fate == T_FATE_MAKING &&
+                ( !scc_root->includes ||
+                  scc_root->includes->fate != T_FATE_MAKING ) )
+            {
+                if ( scc_root->depth < cycle_depth )
+                {
+                    cycle_depth = scc_root->depth;
+                    t->scc_root = scc_root;
+                }
+            }
+        }
+    }
+
+    /*
+     * Step 4: Compute time & fate.
+     */
+
+    /* Step 4a: Pick up dependencies' time and fate. */
+    timestamp_clear( &last );
+    timestamp_clear( &leaf );
+    fate = T_FATE_STABLE;
+    for ( c = t->depends; c; c = c->next )
+    {
+        /* If we are in a different strongly connected component, pull
+         * timestamps from the root.
+         */
+        if ( c->target->scc_root )
+        {
+            TARGET * const scc_root = target_scc( c->target );
+            if ( scc_root != t->scc_root )
+            {
+                timestamp_max( &c->target->leaf, &c->target->leaf,
+                    &scc_root->leaf );
+                timestamp_max( &c->target->time, &c->target->time,
+                    &scc_root->time );
+                c->target->fate = max( c->target->fate, scc_root->fate );
+            }
+        }
+
+        /* If LEAVES has been applied, we only heed the timestamps of the leaf
+         * source nodes.
+         */
+        timestamp_max( &leaf, &leaf, &c->target->leaf );
+        if ( t->flags & T_FLAG_LEAVES )
+        {
+            timestamp_copy( &last, &leaf );
+            continue;
+        }
+        timestamp_max( &last, &last, &c->target->time );
+        fate = max( fate, c->target->fate );
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+        if ( DEBUG_FATE )
+            if ( fate < c->target->fate )
+                out_printf( "fate change %s from %s to %s by dependency %s\n",
+                    object_str( t->name ), target_fate[ (int)fate ],
+                    target_fate[ (int)c->target->fate ], object_str(
+                    c->target->name ) );
+#endif
+    }
+
+    /* Step 4b: Pick up included headers time. */
+
+    /*
+     * If a header is newer than a temp source that includes it, the temp source
+     * will need building.
+     */
+    if ( t->includes )
+        timestamp_copy( &hlast, &t->includes->time );
+    else
+        timestamp_clear( &hlast );
+
+    /* Step 4c: handle NOUPDATE oddity.
+     *
+     * If a NOUPDATE file exists, mark it as having eternally old dependencies.
+     * Do not inherit our fate from our dependencies. Decide fate based only on
+     * other flags and our binding (done later).
+     */
+    if ( t->flags & T_FLAG_NOUPDATE )
+    {
+#ifdef OPT_GRAPH_DEBUG_EXT
+        if ( DEBUG_FATE )
+            if ( fate != T_FATE_STABLE )
+                out_printf( "fate change  %s back to stable, NOUPDATE.\n",
+                    object_str( t->name ) );
+#endif
+
+        timestamp_clear( &last );
+        timestamp_clear( &t->time );
+
+        /* Do not inherit our fate from our dependencies. Decide fate based only
+         * upon other flags and our binding (done later).
+         */
+        fate = T_FATE_STABLE;
+    }
+
+    /* Step 4d: Determine fate: rebuild target or what? */
+
+    /*
+        In English:
+        If can not find or make child, can not make target.
+        If children changed, make target.
+        If target missing, make it.
+        If children newer, make target.
+        If temp's children newer than parent, make temp.
+        If temp's headers newer than parent, make temp.
+        If deliberately touched, make it.
+        If up-to-date temp file present, use it.
+        If target newer than non-notfile parent, mark target newer.
+        Otherwise, stable!
+
+        Note this block runs from least to most stable: as we make it further
+        down the list, the target's fate gets more stable.
+    */
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+    savedFate = fate;
+    oldTimeStamp = 0;
+#endif
+
+    if ( fate >= T_FATE_BROKEN )
+    {
+        fate = T_FATE_CANTMAKE;
+    }
+    else if ( fate >= T_FATE_SPOIL )
+    {
+        fate = T_FATE_UPDATE;
+    }
+    else if ( t->binding == T_BIND_MISSING )
+    {
+        fate = T_FATE_MISSING;
+    }
+    else if ( t->binding == T_BIND_EXISTS && timestamp_cmp( &last, &t->time ) >
+        0 )
+    {
+#ifdef OPT_GRAPH_DEBUG_EXT
+        oldTimeStamp = 1;
+#endif
+        fate = T_FATE_OUTDATED;
+    }
+    else if ( t->binding == T_BIND_PARENTS && timestamp_cmp( &last, &p->time ) >
+        0 )
+    {
+#ifdef OPT_GRAPH_DEBUG_EXT
+        oldTimeStamp = 1;
+#endif
+        fate = T_FATE_NEEDTMP;
+    }
+    else if ( t->binding == T_BIND_PARENTS && timestamp_cmp( &hlast, &p->time )
+        > 0 )
+    {
+        fate = T_FATE_NEEDTMP;
+    }
+    else if ( t->flags & T_FLAG_TOUCHED )
+    {
+        fate = T_FATE_TOUCHED;
+    }
+    else if ( anyhow && !( t->flags & T_FLAG_NOUPDATE ) )
+    {
+        fate = T_FATE_TOUCHED;
+    }
+    else if ( t->binding == T_BIND_EXISTS && ( t->flags & T_FLAG_TEMP ) )
+    {
+        fate = T_FATE_ISTMP;
+    }
+    else if ( t->binding == T_BIND_EXISTS && p && p->binding != T_BIND_UNBOUND
+        && timestamp_cmp( &t->time, &p->time ) > 0 )
+    {
+#ifdef OPT_GRAPH_DEBUG_EXT
+        oldTimeStamp = 1;
+#endif
+        fate = T_FATE_NEWER;
+    }
+    else
+    {
+        fate = T_FATE_STABLE;
+    }
+#ifdef OPT_GRAPH_DEBUG_EXT
+    if ( DEBUG_FATE && ( fate != savedFate ) )
+	{
+        if ( savedFate == T_FATE_STABLE )
+            out_printf( "fate change  %s set to %s%s\n", object_str( t->name ),
+                target_fate[ fate ], oldTimeStamp ? " (by timestamp)" : "" );
+        else
+            out_printf( "fate change  %s from %s to %s%s\n", object_str( t->name ),
+                target_fate[ savedFate ], target_fate[ fate ], oldTimeStamp ?
+                " (by timestamp)" : "" );
+	}
+#endif
+
+    /* Step 4e: Handle missing files. */
+    /* If it is missing and there are no actions to create it, boom. */
+    /* If we can not make a target we do not care about it, okay. */
+    /* We could insist that there are updating actions for all missing */
+    /* files, but if they have dependencies we just pretend it is a NOTFILE. */
+
+    if ( ( fate == T_FATE_MISSING ) && !t->actions && !t->depends )
+    {
+        if ( t->flags & T_FLAG_NOCARE )
+        {
+#ifdef OPT_GRAPH_DEBUG_EXT
+            if ( DEBUG_FATE )
+                out_printf( "fate change %s to STABLE from %s, "
+                    "no actions, no dependencies and do not care\n",
+                    object_str( t->name ), target_fate[ fate ] );
+#endif
+            fate = T_FATE_STABLE;
+        }
+        else
+        {
+            out_printf( "don't know how to make %s\n", object_str( t->name ) );
+            fate = T_FATE_CANTFIND;
+        }
+    }
+
+    /* Step 4f: Propagate dependencies' time & fate. */
+    /* Set leaf time to be our time only if this is a leaf. */
+
+    timestamp_max( &t->time, &t->time, &last );
+    timestamp_copy( &t->leaf, timestamp_empty( &leaf ) ? &t->time : &leaf );
+    /* This target's fate may have been updated by virtue of following some
+     * target's rebuilds list, so only allow it to be increased to the fate we
+     * have calculated. Otherwise, grab its new fate.
+     */
+    if ( fate > t->fate )
+        t->fate = fate;
+    else
+        fate = t->fate;
+
+    /*
+     * Step 4g: If this target needs to be built, make0 all targets
+     * that are updated by the same actions used to update this target.
+     * These have already been marked as REBUILDS, and make1 has
+     * special handling for them.  We just need to make sure that
+     * they get make0ed.
+     */
+    if ( ( fate >= T_FATE_BUILD ) && ( fate < T_FATE_BROKEN ) )
+    {
+        ACTIONS * a;
+        TARGETS * c;
+        for ( a = t->actions; a; a = a->next )
+        {
+            for ( c = a->action->targets; c; c = c->next )
+            {
+                if ( c->target->fate == T_FATE_INIT )
+                {
+                    make0( c->target, ptime, depth + 1, counts, anyhow, rescanning );
+                }
+            }
+        }
+    }
+
+    /* Step 4h: If this target needs to be built, force rebuild everything in
+     * its rebuilds list.
+     */
+    if ( ( fate >= T_FATE_BUILD ) && ( fate < T_FATE_BROKEN ) )
+        force_rebuilds( t );
+
+    /*
+     * Step 5: Sort dependencies by their update time.
+     */
+
+    if ( globs.newestfirst )
+        t->depends = make0sort( t->depends );
+
+    /*
+     * Step 6: A little harmless tabulating for tracing purposes.
+     */
+
+    /* Do not count or report interal includes nodes. */
+    if ( t->flags & T_FLAG_INTERNAL )
+        return;
+
+    if ( counts )
+    {
+#ifdef OPT_IMPROVED_PATIENCE_EXT
+        ++counts->targets;
+#else
+        if ( !( ++counts->targets % 1000 ) && DEBUG_MAKE )
+        {
+            out_printf( "...patience...\n" );
+            out_flush();
+        }
+#endif
+
+        if ( fate == T_FATE_ISTMP )
+            ++counts->temp;
+        else if ( fate == T_FATE_CANTFIND )
+            ++counts->cantfind;
+        else if ( ( fate == T_FATE_CANTMAKE ) && t->actions )
+            ++counts->cantmake;
+        else if ( ( fate >= T_FATE_BUILD ) && ( fate < T_FATE_BROKEN ) &&
+            t->actions )
+            ++counts->updating;
+    }
+
+    if ( !( t->flags & T_FLAG_NOTFILE ) && ( fate >= T_FATE_SPOIL ) )
+        flag = "+";
+    else if ( t->binding == T_BIND_EXISTS && p && timestamp_cmp( &t->time,
+        &p->time ) > 0 )
+        flag = "*";
+
+    if ( DEBUG_MAKEPROG )
+        out_printf( "made%s\t%s\t%s%s\n", flag, target_fate[ (int)t->fate ],
+            spaces( depth ), object_str( t->name ) );
+}
+
+
+#ifdef OPT_GRAPH_DEBUG_EXT
+
+static char const * target_name( TARGET * t )
+{
+    static char buf[ 1000 ];
+    if ( t->flags & T_FLAG_INTERNAL )
+    {
+        sprintf( buf, "%s (internal node)", object_str( t->name ) );
+        return buf;
+    }
+    return object_str( t->name );
+}
+
+
+/*
+ * dependGraphOutput() - output the DG after make0 has run.
+ */
+
+static void dependGraphOutput( TARGET * t, int depth )
+{
+    TARGETS * c;
+
+    if ( ( t->flags & T_FLAG_VISITED ) || !t->name || !t->boundname )
+        return;
+
+    t->flags |= T_FLAG_VISITED;
+
+    switch ( t->fate )
+    {
+        case T_FATE_TOUCHED:
+        case T_FATE_MISSING:
+        case T_FATE_OUTDATED:
+        case T_FATE_UPDATE:
+            out_printf( "->%s%2d Name: %s\n", spaces( depth ), depth, target_name( t
+                ) );
+            break;
+        default:
+            out_printf( "  %s%2d Name: %s\n", spaces( depth ), depth, target_name( t
+                ) );
+            break;
+    }
+
+    if ( !object_equal( t->name, t->boundname ) )
+        out_printf( "  %s    Loc: %s\n", spaces( depth ), object_str( t->boundname )
+            );
+
+    switch ( t->fate )
+    {
+    case T_FATE_STABLE:
+        out_printf( "  %s       : Stable\n", spaces( depth ) );
+        break;
+    case T_FATE_NEWER:
+        out_printf( "  %s       : Newer\n", spaces( depth ) );
+        break;
+    case T_FATE_ISTMP:
+        out_printf( "  %s       : Up to date temp file\n", spaces( depth ) );
+        break;
+    case T_FATE_NEEDTMP:
+        out_printf( "  %s       : Temporary file, to be updated\n", spaces( depth )
+            );
+        break;
+    case T_FATE_TOUCHED:
+        out_printf( "  %s       : Been touched, updating it\n", spaces( depth ) );
+        break;
+    case T_FATE_MISSING:
+        out_printf( "  %s       : Missing, creating it\n", spaces( depth ) );
+        break;
+    case T_FATE_OUTDATED:
+        out_printf( "  %s       : Outdated, updating it\n", spaces( depth ) );
+        break;
+    case T_FATE_REBUILD:
+        out_printf( "  %s       : Rebuild, updating it\n", spaces( depth ) );
+        break;
+    case T_FATE_UPDATE:
+        out_printf( "  %s       : Updating it\n", spaces( depth ) );
+        break;
+    case T_FATE_CANTFIND:
+        out_printf( "  %s       : Can not find it\n", spaces( depth ) );
+        break;
+    case T_FATE_CANTMAKE:
+        out_printf( "  %s       : Can make it\n", spaces( depth ) );
+        break;
+    }
+
+    if ( t->flags & ~T_FLAG_VISITED )
+    {
+        out_printf( "  %s       : ", spaces( depth ) );
+        if ( t->flags & T_FLAG_TEMP     ) out_printf( "TEMPORARY " );
+        if ( t->flags & T_FLAG_NOCARE   ) out_printf( "NOCARE "    );
+        if ( t->flags & T_FLAG_NOTFILE  ) out_printf( "NOTFILE "   );
+        if ( t->flags & T_FLAG_TOUCHED  ) out_printf( "TOUCHED "   );
+        if ( t->flags & T_FLAG_LEAVES   ) out_printf( "LEAVES "    );
+        if ( t->flags & T_FLAG_NOUPDATE ) out_printf( "NOUPDATE "  );
+        out_printf( "\n" );
+    }
+
+    for ( c = t->depends; c; c = c->next )
+    {
+        out_printf( "  %s       : Depends on %s (%s)", spaces( depth ),
+           target_name( c->target ), target_fate[ (int)c->target->fate ] );
+        if ( !timestamp_cmp( &c->target->time, &t->time ) )
+            out_printf( " (max time)");
+        out_printf( "\n" );
+    }
+
+    for ( c = t->depends; c; c = c->next )
+        dependGraphOutput( c->target, depth + 1 );
+}
+#endif
+
+
+/*
+ * make0sort() - reorder TARGETS chain by their time (newest to oldest).
+ *
+ * We walk chain, taking each item and inserting it on the sorted result, with
+ * newest items at the front. This involves updating each of the TARGETS'
+ * c->next and c->tail. Note that we make c->tail a valid prev pointer for every
+ * entry. Normally, it is only valid at the head, where prev == tail. Note also
+ * that while tail is a loop, next ends at the end of the chain.
+ */
+
+static TARGETS * make0sort( TARGETS * chain )
+{
+    PROFILE_ENTER( MAKE_MAKE0SORT );
+
+    TARGETS * result = 0;
+
+    /* Walk the current target list. */
+    while ( chain )
+    {
+        TARGETS * c = chain;
+        TARGETS * s = result;
+
+        chain = chain->next;
+
+        /* Find point s in result for c. */
+        while ( s && timestamp_cmp( &s->target->time, &c->target->time ) > 0 )
+            s = s->next;
+
+        /* Insert c in front of s (might be 0). */
+        c->next = s;                           /* good even if s = 0       */
+        if ( result == s ) result = c;         /* new head of chain?       */
+        if ( !s ) s = result;                  /* wrap to ensure a next    */
+        if ( result != c ) s->tail->next = c;  /* not head? be prev's next */
+        c->tail = s->tail;                     /* take on next's prev      */
+        s->tail = c;                           /* make next's prev us      */
+    }
+
+    PROFILE_EXIT( MAKE_MAKE0SORT );
+    return result;
+}
+
+
+static LIST * targets_to_update_ = L0;
+
+
+void mark_target_for_updating( OBJECT * target )
+{
+    targets_to_update_ = list_push_back( targets_to_update_, object_copy(
+        target ) );
+}
+
+
+LIST * targets_to_update()
+{
+    return targets_to_update_;
+}
+
+
+void clear_targets_to_update()
+{
+    list_free( targets_to_update_ );
+    targets_to_update_ = L0;
+}

--- a/Patches/Boost/1.65.1/make.c
+++ b/Patches/Boost/1.65.1/make.c
@@ -36,8 +36,10 @@
 #ifdef OPT_HEADER_CACHE_EXT
 # include "hcache.h"
 #endif
+#include "execcmd.h"
 #include "headers.h"
 #include "lists.h"
+#include "output.h"
 #include "object.h"
 #include "parse.h"
 #include "rules.h"

--- a/Patches/Boost/1.65.1/path.c
+++ b/Patches/Boost/1.65.1/path.c
@@ -1,0 +1,25 @@
+/* Copyright Vladimir Prus 2003.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include "../constants.h"
+#include "../frames.h"
+#include "../lists.h"
+#include "../native.h"
+#include "../timestamp.h"
+
+
+LIST * path_exists( FRAME * frame, int flags )
+{
+    return file_query( list_front( lol_get( frame->args, 0 ) ) ) ?
+        list_new( object_copy( constant_true ) ) : L0;
+}
+
+
+void init_path()
+{
+    char const * args[] = { "location", 0 };
+    declare_native_rule( "path", "exists", args, path_exists, 1 );
+}

--- a/Patches/Boost/1.65.1/path.c
+++ b/Patches/Boost/1.65.1/path.c
@@ -5,6 +5,7 @@
  */
 
 #include "../constants.h"
+#include "../filesys.h"
 #include "../frames.h"
 #include "../lists.h"
 #include "../native.h"

--- a/Patches/Boost/Common.cmake
+++ b/Patches/Boost/Common.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.3.0)
 
 # Retrieve the list of CMAKE variables
 include("${CMAKE_VARS_FILE}")


### PR DESCRIPTION
Boost's b2 utilities is missing a ton of headers which are causing implicit-function errors. It's started showing up in darwin, Apple clang version 12.0.0.

The patch is useful for all distributions though since the problem is likely to show up in more places as compliers get more strict.