### PR TITLE
Adjust KLV sync/async detection

### DIFF
--- a/Patches/FFmpeg/4.4.1/mpegts.c
+++ b/Patches/FFmpeg/4.4.1/mpegts.c
@@ -1992,9 +1992,9 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
             mpegts_find_stream_type(st, st->codecpar->codec_tag, REGD_types);
             if (st->codecpar->codec_tag == MKTAG('B', 'S', 'S', 'D'))
                 st->internal->request_probe = 50;
-            if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
-                st->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
         }
+        if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
+            st->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
         break;
     case 0x52: /* stream identifier descriptor */
         st->stream_identifier = 1 + get8(pp, desc_end);
@@ -2004,11 +2004,10 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
             *pp += 4;
         if (get8(pp, desc_end) == 0xFF) {
             st->codecpar->codec_tag = bytestream_get_le32(pp);
-            if (st->codecpar->codec_id == AV_CODEC_ID_NONE) {
+            if (st->codecpar->codec_id == AV_CODEC_ID_NONE)
                 mpegts_find_stream_type(st, st->codecpar->codec_tag, METADATA_types);
-                if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
-                    st->codecpar->profile = FF_PROFILE_KLVA_SYNC;
-            }
+            if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
+                st->codecpar->profile = FF_PROFILE_KLVA_SYNC;
         }
         break;
     case 0x7f: /* DVB extension descriptor */

--- a/Patches/FFmpeg/5.1.2/mpegts.c
+++ b/Patches/FFmpeg/5.1.2/mpegts.c
@@ -2021,9 +2021,9 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
             mpegts_find_stream_type(st, st->codecpar->codec_tag, REGD_types);
             if (st->codecpar->codec_tag == MKTAG('B', 'S', 'S', 'D'))
                 sti->request_probe = 50;
-            if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
-                st->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
         }
+        if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
+            st->codecpar->profile = FF_PROFILE_KLVA_ASYNC;
         break;
     case 0x52: /* stream identifier descriptor */
         sti->stream_identifier = 1 + get8(pp, desc_end);
@@ -2033,11 +2033,10 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type
             *pp += 4;
         if (get8(pp, desc_end) == 0xFF) {
             st->codecpar->codec_tag = bytestream_get_le32(pp);
-            if (st->codecpar->codec_id == AV_CODEC_ID_NONE) {
+            if (st->codecpar->codec_id == AV_CODEC_ID_NONE)
                 mpegts_find_stream_type(st, st->codecpar->codec_tag, METADATA_types);
-                if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
-                    st->codecpar->profile = FF_PROFILE_KLVA_SYNC;
-            }
+            if (st->codecpar->codec_tag == MKTAG('K', 'L', 'V', 'A'))
+                st->codecpar->profile = FF_PROFILE_KLVA_SYNC;
         }
         break;
     case 0x7f: /* DVB extension descriptor */


### PR DESCRIPTION
This PR moves the logic which records whether a KLV stream is synchronous or asynchronous to outside of some `if` statements it doesn't need to be in.