### PR TITLE
Add option to omit writing SDT

### DIFF
--- a/Patches/FFmpeg/4.4.1/mpegtsenc.c
+++ b/Patches/FFmpeg/4.4.1/mpegtsenc.c
@@ -114,6 +114,7 @@ typedef struct MpegTSWrite {
     int64_t sdt_period_us;
     int64_t last_pat_ts;
     int64_t last_sdt_ts;
+    int omit_sdt;
 
     int omit_video_pes_length;
 } MpegTSWrite;
@@ -1188,9 +1189,10 @@ static void retransmit_si_info(AVFormatContext *s, int force_pat, int force_sdt,
     MpegTSWrite *ts = s->priv_data;
     int i;
 
-    if ((pcr != AV_NOPTS_VALUE && ts->last_sdt_ts == AV_NOPTS_VALUE) ||
-        (pcr != AV_NOPTS_VALUE && pcr - ts->last_sdt_ts >= ts->sdt_period) ||
-        force_sdt
+    if (!ts->omit_sdt &&
+        ((pcr != AV_NOPTS_VALUE && ts->last_sdt_ts == AV_NOPTS_VALUE) ||
+         (pcr != AV_NOPTS_VALUE && pcr - ts->last_sdt_ts >= ts->sdt_period) ||
+         force_sdt)
     ) {
         if (pcr != AV_NOPTS_VALUE)
             ts->last_sdt_ts = FFMAX(pcr, ts->last_sdt_ts);
@@ -2148,6 +2150,8 @@ static const AVOption options[] = {
       OFFSET(pat_period_us), AV_OPT_TYPE_DURATION, { .i64 = PAT_RETRANS_TIME * 1000LL }, 0, INT64_MAX, ENC },
     { "sdt_period", "SDT retransmission time limit in seconds",
       OFFSET(sdt_period_us), AV_OPT_TYPE_DURATION, { .i64 = SDT_RETRANS_TIME * 1000LL }, 0, INT64_MAX, ENC },
+    { "omit_sdt", "Omit the SDT",
+      OFFSET(omit_sdt), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, ENC },
     { NULL },
 };
 

--- a/Patches/FFmpeg/5.1.2/mpegtsenc.c
+++ b/Patches/FFmpeg/5.1.2/mpegtsenc.c
@@ -120,6 +120,7 @@ typedef struct MpegTSWrite {
     int64_t last_pat_ts;
     int64_t last_sdt_ts;
     int64_t last_nit_ts;
+    int omit_sdt;
 
     uint8_t provider_name[256];
 
@@ -1319,9 +1320,10 @@ static void retransmit_si_info(AVFormatContext *s, int force_pat, int force_sdt,
     MpegTSWrite *ts = s->priv_data;
     int i;
 
-    if ((pcr != AV_NOPTS_VALUE && ts->last_sdt_ts == AV_NOPTS_VALUE) ||
-        (pcr != AV_NOPTS_VALUE && pcr - ts->last_sdt_ts >= ts->sdt_period) ||
-        force_sdt
+    if (!ts->omit_sdt &&
+        ((pcr != AV_NOPTS_VALUE && ts->last_sdt_ts == AV_NOPTS_VALUE) ||
+         (pcr != AV_NOPTS_VALUE && pcr - ts->last_sdt_ts >= ts->sdt_period) ||
+         force_sdt)
     ) {
         if (pcr != AV_NOPTS_VALUE)
             ts->last_sdt_ts = FFMAX(pcr, ts->last_sdt_ts);
@@ -2314,6 +2316,8 @@ static const AVOption options[] = {
       OFFSET(pat_period_us), AV_OPT_TYPE_DURATION, { .i64 = PAT_RETRANS_TIME * 1000LL }, 0, INT64_MAX, ENC },
     { "sdt_period", "SDT retransmission time limit in seconds",
       OFFSET(sdt_period_us), AV_OPT_TYPE_DURATION, { .i64 = SDT_RETRANS_TIME * 1000LL }, 0, INT64_MAX, ENC },
+    { "omit_sdt", "Omit the SDT",
+      OFFSET(omit_sdt), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, ENC },
     { "nit_period", "NIT retransmission time limit in seconds",
       OFFSET(nit_period_us), AV_OPT_TYPE_DURATION, { .i64 = NIT_RETRANS_TIME * 1000LL }, 0, INT64_MAX, ENC },
     { NULL },


### PR DESCRIPTION
The [SDT](https://en.wikipedia.org/wiki/Service_Description_Table) is automatically inserted by FFmpeg whenever it writes a transport stream. This PR adds an option to disable that insertion, to opt out of the default service metadata (`service_name: Service01`, `service_provider: FFmpeg`) being added in. The SDT was designed for e.g. broadcast television and is likely useless in computer vision applications.