### PR TITLE
gdal: ensure that an rpath to the install tree is set

### DIFF
--- a/CMake/External_GDAL.cmake
+++ b/CMake/External_GDAL.cmake
@@ -84,6 +84,9 @@ else()
     # Note: previously this var disabled curl and netcdf which are now handled
     # by _GDAL_ARGS_UNSUPPORTED
     set(_GDAL_ARGS_APPLE --without-libtool --with-local=/usr)
+  else ()
+    list(INSERT GDAL_CONFIGURE_COMMAND 0
+      LDFLAGS=-Wl,-rpath,<INSTALL_DIR>/lib)
   endif()
 
   # GDAL uses a configure based build system, so its important to disable


### PR DESCRIPTION
Without this, loading GDAL was failing to find its dependencies (e.g., `libproj.so.18`) when not in a standard location.