### PR TITLE
Upgrade Boost to 1.78.0

### DIFF
--- a/CMake/External_Boost.cmake
+++ b/CMake/External_Boost.cmake
@@ -66,6 +66,8 @@ ExternalProject_Add(Boost
     ${_Boost_DIR_ARGS}
     -DBoost_source=${fletch_BUILD_PREFIX}/src/Boost
     -Dfletch_BUILD_WITH_PYTHON=${fletch_BUILD_WITH_PYTHON}
+    -DPYTHON_VERSION_MAJOR=${PYTHON_VERSION_MAJOR}
+    -DPYTHON_VERSION_MINOR=${PYTHON_VERSION_MINOR}
     -P ${fletch_SOURCE_DIR}/Patches/Boost/Install.cmake
 )
 add_dependencies(Download Boost-download)

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -22,19 +22,20 @@
 #-
 
 # Boost
-# Support 1.55.0 (Default) and 1.65.1 optionally
-if (fletch_ENABLE_Boost OR fletch_ENABLE_ALL_PACKAGES OR AUTO_ENABLE_CAFFE_DEPENDENCY)
-  set(Boost_SELECT_VERSION 1.65.1 CACHE STRING "Select the major version of Boost to build.")
-  set_property(CACHE Boost_SELECT_VERSION PROPERTY STRINGS "1.55.0" "1.65.1")
+
+# Support 1.78.0 (Default) and 1.65.1 optionally
+if (fletch_ENABLE_Boost OR fletch_ENABLE_ALL_PACKAGES)
+  set(Boost_SELECT_VERSION 1.78.0 CACHE STRING "Select the major version of Boost to build.")
+  set_property(CACHE Boost_SELECT_VERSION PROPERTY STRINGS "1.78.0" "1.65.1")
+  string(REGEX REPLACE "\\\." "_" Boost_version_underscore ${Boost_SELECT_VERSION})
   message(STATUS "Boost Select version: ${Boost_SELECT_VERSION}")
 
   if(Boost_SELECT_VERSION VERSION_EQUAL 1.65.1)
-    # Boost 1.65.1
-    set(Boost_major_version 1)
-    set(Boost_minor_version 65)
-    set(Boost_patch_version 1)
-    set(Boost_url "http://sourceforge.net/projects/boost/files/boost/${Boost_SELECT_VERSION}/boost_${Boost_major_version}_${Boost_minor_version}_${Boost_patch_version}.tar.bz2")
+    set(Boost_url "http://sourceforge.net/projects/boost/files/boost/${Boost_SELECT_VERSION}/boost_${Boost_version_underscore}.tar.bz2")
     set(Boost_md5 "41d7542ce40e171f3f7982aff008ff0d")
+  elseif(Boost_SELECT_VERSION VERSION_EQUAL 1.78.0)
+    set(Boost_url "https://boostorg.jfrog.io/artifactory/main/release/${Boost_SELECT_VERSION}/source/boost_${Boost_version_underscore}.tar.gz")
+    set(Boost_md5 "c2f6428ac52b0e5a3c9b2e1d8cc832b5")
   else()
     message(STATUS "Boost_SELECT_VERSION: Not supported")
   endif()

--- a/Patches/Boost/Install.cmake
+++ b/Patches/Boost/Install.cmake
@@ -18,13 +18,15 @@ if (fletch_BUILD_WITH_PYTHON)
     DESTINATION ${Boost_INSTALL_DIR}/include/boost/python
     USE_SOURCE_PERMISSIONS
     )
-  if( NOT WIN32
-      AND NOT EXISTS ${Boost_INSTALL_DIR}/lib/libboost_python.so
-      AND EXISTS ${Boost_INSTALL_DIR}/lib/libboost_python3.so )
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-      ${Boost_INSTALL_DIR}/lib/libboost_python3.so
-      ${Boost_INSTALL_DIR}/lib/libboost_python.so )
-  endif()
+  foreach(pysuffix ${PYTHON_VERSION_MAJOR}
+                   ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+    if(NOT WIN32
+       AND EXISTS ${Boost_INSTALL_DIR}/lib/libboost_python${pysuffix}.so)
+      execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+        ${Boost_INSTALL_DIR}/lib/libboost_python${pysuffix}.so
+        ${Boost_INSTALL_DIR}/lib/libboost_python.so)
+    endif()
+  endforeach()
 endif()
 
 if(WIN32)

--- a/Patches/Qt/5.11.2/Patch.cmake
+++ b/Patches/Qt/5.11.2/Patch.cmake
@@ -15,6 +15,11 @@ file(COPY ${Qt_patch}/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/jit/JI
   DESTINATION ${Qt_source}/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/jit/
   )
 
+# Fix build issue on Mac
+file(RENAME ${Qt_source}/qtscript/src/3rdparty/javascriptcore/VERSION
+  ${Qt_source}/qtscript/src/3rdparty/javascriptcore/VERSION.txt
+  )
+
 # Patch for gcc 9.1.
 file(COPY ${Qt_patch}/qtbase/src/corelib/global/qrandom.cpp
   DESTINATION ${Qt_source}/qtbase/src/corelib/global/


### PR DESCRIPTION
This has become a sort of combination PR of changes which fix issues that came up when upgrading our CI systems/compilers (#707, #708, #710). The idea with combining them here is to demonstrate that CI can "pass" with all of them together, since if we ran CI on each of them individually we would run into the problems the still exist in `master` but are fixed in the other PRs, preventing the CI from running all the way. It's not intended to be merged like this - we can merge the other PRs one at a time, then this one rebased on `master` - just don't expect their CI to fully pass.

Note that Linux GPU, Mac, and Windows are still failing. However, I wouldn't count these as true "failures" in their current state:
- Linux GPU just always fails due to config issues
- Windows successfully builds fletch and KWIVER, but fails two KWIVER tests which are unrelated to anything here and need to be fixed in KWIVER. The failures have to do with the pseudorandom number generator used by the new version of MSVC just happening to give unfortunate outlier values to these tests. (Update: https://github.com/Kitware/kwiver/pull/1645)
- Mac successfully builds fletch and KWIVER, but GTest times out looking for a few tests. I built them manually on the CI machine afterward and they work fine. There is [precedent](https://github.com/google/googletest/issues/3475) for this happening sometimes on Mac Catalina (which the CI machine was recently upgraded to), so I don't think this is related to anything here.