### PR TITLE
Clean up Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+dockerfile

--- a/dockerfile
+++ b/dockerfile
@@ -1,67 +1,94 @@
 # Fletch Dockerfile
 # Installs the fletch binary to /opt/kitware/fletch
 
-ARG BASE_IMAGE=ubuntu:18.04
-FROM ${BASE_IMAGE}
-
-ARG PY_MAJOR_VERSION=3
+ARG BASE_IMAGE=ubuntu:20.04
 ARG ENABLE_CUDA=OFF
 
-#
-# Install System Dependencies
-#
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential \
-                                               libgl1-mesa-dev \
-                                               libexpat1-dev \
-                                               libgtk2.0-dev \
-                                               libxt-dev \
-                                               libxml2-dev \
-                                               libssl-dev \
-                                               liblapack-dev \
-                                               openssl \
-                                               curl \
-                                               wget \
-                                               git \
-                                               libreadline-dev \
-                                               zlib1g-dev
+FROM ${BASE_IMAGE} AS base
 
-# Install CMake 3.15
-RUN wget --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.15.1/cmake-3.15.1-Linux-x86_64.sh \
-&& chmod +x cmake-3.15.1-Linux-x86_64.sh \
-&& ./cmake-3.15.1-Linux-x86_64.sh --skip-license \
-&& rm -rf cmake-3.15.1-Linux-x86_64.sh
-                                               
-# conditional python package installation based on version
-RUN if [ "$PY_MAJOR_VERSION" = "2" ]; then \
-      apt-get install --no-install-recommends -y python2.7-dev \
-                                                 python2.7-setuptools \
-                                                 python-pip && \
-      pip install numpy==1.16; \
-    else \
-      apt-get install --no-install-recommends -y python3 \
-                                                 python3-dev \
-                                                 python3-pip && \
-      pip3 install numpy && \
-      ln -s /usr/bin/python3 /usr/local/bin/python; \
-    fi
-    
-RUN apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-    
-#
-# Build Fletch
-#
-ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH
+# Install system dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y --no-install-recommends \
+      build-essential \
+      libgl1-mesa-dev \
+      libexpat1-dev \
+      libgtk2.0-dev \
+      libxt-dev \
+      libxml2-dev \
+      libssl-dev \
+      liblapack-dev \
+      openssl \
+      curl \
+      wget \
+      git \
+      libreadline-dev \
+      zlib1g-dev \
+      python3 \
+      python3-dev \
+      python3-pip
+
+# Install Qt-specific system dependencies
+# See https://doc.qt.io/qt-6/linux-requirements.html
+RUN apt-get install -y --no-install-recommends \
+      libfontconfig1-dev \
+      libfreetype6-dev \
+      libx11-dev \
+      libx11-xcb-dev \
+      libxext-dev \
+      libxfixes-dev \
+      libxi-dev \
+      libxrender-dev \
+      libxcb1-dev \
+      libxcb-cursor-dev \
+      libxcb-glx0-dev \
+      libxcb-keysyms1-dev \
+      libxcb-image0-dev \
+      libxcb-shm0-dev \
+      libxcb-icccm4-dev \
+      libxcb-sync-dev \
+      libxcb-xfixes0-dev \
+      libxcb-shape0-dev \
+      libxcb-randr0-dev \
+      libxcb-render-util0-dev \
+      libxcb-util-dev \
+      libxcb-xinerama0-dev \
+      libxcb-xkb-dev \
+      libxkbcommon-dev \
+      libxkbcommon-x11-dev
+
+# Install python dependencies
+RUN pip3 install numpy cmake
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
+
+# Remove unnecessary files
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
+# Setup build environment
 COPY . /fletch
-RUN mkdir -p /fletch/build /opt/kitware/fletch \
-  && cd /fletch/build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
+RUN mkdir -p /fletch/build /opt/kitware/fletch
+ENV LD_LIBRARY_PATH=/opt/kitware/fletch/lib/:$LD_LIBRARY_PATH
+
+# Configure
+RUN cd /fletch/build && \
+    cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
     -Dfletch_ENABLE_ALL_PACKAGES=ON \
     -Dfletch_BUILD_WITH_PYTHON=ON \
     -Dfletch_BUILD_WITH_CUDA=${ENABLE_CUDA} \
-    -Dfletch_PYTHON_MAJOR_VERSION=${PY_MAJOR_VERSION} \
+    -Dfletch_PYTHON_MAJOR_VERSION=3 \
     -Dfletch_BUILD_INSTALL_PREFIX=/opt/kitware/fletch \
-    ../ \
-  && make -j$(nproc) -k \
-  && rm -rf /fletch
+    -Wno-dev
+
+# Build
+RUN cd /fletch/build && \
+    make -j$(nproc) -k
+
+# Remove source and temporary build files
+RUN rm -rf /fletch
+
+# Remove record of intermediate files
+FROM scratch
+COPY --from=base / /


### PR DESCRIPTION
This PR cleans up the `Dockerfile`, which has not been building properly for a long while. Notable changes include removal of the `PY_MAJOR_VERSION` argument (`python2` is long deprecated) and the neat `COPY --from=base / /` trick which reduces the size of the resulting container dramatically (`20GB -> 3GB`) by removing the layers describing the changes to intermediate build files, keeping only the installed final product.