### PR TITLE
Remove the advanced marking for the fletch_ENABLE_VTK_PYTHON option.

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -195,7 +195,6 @@ set(vtk_cmake_args ${vtk_cmake_args}
 # PYTHON
 if(fletch_BUILD_WITH_PYTHON AND MSVC_VERSION VERSION_GREATER_EQUAL 1910)
   option(fletch_ENABLE_VTK_PYTHON "Enable Python wrappings for VTK" ON)
-  mark_as_advanced(fletch_ENABLE_VTK_PYTHON)
 
   find_package(PythonInterp)
   find_package(PythonLibs)


### PR DESCRIPTION
Keeping this option enabled can cause build issues on some platforms and adds a lot of time to the build, especially in Visual Studio. I don't see why it should be marked as advanced. It is better to have the option exposed so folks can remember that it's there before taking so much time building it. VTK is about the last build to finish because of Qt so seeing the failure at the end can be painful.