### PR TITLE
[fix] Update msys2 URL

### DIFF
--- a/CMake/fletch-tarballs.cmake
+++ b/CMake/fletch-tarballs.cmake
@@ -121,7 +121,7 @@ set(yasm_md5 "38802696efbc27554d75d93a84a23183")
 # msys2
 if(WIN32)
   set(msys2_version "20220128")
-  set(msys2_url "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${msys2_version}.tar.xz")
+  set(msys2_url "https://data.kitware.com/api/v1/file/6622b0ecdf5a87675edbc0a6/download/msys2.${msys2_version}.tar.xz")
   set(msys2_md5 "45b3be3d1e30d01e0d95d5bd8e75244a")
 endif()
 


### PR DESCRIPTION
Goal :

 Fix bug to build on windows

Changes :

   - Fix:
        - Update URL of msys2 because current link does not exist anymore.

The changed above are tested to build successfully on windows 10 and ubuntu 22.
