### PR TITLE
Move the nasm args into the already patched CMakeList.txt for simd

### DIFF
--- a/CMake/External_libjpeg-turbo.cmake
+++ b/CMake/External_libjpeg-turbo.cmake
@@ -19,7 +19,7 @@ if(WIN32)
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
       -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
       -DCMAKE_INSTALL_PREFIX:PATH=${fletch_BUILD_INSTALL_PREFIX}
-      -DNASM:FILEPATH=${fletch_YASM} -g vc8
+      -DNASM:FILEPATH=${fletch_YASM}
     )
 
   ExternalProject_Add_Step(libjpeg-turbo fixup-install

--- a/Patches/libjpeg-turbo/simd/CMakeLists.txt
+++ b/Patches/libjpeg-turbo/simd/CMakeLists.txt
@@ -18,10 +18,10 @@ set(NAFLAGS ${NAFLAGS} -I${CMAKE_SOURCE_DIR}/win/ -I${CMAKE_CURRENT_SOURCE_DIR}/
 # when building in the IDE, it's clearly not critical for now.
 # This only works if building from the command line.  There is currently no way
 # to set a variable's value based on the build type when using the MSVC IDE.
-#if(CMAKE_BUILD_TYPE STREQUAL "Debug"
-#  OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-#  set(NAFLAGS ${NAFLAGS} -g)
-#endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug"
+ OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+ set(NAFLAGS ${NAFLAGS} -g v8)
+endif()
 
 if(SIMD_X86_64)
   set(SIMD_BASENAMES jfdctflt-sse-64 jccolor-sse2-64 jcgray-sse2-64


### PR DESCRIPTION
The clear intent of the original CMakeLists.txt that we patched was to run nasm(yasm) with -g in Debug or RelWithDebInfo. We removed those lines and added -g v8 to the CMake arguments. The new CMake 3.20.1 is not happy with those args added in the way we were doing it so libjpeg-turbo stopped configuring. This patch moves those arguments into its expected location and  condition.