### PR TITLE
Revert typo

### DIFF
--- a/CMake/External_ffnvcodec.cmake
+++ b/CMake/External_ffnvcodec.cmake
@@ -8,8 +8,8 @@ if(WIN32)
   set(ffnvcodec_install_command
       ${mingw_prefix} ${msys_bash} -c "make install PREFIX=${fletch_BUILD_INSTALL_PREFIX}")
 else()
-  set(fnvcodec_build_command make)
-  set(ffnvcfodec_install_command make install PREFIX=${fletch_BUILD_INSTALL_PREFIX})
+  set(ffnvcodec_build_command make)
+  set(ffnvcodec_install_command make install PREFIX=${fletch_BUILD_INSTALL_PREFIX})
 endif()
 
 ExternalProject_Add(ffnvcodec


### PR DESCRIPTION
I'm confused about how I didn't notice this, but #717 includes a typo that moves an 'f' from one line to another and breaks this script...