### PR TITLE
Patch caffes framework path

### DIFF
--- a/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/Patch.cmake
+++ b/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/Patch.cmake
@@ -4,7 +4,7 @@ if(WIN32)
 elseif(APPLE)
   # Add more general paths to the Frameworks path to FindVecLib
   file(COPY
-    ${Caffe_patch}/Modules/FindvecLib.cmake
+    ${Caffe_patch}/cmake/Modules/FindvecLib.cmake
     DESTINATION
     ${Caffe_source}/cmake/Modules
     )

--- a/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/Patch.cmake
+++ b/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/Patch.cmake
@@ -1,6 +1,13 @@
 # This patch is targeted at non-windows systems
 if(WIN32)
   message(FATAL_ERROR "This caffe patch is only for non-windows")
+elseif(APPLE)
+  # Add more general paths to the Frameworks path to FindVecLib
+  file(COPY
+    ${Caffe_patch}/Modules/FindvecLib.cmake
+    DESTINATION
+    ${Caffe_source}/cmake/Modules
+    )
 else()
   file(COPY
     ${Caffe_patch}/Dependencies.cmake

--- a/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/cmake/Modules/FindvecLib.cmake
+++ b/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/cmake/Modules/FindvecLib.cmake
@@ -1,0 +1,35 @@
+# Find the vecLib libraries as part of Accelerate.framework or as standalon framework
+#
+# The following are set after configuration is done:
+#  VECLIB_FOUND
+#  vecLib_INCLUDE_DIR
+#  vecLib_LINKER_LIBS
+
+
+if(NOT APPLE)
+  return()
+endif()
+
+set(__veclib_include_suffix "Frameworks/vecLib.framework/Versions/Current/Headers")
+
+find_path(vecLib_INCLUDE_DIR vecLib.h
+          DOC "vecLib include directory"
+          PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
+                /System/Library/${__veclib_include_suffix}
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+          NO_DEFAULT_PATH)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(vecLib DEFAULT_MSG vecLib_INCLUDE_DIR)
+
+if(VECLIB_FOUND)
+  if(vecLib_INCLUDE_DIR MATCHES "^/System/Library/Frameworks/vecLib.framework.*")
+    set(vecLib_LINKER_LIBS -lcblas "-framework vecLib")
+    message(STATUS "Found standalone vecLib.framework")
+  else()
+    set(vecLib_LINKER_LIBS -lcblas "-framework Accelerate")
+    message(STATUS "Found vecLib as part of Accelerate.framework")
+  endif()
+
+  mark_as_advanced(vecLib_INCLUDE_DIR)
+endif()

--- a/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/cmake/Modules/FindvecLib.cmake
+++ b/Patches/Caffe/7f5cea3b2986a7d2c913b716eb524c27b6b2ba7b/cmake/Modules/FindvecLib.cmake
@@ -17,6 +17,7 @@ find_path(vecLib_INCLUDE_DIR vecLib.h
           PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
                 /System/Library/${__veclib_include_suffix}
                 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
           NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
@@ -1,6 +1,13 @@
 # This patch is targeted at non-windows systems
 if(WIN32)
   message(FATAL_ERROR "This caffe patch is only for non-windows")
+elseif(APPLE)
+  # Add more general paths to the Frameworks path to FindVecLib
+  file(COPY
+    ${Caffe_patch}/Modules/FindvecLib.cmake
+    DESTINATION
+    ${Caffe_source}/cmake/Modules
+    )
 else()
   file(COPY ${Caffe_Segnet_patch}/cmake/Dependencies.cmake
        DESTINATION ${Caffe_Segnet_source}/cmake/ )

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/Patch.cmake
@@ -4,9 +4,9 @@ if(WIN32)
 elseif(APPLE)
   # Add more general paths to the Frameworks path to FindVecLib
   file(COPY
-    ${Caffe_patch}/Modules/FindvecLib.cmake
+    ${Caffe_Segnet_patch}/cmake/Modules/FindvecLib.cmake
     DESTINATION
-    ${Caffe_source}/cmake/Modules
+    ${Caffe_Segnet_source}/cmake/Modules
     )
 else()
   file(COPY ${Caffe_Segnet_patch}/cmake/Dependencies.cmake

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Modules/FindvecLib.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Modules/FindvecLib.cmake
@@ -1,0 +1,35 @@
+# Find the vecLib libraries as part of Accelerate.framework or as standalon framework
+#
+# The following are set after configuration is done:
+#  VECLIB_FOUND
+#  vecLib_INCLUDE_DIR
+#  vecLib_LINKER_LIBS
+
+
+if(NOT APPLE)
+  return()
+endif()
+
+set(__veclib_include_suffix "Frameworks/vecLib.framework/Versions/Current/Headers")
+
+find_path(vecLib_INCLUDE_DIR vecLib.h
+          DOC "vecLib include directory"
+          PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
+                /System/Library/${__veclib_include_suffix}
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+          NO_DEFAULT_PATH)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(vecLib DEFAULT_MSG vecLib_INCLUDE_DIR)
+
+if(VECLIB_FOUND)
+  if(vecLib_INCLUDE_DIR MATCHES "^/System/Library/Frameworks/vecLib.framework.*")
+    set(vecLib_LINKER_LIBS -lcblas "-framework vecLib")
+    message(STATUS "Found standalone vecLib.framework")
+  else()
+    set(vecLib_LINKER_LIBS -lcblas "-framework Accelerate")
+    message(STATUS "Found vecLib as part of Accelerate.framework")
+  endif()
+
+  mark_as_advanced(vecLib_INCLUDE_DIR)
+endif()

--- a/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Modules/FindvecLib.cmake
+++ b/Patches/Caffe_Segnet/abcf30dca449245e101bf4ced519f716177f0885/cmake/Modules/FindvecLib.cmake
@@ -17,6 +17,7 @@ find_path(vecLib_INCLUDE_DIR vecLib.h
           PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
                 /System/Library/${__veclib_include_suffix}
                 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
           NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This PR provide a more general path the Apple Frameworks so it can find vecLib. The previous FindvecLib passed in a very specific MacOS version, 10.9.sdk. I've added the path with MacOSX.sdk which points to the correct system.