### PR TITLE
Fix versioning

### DIFF
--- a/CMake/External_libkml.cmake
+++ b/CMake/External_libkml.cmake
@@ -1,13 +1,13 @@
 
-# Use the expat library that comes with Unix systems, else go ahead and build
-# it on windows.
-if(WIN32)
+# Find expat if missing, go ahead and build it.
+find_package(EXPAT)
+if (EXPAT_FOUND)
   set(libkml_use_external_expat
-    -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=OFF
+    -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=ON
     )
 else()
   set(libkml_use_external_expat
-    -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=ON
+    -DLIBKML_USE_EXTERNAL_EXPAT:BOOL=OFF
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 # can still detect after the change)
 #-
 set(fletch_VERSION_MAJOR 1)
-set(fletch_VERSION_MINOR 4)
-set(fletch_VERSION_PATCH 1)
+set(fletch_VERSION_MINOR 5)
+set(fletch_VERSION_PATCH 0)
 
 set(fletch_VERSION "${fletch_VERSION_MAJOR}.${fletch_VERSION_MINOR}.${fletch_VERSION_PATCH}")
 


### PR DESCRIPTION
Our versioning is somewhat messed up here. There is a `v1.5.0` tag, but its `CMakeLists.txt` version is `1.4.1`. Also, it has commits in it that the `release` branch does not have? Neither of these make sense, so this PR attempts to fix them by updating the version number and merging `v1.5.0` into `release`. We should probably make a `v1.5.1` release soon to get this all in a clean state.