### PR TITLE
Only enable Qt in VTK if it is present

### DIFF
--- a/CMake/External_VTK.cmake
+++ b/CMake/External_VTK.cmake
@@ -65,47 +65,49 @@ set(vtk_cmake_args ${vtk_cmake_args}
   )
 
 # Qt
-if(Qt_version_major EQUAL 4)
-  add_package_dependency(
-    PACKAGE VTK
-    PACKAGE_DEPENDENCY Qt
-    PACKAGE_DEPENDENCY_ALIAS Qt4
-  )
-  if(QT_QMAKE_EXECUTABLE)
-    set(BUILD_QT_WEBKIT ${QT_QTWEBKIT_FOUND})
+if(QT_FOUND)
+  if(Qt_version_major EQUAL 4)
+    add_package_dependency(
+      PACKAGE VTK
+      PACKAGE_DEPENDENCY Qt
+      PACKAGE_DEPENDENCY_ALIAS Qt4
+    )
+    if(QT_QMAKE_EXECUTABLE)
+      set(BUILD_QT_WEBKIT ${QT_QTWEBKIT_FOUND})
+      set(vtk_cmake_args ${vtk_cmake_args}
+        -DQT_QMAKE_EXECUTABLE:PATH=${QT_QMAKE_EXECUTABLE}
+        -DVTK_QT_VERSION:STRING=4
+      )
+    endif()
+  else()
+    add_package_dependency(
+      PACKAGE VTK
+      PACKAGE_DEPENDENCY Qt
+      PACKAGE_DEPENDENCY_ALIAS Qt5
+      PACKAGE_DEPENDENCY_COMPONENTS
+        Core Gui Widgets OpenGL Designer UiPlugin
+    )
     set(vtk_cmake_args ${vtk_cmake_args}
-      -DQT_QMAKE_EXECUTABLE:PATH=${QT_QMAKE_EXECUTABLE}
-      -DVTK_QT_VERSION:STRING=4
+      -DQt5_DIR:PATH=${Qt5_DIR}
+      -DVTK_QT_VERSION:STRING=5
     )
   endif()
-else()
-  add_package_dependency(
-    PACKAGE VTK
-    PACKAGE_DEPENDENCY Qt
-    PACKAGE_DEPENDENCY_ALIAS Qt5
-    PACKAGE_DEPENDENCY_COMPONENTS
-      Core Gui Widgets OpenGL Designer UiPlugin
-  )
-  set(vtk_cmake_args ${vtk_cmake_args}
-    -DQt5_DIR:PATH=${Qt5_DIR}
-    -DVTK_QT_VERSION:STRING=5
-  )
-endif()
-if(VTK_SELECT_VERSION VERSION_LESS 9.0)
-  set(vtk_cmake_args ${vtk_cmake_args}
-    -DVTK_Group_Qt:BOOL=OFF
-    -DModule_vtkGUISupportQt:BOOL=ON
-    -DModule_vtkGUISupportQtOpenGL:BOOL=ON
-    -DModule_vtkGUISupportQtSQL:BOOL=ON
-    -DModule_vtkGUISupportQtWebkit:BOOL=${BUILD_QT_WEBKIT}
-    -DModule_vtkRenderingQt:BOOL=ON
-    -DModule_vtkViewsQt:BOOL=ON
-    -DVTK_QT_VERSION:STRING=${Qt_version_major}
-  )
-else()
-  set(vtk_cmake_args ${vtk_cmake_args}
-    -DVTK_GROUP_ENABLE_Qt:STRING=YES
-  )
+  if(VTK_SELECT_VERSION VERSION_LESS 9.0)
+    set(vtk_cmake_args ${vtk_cmake_args}
+      -DVTK_Group_Qt:BOOL=OFF
+      -DModule_vtkGUISupportQt:BOOL=ON
+      -DModule_vtkGUISupportQtOpenGL:BOOL=ON
+      -DModule_vtkGUISupportQtSQL:BOOL=ON
+      -DModule_vtkGUISupportQtWebkit:BOOL=${BUILD_QT_WEBKIT}
+      -DModule_vtkRenderingQt:BOOL=ON
+      -DModule_vtkViewsQt:BOOL=ON
+      -DVTK_QT_VERSION:STRING=${Qt_version_major}
+    )
+  else()
+    set(vtk_cmake_args ${vtk_cmake_args}
+      -DVTK_GROUP_ENABLE_Qt:STRING=YES
+    )
+  endif()
 endif()
 
 # PostgreSQL


### PR DESCRIPTION
Only enable Qt in VTK if Qt is present. The diff is less than it looks since I just wrapped the Qt setup in an `if(QT_FOUND) - endif()`.