### PR TITLE
Update cppzmq

### DIFF
--- a/CMake/External_cppzmq.cmake
+++ b/CMake/External_cppzmq.cmake
@@ -7,20 +7,34 @@ if(NOT fletch_ENABLE_ZeroMQ)
   message(WARNING "cppzmq module enabled without ZeroMQ! Only the header will be installed!")
 endif()
 
-ExternalProject_Add(cppzmq
-  URL ${cppzmq_url}
-  URL_MD5 ${cppzmq_md5}
-  ${COMMON_EP_ARGS}
-  ${COMMON_CMAKE_EP_ARGS}
-  PATCH_COMMAND ${CMAKE_COMMAND}
-   -Dcppzmq_patch:PATH=${fletch_SOURCE_DIR}/Patches/cppzmq
-   -Dcppzmq_source:PATH=${fletch_BUILD_PREFIX}/src/cppzmq
-   -P ${fletch_SOURCE_DIR}/Patches/cppzmq/Patch.cmake
-  CMAKE_ARGS
-    ${COMMON_CMAKE_ARGS}
-    -DCMAKE_INSTALL_PREFIX:PATH=${fletch_BUILD_INSTALL_PREFIX}
-    -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
-)
+set(patch_args)
+if (cppzmq_version VERSION_LESS 4.10.0)
+  ExternalProject_Add(cppzmq
+    URL ${cppzmq_url}
+    URL_MD5 ${cppzmq_md5}
+    ${COMMON_EP_ARGS}
+    ${COMMON_CMAKE_EP_ARGS}
+    PATCH_COMMAND ${CMAKE_COMMAND}
+    -Dcppzmq_patch:PATH=${fletch_SOURCE_DIR}/Patches/cppzmq
+    -Dcppzmq_source:PATH=${fletch_BUILD_PREFIX}/src/cppzmq
+    -P ${fletch_SOURCE_DIR}/Patches/cppzmq/Patch.cmake
+    CMAKE_ARGS
+      ${COMMON_CMAKE_ARGS}
+      -DCMAKE_INSTALL_PREFIX:PATH=${fletch_BUILD_INSTALL_PREFIX}
+      -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+  )
+else()
+  ExternalProject_Add(cppzmq
+    URL ${cppzmq_url}
+    URL_MD5 ${cppzmq_md5}
+    ${COMMON_EP_ARGS}
+    ${COMMON_CMAKE_EP_ARGS}
+    CMAKE_ARGS
+      ${COMMON_CMAKE_ARGS}
+      -DCMAKE_INSTALL_PREFIX:PATH=${fletch_BUILD_INSTALL_PREFIX}
+      -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+  )
+endif()
 
 # CMake build configuration additions
 

--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -618,9 +618,20 @@ set(ZeroMQ_md5 "da43d89dac623d99909fb95e2725fe05")
 list(APPEND fletch_external_sources ZeroMQ)
 
 # CPP ZeroMQ header
-set(cppzmq_version "4.2.3")
-set(cppzmq_url "https://data.kitware.com/api/v1/file/6622b07ddf5a87675edbc049/download/cppzmq.${cppzmq_version}.zip")
-set(cppzmq_md5 "f5a2ef3a4d47522fcb261171eb7ecfc4")
+set(cppzmq_SELECT_VERSION 4.2.3 CACHE STRING "Select the version of cppzmq to build.")
+set_property(CACHE cppzmq_SELECT_VERSION PROPERTY STRINGS "4.2.3" "4.10.0")
+mark_as_advanced(cppzmq_SELECT_VERSION)
+
+set(cppzmq_version ${cppzmq_SELECT_VERSION})
+set(cppzmq_url "https://github.com/zeromq/cppzmq/archive/v${cppzmq_version}.zip")
+if (cppzmq_version VERSION_EQUAL 4.2.3)
+  set(cppzmq_md5 "f5a2ef3a4d47522fcb261171eb7ecfc4")
+elseif (cppzmq_version VERSION_EQUAL 4.10.0)
+  set(cppzmq_md5 "b3110cc4146126cfde994f1fd8ae904b")
+  set(cppzmq_dlname "cppzmq-v${cppzmq_version}.zip")
+else()
+  message("Unsupported cppzmq version ${cppzmq_version}")
+endif()
 list(APPEND fletch_external_sources cppzmq)
 
 #+


### PR DESCRIPTION
Updates cppzmq to add option for a later release (4.10.0), which includes many API improvements. The previous version (4.2.3) is still the default.

Note: this supersedes #738
closes #738
