### PR TITLE
Add msys include guard

### DIFF
--- a/CMake/External_msys2.cmake
+++ b/CMake/External_msys2.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 if(WIN32)
   set (msys_patch "${fletch_SOURCE_DIR}/Patches/msys2")
 


### PR DESCRIPTION
This PR ensures that multiple sub-projects which use MSYS2 to build on Windows don't run into redefinition errors when including the MSYS2 file from both sub-project files.