### PR TITLE
Add FFmpeg NVidia codec headers

### DIFF
--- a/CMake/External_FFmpeg.cmake
+++ b/CMake/External_FFmpeg.cmake
@@ -51,6 +51,20 @@ if(fletch_ENABLE_x265)
   set(_FFmpeg_x265 --enable-gpl --enable-libx265)
 endif()
 
+if(fletch_BUILD_WITH_CUDA)
+  if(fletch_ENABLE_ffnvcodec)
+    include(External_ffnvcodec)
+    list(APPEND ffmpeg_DEPENDS ffnvcodec)
+    set(_FFmpeg_cuda
+      "--enable-cuda\
+      --enable-cuvid\
+      --enable-nvenc"
+      )
+  else()
+    message(WARNING "FFmpeg will not build NVidia/CUDA hardware-accelerated codecs (fletch_ENABLE_ffnvcodec)")
+  endif()
+endif()
+
 set(FFMPEG_PKGCONFIG_PATH ${fletch_BUILD_INSTALL_PREFIX}/lib/pkgconfig)
 if(WIN32)
   include(External_msys2)
@@ -69,6 +83,7 @@ if(WIN32)
     ${_FFmpeg_x264}\
     ${_FFmpeg_x265}\
     ${_FFmpeg_zlib}\
+    ${_FFmpeg_cuda}\
     ${_shared_lib_params}\
     --enable-rpath\
     --disable-programs\
@@ -90,6 +105,7 @@ else()
     ${_FFmpeg_x265}
     ${_FFmpeg_yasm}
     ${_FFmpeg_zlib}
+    ${_FFmpeg_cuda}
     ${_shared_lib_params}
     --cc=${CMAKE_C_COMPILER}
     --cxx=${CMAKE_CXX_COMPILER}

--- a/CMake/External_ffnvcodec.cmake
+++ b/CMake/External_ffnvcodec.cmake
@@ -1,0 +1,25 @@
+# FFmpeg NVidia (CUDA/CUVID/NVENC) codec headers
+
+set(ffnvcodec_build_command make)
+set(ffnvcodec_install_command make install PREFIX=${fletch_BUILD_INSTALL_PREFIX})
+
+if(WIN32)
+  include(External_msys2)
+  list(APPEND ffnvcodec_depends msys2)
+  set(ffnvcodec_build_command ${mingw_prefix} ${mingw_bash} -c "${ffnvcodec_build_command}")
+  set(ffnvcodec_install_command ${mingw_prefix} ${mingw_bash} -c "${ffnvcodec_install_command")
+endif()
+
+ExternalProject_Add(ffnvcodec
+  GIT_REPOSITORY ${ffnvcodec_url}
+  GIT_TAG ${ffnvcodec_version}
+  DEPENDS ${ffnvcodec_depends}
+  ${COMMON_EP_ARGS}
+  CONFIGURE_COMMAND ""
+  BUILD_IN_SOURCE true
+  BUILD_COMMAND ${ffnvcodec_build_command}
+  INSTALL_COMMAND ${ffnvcodec_install_command}
+  UPDATE_COMMAND ""
+)
+
+fletch_external_project_force_install(PACKAGE ffnvcodec)

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -105,6 +105,10 @@ set(x265_version "3.4")
 set(x265_url "https://github.com/videolan/x265/archive/refs/tags/${x265_version}.tar.gz")
 set(x265_md5 "d867c3a7e19852974cf402c6f6aeaaf3")
 
+# FFmpeg NVidia codec headers
+set(ffnvcodec_version "n11.1.5.1")
+set(ffnvcodec_url "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git")
+
 # FFmpeg
 if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
   # allow different versions to be selected for testing purposes
@@ -129,6 +133,7 @@ if (fletch_ENABLE_FFmpeg OR fletch_ENABLE_ALL_PACKAGES)
 
   set(fletch_ENABLE_x264 ON CACHE BOOL "Include x264")
   set(fletch_ENABLE_x265 ON CACHE BOOL "Include x265")
+  set(fletch_ENABLE_ffnvcodec ON CACHE BOOL "Include FFmpeg NVidia codec headers")
 endif()
 
 # EIGEN


### PR DESCRIPTION
This PR pulls the special FFmpeg headers for working with NVidia codecs. These are required in order to use CUDA to accelerate video decoding and encoding.