### PR TITLE
Add x265 support

### DIFF
--- a/CMake/External_msys2.cmake
+++ b/CMake/External_msys2.cmake
@@ -14,7 +14,7 @@ if(WIN32)
 	  ${mingw_prefix} ${msys_bash} -c "sed -i 's|\"\${postinst}\"$|& \\&>/dev/null|g' /etc/profile"
 	  CONFIGURE_COMMAND
 	  ${mingw_prefix} ${msys_bash} -l -c "pacman -Syyuq --noconfirm"
-	  BUILD_COMMAND ""
+	  BUILD_COMMAND
 	  ${mingw_prefix} ${msys_bash} -l -c "pacman -Syyq --noconfirm make gcc diffutils yasm nasm git pkgconf mingw-w64-x86_64-nasm mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-binutils"
 	  INSTALL_COMMAND
 	  ${mingw_prefix} ${msys_bash} -l -c "cp /mingw64/bin/*.dll ${fletch_BUILD_INSTALL_PREFIX}/bin"

--- a/CMake/External_x265.cmake
+++ b/CMake/External_x265.cmake
@@ -1,0 +1,15 @@
+ExternalProject_Add(x265
+  URL ${x265_url}
+  DEPENDS ${x265_DEPENDS}
+  URL_MD5 ${x265_md5}
+  ${COMMON_EP_ARGS}
+  ${COMMON_CMAKE_EP_ARGS}
+  SOURCE_SUBDIR source
+  CMAKE_ARGS
+    ${COMMON_CMAKE_ARGS}
+    -DCMAKE_INSTALL_PREFIX=${fletch_BUILD_INSTALL_PREFIX}
+  )
+
+fletch_external_project_force_install(PACKAGE x265)
+
+set(x265_ROOT ${fletch_BUILD_INSTALL_PREFIX} CACHE PATH "" FORCE)

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -100,6 +100,11 @@ set(x264_version "bfc87b7a330f75f5c9a21e56081e4b20344f139e")
 set(x264_url "https://code.videolan.org/videolan/x264/-/archive/${x264_version}/x264-${x264_version}.tar.bz2")
 set(x264_md5 "fd71fead6422ccb5094207c9d2ad70bd")
 
+# x265
+set(x265_version "3.4")
+set(x265_url "https://github.com/videolan/x265/archive/refs/tags/${x265_version}.tar.gz")
+set(x265_md5 "d867c3a7e19852974cf402c6f6aeaaf3")
+
 # FFmpeg
 if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
   # allow different versions to be selected for testing purposes
@@ -123,6 +128,7 @@ if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
   list(APPEND fletch_external_sources FFmpeg)
 
   set(fletch_ENABLE_x264 ON CACHE BOOL "Include x264")
+  set(fletch_ENABLE_x265 ON CACHE BOOL "Include x265")
 endif()
 
 # EIGEN


### PR DESCRIPTION
This PR adds support for the x265 library. x265 provides a FFmpeg-compatible H.265/HEVC video output codec.