### PR TITLE
Fix Qt configure make jobserver bug

### DIFF
--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -141,7 +141,7 @@ if(WIN32)
 else()
   set(env ${CMAKE_COMMAND} -E env)
 
-  set(configure_env_var PKG_CONFIG_PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/pkgconfig)
+  set(configure_env_var PKG_CONFIG_PATH=${fletch_BUILD_INSTALL_PREFIX}/lib/pkgconfig DUMMYMAKEENVVAR="$(MAKE)")
   if(NOT "$ENV{PKG_CONFIG_PATH}" STREQUAL "")
     set(configure_env_var "${configure_env_var}:$ENV{PKG_CONFIG_PATH}")
   endif()


### PR DESCRIPTION
When configuring Qt on Linux using Makefiles, `make` may encounter a [fatal error](http://canifis:8080/view/Fletch/job/FletchLinuxNightly/31/consoleFull) or warning, depending on the version of `make`. This is due to `./configure` internally calling `make`, but because that call is hidden inside `./configure`, the parent `make` does not know about it. However, thanks to the `MAKEFLAGS` environment variable, the child does know about the parent, and attempts to coordinate jobs with it. This fails, as the parent is not expecting a child `make` instance; hence the error/warning.

This PR fixes the issue by including in the configure command the string `$(MAKE)`, which, even though it doesn't actually do anything here, signals to the parent `make` instance to expect a child `make`, allowing the two to connect and resolving the problem.