### PR TITLE
Patch boost python 3.10

### DIFF
--- a/Patches/Boost/1.65.1/Patch.cmake
+++ b/Patches/Boost/1.65.1/Patch.cmake
@@ -45,3 +45,8 @@ file(COPY ${Boost_patch}/make.c
 file(COPY ${Boost_patch}/path.c
   DESTINATION ${Boost_source}/tools/build/src/engine/modules/
   )
+
+# Path to fix Boost with Python 3.10
+file(COPY ${Boost_patch}/exec.cpp
+  DESTINATION ${Boost_source}/libs/python/src/
+  )

--- a/Patches/Boost/1.65.1/exec.cpp
+++ b/Patches/Boost/1.65.1/exec.cpp
@@ -1,0 +1,129 @@
+// Copyright Stefan Seefeld 2005.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/python/exec.hpp>
+#include <boost/python/borrowed.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/handle.hpp>
+
+namespace boost 
+{ 
+namespace python 
+{
+
+object BOOST_PYTHON_DECL eval(str string, object global, object local)
+{
+    return eval(python::extract<char const *>(string));
+}
+
+object BOOST_PYTHON_DECL eval(char const *string, object global, object local)
+{
+  // Set suitable default values for global and local dicts.
+  if (global.is_none())
+  {
+    if (PyObject *g = PyEval_GetGlobals())
+      global = object(detail::borrowed_reference(g));
+    else
+      global = dict();
+  }
+  if (local.is_none()) local = global;
+  // should be 'char const *' but older python versions don't use 'const' yet.
+  char *s = const_cast<char *>(string);
+  PyObject* result = PyRun_String(s, Py_eval_input, global.ptr(), local.ptr());
+  if (!result) throw_error_already_set();
+  return object(detail::new_reference(result));
+}
+
+object BOOST_PYTHON_DECL exec(str string, object global, object local)
+{
+    return exec(python::extract<char const *>(string));
+}
+
+object BOOST_PYTHON_DECL exec(char const *string, object global, object local)
+{
+  // Set suitable default values for global and local dicts.
+  if (global.is_none())
+  {
+    if (PyObject *g = PyEval_GetGlobals())
+      global = object(detail::borrowed_reference(g));
+    else
+      global = dict();
+  }
+  if (local.is_none()) local = global;
+  // should be 'char const *' but older python versions don't use 'const' yet.
+  char *s = const_cast<char *>(string);
+  PyObject* result = PyRun_String(s, Py_file_input, global.ptr(), local.ptr());
+  if (!result) throw_error_already_set();
+  return object(detail::new_reference(result));
+}
+
+object BOOST_PYTHON_DECL exec_statement(str string, object global, object local)
+{
+    return exec_statement(python::extract<char const *>(string), global, local);
+}
+
+object BOOST_PYTHON_DECL exec_statement(char const *string, object global, object local)
+{
+  // Set suitable default values for global and local dicts.
+  if (global.is_none())
+  {
+    if (PyObject *g = PyEval_GetGlobals())
+      global = object(detail::borrowed_reference(g));
+    else
+      global = dict();
+  }
+  if (local.is_none()) local = global;
+  // should be 'char const *' but older python versions don't use 'const' yet.
+  char *s = const_cast<char *>(string);
+  PyObject* result = PyRun_String(s, Py_single_input, global.ptr(), local.ptr());
+  if (!result) throw_error_already_set();
+  return object(detail::new_reference(result));
+}
+
+// Execute python source code from file filename.
+// global and local are the global and local scopes respectively,
+// used during execution.
+object BOOST_PYTHON_DECL exec_file(str filename, object global, object local)
+{
+    return exec_file(python::extract<char const *>(filename), global, local);
+}
+
+object BOOST_PYTHON_DECL exec_file(char const *filename, object global, object local)
+{
+  // Set suitable default values for global and local dicts.
+  if (global.is_none())
+  {
+    if (PyObject *g = PyEval_GetGlobals())
+      global = object(detail::borrowed_reference(g));
+    else
+      global = dict();
+  }
+  if (local.is_none()) local = global;
+  // should be 'char const *' but older python versions don't use 'const' yet.
+  char *f = const_cast<char *>(filename);
+  // Let python open the file to avoid potential binary incompatibilities.
+#if PY_VERSION_HEX >= 0x03040000
+  FILE *fs = _Py_fopen(f, "r");
+#elif PY_VERSION_HEX >= 0x03000000
+  PyObject *fo = Py_BuildValue("s", f);
+  FILE *fs = _Py_fopen(fo, "r");
+  Py_DECREF(fo);
+#else
+  PyObject *pyfile = PyFile_FromString(f, const_cast<char*>("r"));
+  if (!pyfile) throw std::invalid_argument(std::string(f) + " : no such file");
+  python::handle<> file(pyfile);
+  FILE *fs = PyFile_AsFile(file.get());
+#endif
+  PyObject* result = PyRun_File(fs,
+                f,
+                Py_file_input,
+		global.ptr(), local.ptr());
+  if (!result) throw_error_already_set();
+  return object(detail::new_reference(result));
+}
+
+}  // namespace boost::python
+}  // namespace boost

--- a/Patches/Boost/1.65.1/exec.cpp
+++ b/Patches/Boost/1.65.1/exec.cpp
@@ -106,10 +106,10 @@ object BOOST_PYTHON_DECL exec_file(char const *filename, object global, object l
   char *f = const_cast<char *>(filename);
   // Let python open the file to avoid potential binary incompatibilities.
 #if PY_VERSION_HEX >= 0x03040000
-  FILE *fs = _Py_fopen(f, "r");
+  FILE *fs = fopen(f, "r");
 #elif PY_VERSION_HEX >= 0x03000000
   PyObject *fo = Py_BuildValue("s", f);
-  FILE *fs = _Py_fopen(fo, "r");
+  FILE *fs = fopen(fo, "r");
   Py_DECREF(fo);
 #else
   PyObject *pyfile = PyFile_FromString(f, const_cast<char*>("r"));


### PR DESCRIPTION
Boost 1.65.1 uses the private python API function, _Py_fopen which is removed in python 3.10. Switch to using the public fopen function instead.