### PR TITLE
Set pybind11 to build with C++17

### DIFF
--- a/CMake/External_pybind11.cmake
+++ b/CMake/External_pybind11.cmake
@@ -14,6 +14,7 @@ ExternalProject_Add(pybind11
   ${COMMON_CMAKE_EP_ARGS}
   CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
+    -DCMAKE_CXX_STANDARD=17
     # PYTHON_EXECUTABLE addded to cover when it's installed in nonstandard loc.
     # But don't pass if python isn't enabled. It will prevent pybind from finding it.
     ${pybind_PYTHON_ARGS}


### PR DESCRIPTION
This PR fixes a mysterious bug in some GCC builds of KWIVER. When pybind11 is enabled, it can sometimes override the C++ standard level in KWIVER for those files that are building against pybind11 using [`INTERFACE_COMPILE_OPTIONS`](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_COMPILE_OPTIONS.html) in CMake. Our pinned version of pybind11 in fletch is old enough so that the newest version it will set itself to is C++14. So any C++17 features in headers included by KWIVER's python module will throw an error when pybind11 overrides the version back down to 14. Luckily, this can be fixed by just telling pybind11 to use C++17.